### PR TITLE
Don’t index overview pages for previous versions

### DIFF
--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -6,27 +6,24 @@ import { useLocation } from '@docusaurus/router'
 
 // yeah, we need to standardize things!
 const previousVersionPattern = new RegExp(
-  '[^/]*(previous-|older-)(versions?|releases?)/.'
+  '[^/]*(?:previous-|older-)(?:versions?|releases?)/'
 )
 
 export default function MDXContentWrapper(props) {
   const location = useLocation()
+  const outdated = previousVersionPattern.test(location.pathname)
+  if (!outdated) return <MDXContent {...props} />
+  const [latest, subpage] = location.pathname.split(previousVersionPattern)
   return (
     <>
-      {previousVersionPattern.test(location.pathname) && (
-        <>
-          <Head>
-            <meta name="robots" content="noindex, follow" />
-            <meta name="docsearch:outdated" content="true" />
-          </Head>
-          <Admonition type="caution">
-            You are reading documentation for an outdated version. Here’s the{' '}
-            <a href={location.pathname.split(previousVersionPattern)[0]}>
-              latest one
-            </a>
-            !
-          </Admonition>
-        </>
+      <Head>
+        <meta name="robots" content="noindex, follow" />
+      </Head>
+      {subpage.length > 0 && (
+        <Admonition type="caution">
+          You are reading documentation for an outdated version. Here’s the{' '}
+          <a href={latest}>latest one</a>!
+        </Admonition>
       )}
       <MDXContent {...props} />
     </>


### PR DESCRIPTION
This improves on https://github.com/snowplow/documentation/pull/114 and https://github.com/snowplow/documentation/pull/134:
* Now not only pages inside `previous-versions/` are removed from external search indexes, but `previous-versions/` pages themselves as well.
* We don’t need an extra meta attribute for Algolia. I've configured the crawler to rank anything with a `noindex` lower.