### PR TITLE
Fix broken link to VPC peering in BDP AWS setup

### DIFF
--- a/docs/getting-started-with-snowplow-bdp/aws-setup-guide/index.md
+++ b/docs/getting-started-with-snowplow-bdp/aws-setup-guide/index.md
@@ -23,7 +23,7 @@ To setup your cloud environment as required you will need
 
 - to be able to set up a sub-account and appropriate permissions on AWS
 - to know which AWS region you’d like us to install your Snowplow pipeline into
-- to know whether or not you want VPC peering, and for which /21 or /22 CIDR range (note: [VPC peering is an additional bolt-on for basecamp and ascent tiers](this is a bolt-on for basecamp / ascent tiers))
+- to know whether or not you want VPC peering, and for which /21 or /22 CIDR range (note: [VPC peering is an additional bolt-on for basecamp and ascent tiers](https://snowplow.io/snowplow-bdp-product-description/#bolt-ons))
 
 We often find our point of contact requires support from their DevOps or Networking colleagues to complete the cloud setup step; in Snowplow BDP Console you can [easily create accounts for colleagues](/docs/using-the-snowplow-console/managing-users/index.md) who can complete this step for you.
 


### PR DESCRIPTION

Page https://docs.snowplow.io/docs/getting-started-with-snowplow-bdp/aws-setup-guide/ has broken link to VPC peering bolt-on.  Pointed it to the Bolt ons section on https://snowplow.io/snowplow-bdp-product-description/.