### PR TITLE
Fix table in Java tracker page

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/java-tracker/tracking-specific-client-side-properties/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/java-tracker/tracking-specific-client-side-properties/index.md
@@ -115,6 +115,7 @@ SelfDescribing selfDescribing = SelfDescribing.builder()
 tracker.track(selfDescribing);
 ```
 The resulting enriched event would have these `Subject` atomic columns populated:
+
  | Column in enriched event | Value / example value                       | Source         |
  |--------------------------|---------------------------------------------|----------------|
  | user_id                  | "java@snowplowanalytics.com"                | eventSubject   |


### PR DESCRIPTION
Turns out tables need an empty line above them to render correctly.