### PR TITLE
Add redirect for mobile hybrid app accelerator

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,6 @@
 # Sister websites
 /accelerators/web/* https://snowplow-axl-web.netlify.app/accelerators/web/:splat 200
+/accelerators/hybrid/* https://snowplow-axl-hybrid.netlify.app/accelerators/hybrid/:splat 200
 /snowplow-android-tracker/* https://snowplow.github.io/snowplow-android-tracker/:splat 302
 /snowplow-cpp-tracker/* https://snowplow.github.io/snowplow-cpp-tracker/:splat 302
 /snowplow-lua-tracker/* https://snowplow.github.io/snowplow-lua-tracker/:splat 302


### PR DESCRIPTION
The deployment for the accelerator to Netlify is being [reviewed in this PR](https://github.com/snowplow/mobile-hybrid-apps-accelerator/pull/3).