### PR TITLE
Add info to dbt schema config

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/index.md
@@ -32,6 +32,12 @@ Each model has specific configuration variables, however some variables are appl
 ## Output Schemas
 By default all scratch/staging tables will be created in the `<target.schema>_scratch` schema, the derived tables ( e.g. `snowplow_web_page_views`, `snowplow_web_sessions`, `snowplow_web_users`) will be created in `<target.schema>_derived` and all manifest tables in `<target.schema>_snowplow_manifest`. Some of these schemas are only used by specific packages, ensure you add the correct configurations for each packages you are using. To change, please add the following to your `dbt_project.yml` file:
 
+:::tip
+
+If you want to use just your connection schema with no suffixes, set the `+schema:` values to `null`
+
+:::
+
 <Tabs groupId="dbt-packages">
 <TabItem value="web" label="Snowplow Web" default>
 


### PR DESCRIPTION
Added information about how to set the output schema to be the same as the default connection schema, this has come up a few times from customers so worth adding to avoid confusion.