### PR TITLE
Fix broken link syntax in analytics npm page

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/snowplow-plugin-for-analytics-npm-package/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/snowplow-plugin-for-analytics-npm-package/index.md
@@ -8,7 +8,7 @@ The Snowplow JavaScript Tracker can now be deployed directly into your web and n
 
 Recommendation
 
-Snowplow recommends using the official `[@snowplow/browser-tracker](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/index.md)` or `[@snowplow/node-tracker](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/node-js-tracker/index.md)` instead of this package as you will receive updates faster and install a smaller dependency into your application, unless you wish to send your events to multiple providers which is where the @analytics packages are particularly useful.
+Snowplow recommends using the official [@snowplow/browser-tracker](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/index.md) or [@snowplow/node-tracker](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/node-js-tracker/index.md) instead of this package as you will receive updates faster and install a smaller dependency into your application, unless you wish to send your events to multiple providers which is where the @analytics packages are particularly useful.
 
 ### Quick Start
 


### PR DESCRIPTION

before
<img width="1075" alt="Screen Shot 2022-11-06 at 6 49 05 AM" src="https://user-images.githubusercontent.com/980077/200177698-acb4c06a-7f7d-499f-a783-04850c39c14f.png">

after
<img width="1404" alt="Screen Shot 2022-11-06 at 6 49 10 AM" src="https://user-images.githubusercontent.com/980077/200177695-c98f7f9d-6c6d-48ad-bf75-1977059f0055.png">