### PR TITLE
Add documentation updates for React Native v1.3

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/anonymous-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/anonymous-tracking/index.md
@@ -17,15 +17,11 @@ This feature is available since v4.
 
 :::
 
-Anonymous tracking is a tracker feature that enables anonymising various user and session identifiers to support user privacy in case consent for tracking the identifiers is not given.
+```mdx-code-block
+import Block8155 from "@site/docs/reusable/anonymous-tracking-mobile/_index.md"
 
-The affected user and session identifiers are stored in two context entities: [Session](../tracking-events/index.md#session) and [Platform context](../tracking-events/index.md#platform). The Session context entity contains user and session identifiers, while the Platform context entity contains user identifiers. Concretely, the following user and session identifiers can be anonymised:
-
-1. Client-side user identifiers: the `userId` in Session context entity and the IDFA identifiers (`appleIdfa`, and `appleIdfv`) in the Platform context entity.
-2. Client-side session identifiers: `sessionId` in Session context.
-3. Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.
-
-There are several levels to the anonymisation depending on which of the three categories are affected:
+<Block8155/>
+```
 
 ## 1. Full client-side anonymisation
 

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/anonymous-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/anonymous-tracking/index.md
@@ -18,9 +18,9 @@ This feature is available since v4.
 :::
 
 ```mdx-code-block
-import Block8155 from "@site/docs/reusable/anonymous-tracking-mobile/_index.md"
+import AnonymousTrackingSharedBlock from "@site/docs/reusable/anonymous-tracking-mobile/_index.md"
 
-<Block8155/>
+<AnonymousTrackingSharedBlock/>
 ```
 
 ## 1. Full client-side anonymisation

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
@@ -46,7 +46,7 @@ const tracker = createTracker(
 
 ## 2. Client-side anonymisation with session tracking
 
-This setting disables client-side user identifiers are but tracks session information. In practice, this means that events track the Session context entity but the `userId` property is a null UUID (`00000000-0000-0000-0000-000000000000`). In case Platform context is enabled, the IDFA identifiers will not be present.
+This setting disables client-side user identifiers but tracks session information. In practice, this means that events track the Session context entity but the `userId` property is a null UUID (`00000000-0000-0000-0000-000000000000`). In case Platform context is enabled, the IDFA identifiers will not be present.
 
 ```typescript
 const tracker = createTracker(

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
@@ -18,9 +18,9 @@ This feature is available since v1.3.
 :::
 
 ```mdx-code-block
-import Block8155 from "@site/docs/reusable/anonymous-tracking-mobile/_index.md"
+import AnonymousTrackingSharedBlock from "@site/docs/reusable/anonymous-tracking-mobile/_index.md"
 
-<Block8155/>
+<AnonymousTrackingSharedBlock/>
 ```
 
 ## 1. Full client-side anonymisation

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
@@ -17,15 +17,11 @@ This feature is available since v1.3.
 
 :::
 
-Anonymous tracking is a tracker feature that enables anonymising various user and session identifiers to support user privacy in case consent for tracking the identifiers is not given.
+```mdx-code-block
+import Block8155 from "@site/docs/reusable/anonymous-tracking-mobile/_index.md"
 
-The affected user and session identifiers are stored in two context entities: [Session](../tracking-events/index.md#session) and [Platform context](../tracking-events/index.md#platform). The Session context entity contains user and session identifiers, while the Platform context entity contains user identifiers. Concretely, the following user and session identifiers can be anonymised:
-
-1. Client-side user identifiers: the `userId` in Session context entity and the IDFA identifiers (`appleIdfa`, and `appleIdfv`) in the Platform context entity.
-2. Client-side session identifiers: `sessionId` in Session context.
-3. Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.
-
-There are several levels to the anonymisation depending on which of the three categories are affected:
+<Block8155/>
+```
 
 ## 1. Full client-side anonymisation
 

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/anonymous-tracking/index.md
@@ -1,0 +1,80 @@
+---
+title: "Anonymous Tracking"
+date: "2022-08-30"
+sidebar_position: 25
+---
+
+# Anonymous Tracking
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
+:::info
+
+This feature is available since v1.3.
+
+:::
+
+Anonymous tracking is a tracker feature that enables anonymising various user and session identifiers to support user privacy in case consent for tracking the identifiers is not given.
+
+The affected user and session identifiers are stored in two context entities: [Session](../tracking-events/index.md#session) and [Platform context](../tracking-events/index.md#platform). The Session context entity contains user and session identifiers, while the Platform context entity contains user identifiers. Concretely, the following user and session identifiers can be anonymised:
+
+1. Client-side user identifiers: the `userId` in Session context entity and the IDFA identifiers (`appleIdfa`, and `appleIdfv`) in the Platform context entity.
+2. Client-side session identifiers: `sessionId` in Session context.
+3. Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.
+
+There are several levels to the anonymisation depending on which of the three categories are affected:
+
+## 1. Full client-side anonymisation
+
+In this case, we want to anonymise both the client-side user identifiers as well as the client-side session identifiers. This means disabling the Session context altogether and enabling user anonymisation:
+
+```typescript
+const tracker = createTracker(
+    'appTracker',
+    {endpoint: COLLECTOR_URL},
+    {
+        trackerConfig: {
+            sessionContext: false, // Session context entity won't be added to events
+            userAnonymisation: true // User identifiers in Platform context (IDFA and IDFV) will be anonymised
+        }
+    }
+);
+```
+
+## 2. Client-side anonymisation with session tracking
+
+This setting disables client-side user identifiers are but tracks session information. In practice, this means that events track the Session context entity but the `userId` property is a null UUID (`00000000-0000-0000-0000-000000000000`). In case Platform context is enabled, the IDFA identifiers will not be present.
+
+```typescript
+const tracker = createTracker(
+    'appTracker',
+    {endpoint: COLLECTOR_URL},
+    {
+        trackerConfig: {
+            sessionContext: true, // Session context is tracked with the session ID
+            userAnonymisation: true // User identifiers in Session and Platform context are anonymised
+        }
+    }
+);
+```
+
+## 3. Server-side anonymisation
+
+Server-side anonymisation affects user identifiers set server-side. In particular, these are the `network_userid` property set in server-side cookie and the user IP address. You can anonymise the properties using the `serverAnonymisation` flag in `EmitterConfiguration`:
+
+```typescript
+const tracker = createTracker(
+    'appTracker',
+    {endpoint: COLLECTOR_URL},
+    {
+        emitterConfig: {
+            serverAnonymisation: true
+        }
+    }
+);
+```
+
+Setting the flag will add a `SP-Anonymous` HTTP header to requests sent to the Snowplow collector. The Snowplow pipeline will take care of anonymising the identifiers.

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/quick-start-guide/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/quick-start-guide/index.md
@@ -81,7 +81,8 @@ const tracker = createTracker(
             lifecycleAutotracking: false,
             installAutotracking: true,
             exceptionAutotracking: true,
-            diagnosticAutotracking: false
+            diagnosticAutotracking: false,
+            userAnonymisation: false // Whether to anonymise client-side user identifiers in session and platform context entities
         },
         sessionConfig: {
             foregroundTimeout: 1800,
@@ -92,7 +93,8 @@ const tracker = createTracker(
             emitRange: 150,
             threadPoolSize: 15,
             byteLimitPost: 40000,
-            byteLimitGet: 40000
+            byteLimitGet: 40000,
+            serverAnonymisation: false // Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
         },
         subjectConfig: {
             userId: 'my-user-id',

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/quick-start-guide/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/quick-start-guide/index.md
@@ -63,7 +63,9 @@ const tracker = createTracker(
     'appTracker',
     {
       endpoint: COLLECTOR_URL,
-      method: 'post'
+      method: 'post',
+      customPostPath: 'com.snowplowanalytics.snowplow/tp2', // A custom path which will be added to the endpoint URL to specify the complete URL of the collector when paired with the POST method.
+      requestHeaders: {} // Custom headers for HTTP requests to the Collector
     },
     {
         trackerConfig: {

--- a/docs/reusable/anonymous-tracking-mobile/_index.md
+++ b/docs/reusable/anonymous-tracking-mobile/_index.md
@@ -1,0 +1,9 @@
+Anonymous tracking is a tracker feature that enables anonymising various user and session identifiers to support user privacy in case consent for tracking the identifiers is not given.
+
+The affected user and session identifiers are stored in two context entities: [Session](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2) and [Platform context](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2). The Session context entity contains user and session identifiers, while the Platform context entity contains user identifiers. Concretely, the following user and session identifiers can be anonymised:
+
+* Client-side user identifiers: the `userId` in Session context entity and the IDFA identifiers (`appleIdfa`, and `appleIdfv`) in the Platform context entity.
+* Client-side session identifiers: `sessionId` in Session context.
+* Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.
+
+There are several levels to the anonymisation depending on which of the three categories are affected:


### PR DESCRIPTION
1. Documentation for anonymous tracking
2. Adds mention of new `customPostPath` and `requestHeaders` parameters in network configuration

There is a separate PR for Web view tracking docs #102 which also adds a page for the React Native tracker.