### PR TITLE
Remove empty tutorial

### DIFF
--- a/docs/tutorials/tutorial-define-track-and-query-your-own-custom-event/index.md
+++ b/docs/tutorials/tutorial-define-track-and-query-your-own-custom-event/index.md
@@ -1,7 +1,0 @@
----
-title: "Tutorial: define, track and query your own custom event"
-date: "2020-02-13"
-sidebar_position: 0
----
-
-Coming soon.


### PR DESCRIPTION
Noticed by a user that there's a blank tutorial. This will likely be covered by the accelerators when they launch in November so I see no reason to keep this blank page around 

https://discourse.snowplow.io/t/nodejs-unstructured-events-http-iglucentral-com/7632/2?u=paulboocock