### PR TITLE
Add global accelerator to AWS policy list

### DIFF
--- a/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-aws/index.md
+++ b/docs/getting-started-with-snowplow-bdp/enterprise/setup-guide-aws/index.md
@@ -72,6 +72,7 @@ You will need to share this role with us as part of filling out the setup form i
  "es:*",
  "execute-api:*",
  "events:*",
+ "globalaccelerator:*",
  "iam:*",
  "kinesis:*",
  "kinesisanalytics:*",


### PR DESCRIPTION
Updating the docs to include global accelerator as part of our AWS policy list needed for Snowplow Admin role