### PR TITLE
Redirect /accelerators/ route to listing page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,5 @@
 # Sister websites
+/accelerators/ https://snowplow.io/data-product-accelerators/ 302
 /accelerators/web/* https://snowplow-axl-web.netlify.app/accelerators/web/:splat 200
 /accelerators/mobile/* https://snowplow-axl-mobile.netlify.app/accelerators/mobile/:splat 200
 /accelerators/hybrid/* https://snowplow-axl-hybrid.netlify.app/accelerators/hybrid/:splat 200


### PR DESCRIPTION
This redirects https://docs.snowplow.io/accelerators/ to https://snowplow.io/data-product-accelerators/ if someone tries to alter the url to get a listing page