### PR TITLE
Get GCS loader version from componentVersions and use code blocks

### DIFF
--- a/docs/getting-started-on-snowplow-open-source/setup-snowplow-on-gcp/setup-google-cloud-storage-gcs-destination/downloading-google-cloud-storage-loader/index.md
+++ b/docs/getting-started-on-snowplow-open-source/setup-snowplow-on-gcp/setup-google-cloud-storage-gcs-destination/downloading-google-cloud-storage-loader/index.md
@@ -4,43 +4,48 @@ date: "2020-03-02"
 sidebar_position: 0
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 Docker images can be found on [Docker Hub](https://hub.docker.com/r/snowplow/snowplow-google-cloud-storage-loader).
 
 Loader can be run with:
 
-```docker
-docker run \
-  -v $PWD/config:/snowplow/config \
-  -e GOOGLE_APPLICATION_CREDENTIALS=/snowplow/config/credentials.json \ # if running outside GCP
-  snowplow/snowplow-google-cloud-storage-loader:0.5.1 \
-  --runner=DataFlowRunner \
-  --jobName=[JOB-NAME] \
-  --project=[PROJECT] \
-  --streaming=true \
-  --workerZone=[ZONE] \
-  --inputSubscription=projects/[PROJECT]/subscriptions/[SUBSCRIPTION] \
-  --outputDirectory=gs://[BUCKET] \
-  --outputFilenamePrefix=output \ # optional
-  --shardTemplate=-W-P-SSSSS-of-NNNNN \ # optional
-  --outputFilenameSuffix=.txt \ # optional
-  --windowDuration=5 \ # optional, in minutes
-  --compression=none \ # optional, gzip, bz2 or none
-  --numShards=1 \ # optional
-  --dateFormat=YYYY/MM/dd/HH/ \ # optional
-  --labels={\"label\": \"value\"} \ #OPTIONAL
+<CodeBlock language="bash">{
+`docker run \\
+  -v $PWD/config:/snowplow/config \\
+  -e GOOGLE_APPLICATION_CREDENTIALS=/snowplow/config/credentials.json \\ # if running outside GCP
+  snowplow/snowplow-google-cloud-storage-loader:${versions.gcsLoader} \\
+  --runner=DataFlowRunner \\
+  --jobName=[JOB-NAME] \\
+  --project=[PROJECT] \\
+  --streaming=true \\
+  --workerZone=[ZONE] \\
+  --inputSubscription=projects/[PROJECT]/subscriptions/[SUBSCRIPTION] \\
+  --outputDirectory=gs://[BUCKET] \\
+  --outputFilenamePrefix=output \\ # optional
+  --shardTemplate=-W-P-SSSSS-of-NNNNN \\ # optional
+  --outputFilenameSuffix=.txt \\ # optional
+  --windowDuration=5 \\ # optional, in minutes
+  --compression=none \\ # optional, gzip, bz2 or none
+  --numShards=1 \\ # optional
+  --dateFormat=YYYY/MM/dd/HH/ \\ # optional
+  --labels={\\"label\\": \\"value\\"} \\ #OPTIONAL
   --partitionedOuptutDirectory=gs://[BUCKET]/[SUBDIR] # optional
-```
+`}</CodeBlock>
 
 To display the help message:
 
-```docker
-docker run snowplow/snowplow-google-cloud-storage-loader:0.5.1 \
+<CodeBlock language="bash">{
+`docker run snowplow/snowplow-google-cloud-storage-loader:${versions.gcsLoader} \\
   --help
-```
+`}</CodeBlock>
 
 To display documentation about Cloud Storage Loader-specific options:
 
-```docker
-docker run snowplow/snowplow-google-cloud-storage-loader:0.5.1 \
+<CodeBlock language="bash">{
+`docker run snowplow/snowplow-google-cloud-storage-loader:${versions.gcsLoader} \\
   --help=com.snowplowanalytics.storage.googlecloudstorage.loader.Options
-```
+`}</CodeBlock>


### PR DESCRIPTION
Current version:
![image](https://user-images.githubusercontent.com/3072877/199704861-92326fc0-9b4c-4762-b26c-80033851ce4b.png)

With these changes:
![image](https://user-images.githubusercontent.com/3072877/199704762-bcb27942-537a-42d5-8185-5be0c8e07261.png)
