### PR TITLE
Update accelerator netlify URL

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,5 @@
 # Sister websites
-/accelerators/web/* https://snowplow-axl-advanced-analytics-web.netlify.app/accelerators/web/:splat 200
+/accelerators/web/* https://snowplow-axl-web.netlify.app/accelerators/web/:splat 200
 /snowplow-android-tracker/* https://snowplow.github.io/snowplow-android-tracker/:splat 302
 /snowplow-cpp-tracker/* https://snowplow.github.io/snowplow-cpp-tracker/:splat 302
 /snowplow-lua-tracker/* https://snowplow.github.io/snowplow-lua-tracker/:splat 302


### PR DESCRIPTION
We renamed the netlify site url for the accelerator for advanced analytics. This updates it to the new location.