### PR TITLE
Fix links where converted into double square brackets

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-5-0/initialization/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-5-0/initialization/index.md
@@ -48,7 +48,7 @@ tracker.enableEc2Context()
 
 ## Google Compute Engine Metadata context
 
-Google [Cloud Compute Engine][gce] can provide basic information about instance running your app. You can add this informational as additional custom context to all sent events by enabling it in Tracker after initializaiton of your tracker:
+Google [Cloud Compute Engine](https://cloud.google.com/compute) can provide basic information about instance running your app. You can add this informational as additional custom context to all sent events by enabling it in Tracker after initializaiton of your tracker:
 
 ```java
 tracker.enableGceContext()

--- a/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-6-0/initialization/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-6-0/initialization/index.md
@@ -48,7 +48,7 @@ tracker.enableEc2Context()
 
 ## Google Compute Engine Metadata context
 
-Google [Cloud Compute Engine][gce] can provide basic information about instance running your app. You can add this informational as additional custom context to all sent events by enabling it in Tracker after initializaiton of your tracker:
+Google [Cloud Compute Engine](https://cloud.google.com/compute) can provide basic information about instance running your app. You can add this informational as additional custom context to all sent events by enabling it in Tracker after initializaiton of your tracker:
 
 ```scala
 tracker.enableGceContext()

--- a/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-7-0/initialization/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-7-0/initialization/index.md
@@ -48,7 +48,7 @@ tracker.enableEc2Context()
 
 ## Google Compute Engine Metadata context
 
-Google [Cloud Compute Engine][gce] can provide basic information about instance running your app. You can add this informational as additional custom context to all sent events by enabling it in Tracker after initializaiton of your tracker:
+Google [Cloud Compute Engine](https://cloud.google.com/compute) can provide basic information about instance running your app. You can add this informational as additional custom context to all sent events by enabling it in Tracker after initializaiton of your tracker:
 
 ```scala
 tracker.enableGceContext()

--- a/docs/collecting-data/collecting-from-own-applications/webview-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/webview-tracker/index.md
@@ -71,7 +71,7 @@ You will then be able to use the functions provided by the WebView tracker as fo
 import { trackSelfDescribingEvent } from '@snowplow/webview-tracker';
 ```
 
-In addition, you will need to install the iOS or Android tracker in your native code and configure and initialize a tracker (see the [mobile tracker docs][mobile-tracker-setup-docs]). Afterwards, you will be able to subscribe to and track the events from the WebView tracker in a Web view by calling `Snowplow.subscribeToWebViewEvents(webView)`.
+In addition, you will need to install the iOS or Android tracker in your native code and configure and initialize a tracker (see the [mobile tracker docs](../mobile-trackers/installation-and-set-up/index.md)). Afterwards, you will be able to subscribe to and track the events from the WebView tracker in a Web view by calling `Snowplow.subscribeToWebViewEvents(webView)`.
 
   </TabItem>
   <TabItem value="tag" label="Using Snowplow tag">

--- a/docs/modeling-your-data/analytics-sdk/analytics-sdk-python/index.md
+++ b/docs/modeling-your-data/analytics-sdk/analytics-sdk-python/index.md
@@ -87,7 +87,7 @@ for run_id in list_runids(s3, enriched_events_archive):
         pass
 ```
 
-In above example, we create two AWS service clients for S3 (to list job runs) and for DynamoDB (to access manifests). These cliens are provided via [boto3][boto3] Python AWS SDK and can be initialized with static credentials or with system-provided credentials.
+In above example, we create two AWS service clients for S3 (to list job runs) and for DynamoDB (to access manifests). These clients are provided via [boto3](https://aws.amazon.com/sdk-for-python/) Python AWS SDK and can be initialized with static credentials or with system-provided credentials.
 
 Then we list all run ids in particular S3 path and process (by user-provided `process` function) only those that were not processed already. Note that `run_id` is simple string with S3 key of particular job run.
 

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/index.md
@@ -165,7 +165,7 @@ By removing the `snowplow_web_custom_incremental_model` model from the manifest 
 dbt run --select +snowplow_mobile_custom_incremental_model --vars '{snowplow__start_date: "yyyy-mm-dd", models_to_remove: snowplow_mobile_custom_incremental_model}'
 ```
 
-By removing the `snowplow_mobile_custom_incremental_model` model from the manifest the mobile packages will be in state 2 (see the section on [incremental logic][incremental logic](/docs/modeling-your-data/modeling-your-data-with-dbt/index.md#incremental-logic))  and will replay all events.
+By removing the `snowplow_mobile_custom_incremental_model` model from the manifest the mobile packages will be in state 2 (see the section on [incremental logic](/docs/modeling-your-data/modeling-your-data-with-dbt/index.md#incremental-logic))  and will replay all events.
 
 </TabItem>
 </Tabs>

--- a/docs/pipeline-components-and-applications/right-to-be-forgotten-spark-application/right-to-be-forgotten-spark-application-setup-guide/index.md
+++ b/docs/pipeline-components-and-applications/right-to-be-forgotten-spark-application/right-to-be-forgotten-spark-application-setup-guide/index.md
@@ -25,13 +25,13 @@ target/snowplow-right-to-be-forgotten-job-x.x.x.jar
 
 ## Deploying
 
-Deploying will depend on where you have chosen to run the spark job. Assuming that are running on [Amazon Elastic MapReduce][emr], then deploying is consists of copying the jar to S3 or directly to the master node.
+Deploying will depend on where you have chosen to run the spark job. Assuming that are running on [Amazon Elastic MapReduce](https://docs.aws.amazon.com/emr/), then deploying is consists of copying the jar to S3 or directly to the master node.
 
 The example on running below assumes that you have copied the jar to the master node.
 
 ## Running
 
-Running R2F requires a "removal criteria" file in order to match the rows to be erased. The file consists of rows of a single JSON self-describing datum which conforms to the [iglu schema here][removal-criteria-iglu-schema].  
+Running R2F requires a "removal criteria" file in order to match the rows to be erased. The file consists of rows of a single JSON self-describing datum which conforms to the [iglu schema here](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow.r2f/removal_criteria/jsonschema/1-0-0).  
 As can be seen from the schema, it expects a single criterion of either `json` or `pojo` fields. Special care needs to be taken that the value uniquely identifies an individual as there is a chance (e.g. when using an IP address) that it does not and more data than intended is erased.  
 To avoid that, an additional argument needs to be provided to the spark job that specifies the maximum proportion of rows from the archive that you expect to be matched in that execution (e.g. 0.5 for half), as a safeguard. The job will fail if that number is exceeded.
 


### PR DESCRIPTION
Fixing links such as [...][...] where the link seems to have been lost :-

- https://docs.snowplow.io/docs/modeling-your-data/analytics-sdk/analytics-sdk-python/
- https://docs.snowplow.io/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/
- https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/webview-tracker/
- https://docs.snowplow.io/docs/pipeline-components-and-applications/right-to-be-forgotten-spark-application/right-to-be-forgotten-spark-application-setup-guide/
- https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-7-0/initialization/
- https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-6-0/initialization/
- https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/scala-tracker/previous-versions/0-5-0/initialization/