### PR TITLE
Correct link for demos repository

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/installation-and-set-up/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/installation-and-set-up/index.md
@@ -113,7 +113,7 @@ Snowplow.createTracker(
 
 The `createTracker` method allows the creation of multiple trackers in the same app. The `namespace` field lets you distinguish events sent by a specific tracker instance. It is mandatory even in case the app uses just a single tracker instance like in the example above.
 
-The [Examples Github repository](https://github.com/snowplow/snowplow-objc-tracker-examples) includes demo apps for Swift and Objective-C covering the most popular dependencies managers. They are provided as simple reference apps to help you set up the tracker.
+The [Examples Github repository](https://github.com/snowplow-incubator/snowplow-objc-tracker-examples) includes demo apps for Swift and Objective-C covering the most popular dependencies managers. They are provided as simple reference apps to help you set up the tracker.
 
   </TabItem>
   <TabItem value="android" label="Android">


### PR DESCRIPTION
The old link is broken, I suspect it should now be https://github.com/snowplow-incubator/snowplow-objc-tracker-examples