### PR TITLE
Update tracker configuration with a new cookie name for the biz1 tracker

### DIFF
--- a/snowplow.js
+++ b/snowplow.js
@@ -15,17 +15,19 @@ import Cookies from 'js-cookie'
 import { COOKIE_PREF_KEY, DOCS_SITE_URLS } from './src/constants/config'
 import { reloadOnce } from './src/helpers/reloadOnce'
 
-const setupBrowserTracker = () => {
+const createTrackerConfig = (cookieName) => {
   const appId = DOCS_SITE_URLS.includes(window.location.hostname)
     ? 'docs2'
     : 'test'
   const domain = location.host.split('.').reverse()
 
-  const trackerConfig = {
+  let trackerConfig = {
     appId,
+    eventMethod: 'post',
     plugins: [LinkClickTrackingPlugin()],
     cookieDomain: `.${domain[1]}.${domain[0]}`,
-    cookieName: '_sp5_',
+    cookieName,
+    cookieSameSite: 'Lax',
     contexts: {
       webPage: true,
       performanceTiming: true,
@@ -41,8 +43,12 @@ const setupBrowserTracker = () => {
     }
   }
 
-  newTracker('snplow5', 'https://collector.snowplow.io', trackerConfig)
-  newTracker('biz1', 'https://c.snowplow.io', trackerConfig)
+  return trackerConfig;
+};
+
+const setupBrowserTracker = () => {
+  newTracker('snplow5', 'https://collector.snowplow.io', createTrackerConfig('_sp5_'))
+  newTracker('biz1', 'https://c.snowplow.io', createTrackerConfig('_sp_biz1_'))
 
   enableLinkClickTracking()
   refreshLinkClickTracking()

--- a/snowplow.js
+++ b/snowplow.js
@@ -21,7 +21,7 @@ const createTrackerConfig = (cookieName) => {
     : 'test'
   const domain = location.host.split('.').reverse()
 
-  let trackerConfig = {
+  const trackerConfig = {
     appId,
     eventMethod: 'post',
     plugins: [LinkClickTrackingPlugin()],

--- a/src/pages/cookie-preferences.mdx
+++ b/src/pages/cookie-preferences.mdx
@@ -61,12 +61,12 @@ The below list details the cookies used in our website.
       <td>Set by Google to distinguish users.</td>
     </tr>
     <tr>
-      <td>_sp5_id</td>
-      <td>The _sp5_id cookie stores user information that is created when a user first visits a site and updated on subsequent visits. It is used to identify users and track user activity across a domain. This cookie stores a unique identifier for each user, a unique identifier for the user’s current session, the number of visits a user has made to the site, the timestamp of the user’s first visit, the timestamp of their previous visit and the timestamp of their current visit, references to previous session and first event in the current session, and index of the last event in the session.</td>
+      <td>_sp5_id and _sp_biz1_id</td>
+      <td>The _sp5_id and _sp_biz1_id cookies store user information that is created when a user first visits a site and updated on subsequent visits. They are used to identify users and track user activity across a domain. These cookies store a unique identifier for each user, a unique identifier for the user’s current session, the number of visits a user has made to the site, the timestamp of the user’s first visit, the timestamp of their previous visit and the timestamp of their current visit, references to previous session and first event in the current session, and index of the last event in the session.</td>
     </tr>
     <tr>
-      <td>_sp5_ses</td>
-      <td>The _sp5_ses cookie is used to identify if the user is in an active session on a site or if this is a new session for a user (i.e. cookie doesn’t exist or has expired).</td>
+      <td>_sp5_ses and _sp_biz1_ses</td>
+      <td>The _sp5_ses and _sp_biz1_ses cookies are used to identify if the user is in an active session on a site or if this is a new session for a user (i.e. cookie doesn’t exist or has expired).</td>
     </tr>
     <tr>
       <td>sp</td>


### PR DESCRIPTION
Updates the configuration for `snplow5` and `biz1` trackers:

* sets the method to POST on both trackers
* sets `cookieSameSite` to `Lax` on both trackers
* changes the `cookieName` for `biz1` tracker