### PR TITLE
Update _redirects for accelerator

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,5 @@
 # Sister websites
-/accelerators/advanced-analytics-web/* https://snowplow-axl-advanced-analytics-web.netlify.app/:splat 200
+/accelerators/advanced-analytics-web/* https://snowplow-axl-advanced-analytics-web.netlify.app/accelerators/advanced-analytics-web/:splat 200
 /snowplow-android-tracker/* https://snowplow.github.io/snowplow-android-tracker/:splat 302
 /snowplow-cpp-tracker/* https://snowplow.github.io/snowplow-cpp-tracker/:splat 302
 /snowplow-lua-tracker/* https://snowplow.github.io/snowplow-lua-tracker/:splat 302

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,5 @@
 # Sister websites
-/advanced-analytics-web-accelerator/* https://snowplow.github.io/advanced-analytics-web-accelerator/:splat 302
+/accelerators/advanced-analytics-web/* https://snowplow-axl-advanced-analytics-web.netlify.app/:splat 200
 /snowplow-android-tracker/* https://snowplow.github.io/snowplow-android-tracker/:splat 302
 /snowplow-cpp-tracker/* https://snowplow.github.io/snowplow-cpp-tracker/:splat 302
 /snowplow-lua-tracker/* https://snowplow.github.io/snowplow-lua-tracker/:splat 302
@@ -7,6 +7,7 @@
 /snowplow-ruby-tracker/* https://snowplow.github.io/snowplow-ruby-tracker/:splat 302
 
 # Page renaming
+/advanced-analytics-web-accelerator/* /accelerators/advanced-analytics-web/:splat 301
 /docs/collecting-data/collecting-from-own-applications/scala-tracker/setup-2 /docs/collecting-data/collecting-from-own-applications/scala-tracker/setup 301
 /docs/collecting-data/collecting-from-own-applications/mobile-trackers/mobile-trackers-v3-0/* /docs/collecting-data/collecting-from-own-applications/mobile-trackers/:splat 301
 /docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader-3-0-0/* /docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader-3-0-0/:splat 301


### PR DESCRIPTION
Moving accelerators to `/accelerators` and adding a redirect for the old URL.