### PR TITLE
Add additional permissions for BDP Enterprise GCP setup for RDB-Loader

### DIFF
--- a/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-gcp/index.md
+++ b/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-gcp/index.md
@@ -29,7 +29,7 @@ Please add **techops-cloud-admin@snowplowanalytics.com** to your project with 
 - `Roles/iam.roleAdmin`
 - `Roles/iam.serviceAccountAdmin`
 
-The following roles are also required if using [RDB-Loader](docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader/index.md) within GCP:
+The following roles are also required if using [RDB Loader](/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader/index.md) within GCP:
 
 - `Roles/secretmanager.secretAccessor`
 - `Roles/secretmanager.secretVersionAdder`

--- a/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-gcp/index.md
+++ b/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-gcp/index.md
@@ -28,6 +28,9 @@ Please add **techops-cloud-admin@snowplowanalytics.com** to your project with 
 - `Roles/monitoring.admin`
 - `Roles/iam.roleAdmin`
 - `Roles/iam.serviceAccountAdmin`
+
+The following roles are also required if using [RDB-Loader](docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader/index.md) within GCP:
+
 - `Roles/secretmanager.secretAccessor`
 - `Roles/secretmanager.secretVersionAdder`
 

--- a/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-gcp/index.md
+++ b/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-gcp/index.md
@@ -28,6 +28,8 @@ Please add **techops-cloud-admin@snowplowanalytics.com** to your project with 
 - `Roles/monitoring.admin`
 - `Roles/iam.roleAdmin`
 - `Roles/iam.serviceAccountAdmin`
+- `Roles/secretmanager.secretAccessor`
+- `Roles/secretmanager.secretVersionAdder`
 
 ### Enable billing for the project
 


### PR DESCRIPTION
The RDB-Loader pipeline in GCP uses SecretManager to make destination password available to the running Kubernetes loader service.  

Two additional permissions have been added to the https://docs.snowplow.io/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-gcp/#set-up-required-permissions page.

Only customers who move onto using RDB-Loader in GCP will need to add these.