### PR TITLE
Update iglu client pages for easier reading

### DIFF
--- a/docs/pipeline-components-and-applications/iglu/common-architecture/iglu-core/index.md
+++ b/docs/pipeline-components-and-applications/iglu/common-architecture/iglu-core/index.md
@@ -4,42 +4,42 @@ date: "2021-03-26"
 sidebar_position: 120
 ---
 
-Iglu is designed to be not dependent on any particular programming language or platform. But there's growing set of applications beside clients and registries using different concepts originated from Iglu. To have consistent data structures and behavior among different applications, we're developing Iglu core libraries for different languages.
+Iglu is designed not to be dependent on any particular programming language or platform. However, there is a growing set of applications beside clients and registries using different concepts originated from Iglu. To have consistent data structures and behavior among different applications, we're developing Iglu core libraries for different languages.
 
 ## Basic data structures
 
-All languages have their own unique features and particular Iglu Core implementation may or may not use these features. One common rule for all Iglu core implementations is to minimize dependencies. Ideally Iglu core should have no external dependencies. Another rule is to implement the required basic data structures (in form of classes, structs, ADTs or any other appropriate form) and functions.
+All languages have their own unique features and a particular Iglu Core implementation may or may not use these features. One common rule for all Iglu core implementations is to minimize dependencies; ideally Iglu core should have no external dependencies. Another rule is to implement the required basic data structures (in form of classes, structs, ADTs or any other appropriate form) and functions.
 
 ### SchemaKey
 
-This data structure contains information about Self-describing datum, such as Snowplow unstructured event or context.
+This data structure contains information about Self-describing data, such as a Snowplow unstructured event or context.
 
-It also should have related `parse` functions, which can parse `SchemaKey` from most common representation - Iglu URI (string with form of `iglu:com.acme/someschema/format/1-0-0`) and Iglu path (same, but without `iglu:` protocol part). Reverse `asString` function required as well.
+It also should have be able to be created from most common representations of a schema key; Iglu URI (string with form of `iglu:com.acme/someschema/format/1-0-0`) and Iglu path (same, but without `iglu:` protocol part). The structure should also have functions to return these values. This structure may include validation of the schema key. 
 
-This also can include appropriate regular expressions to extract and validate schema key. Function for parsing `SchemaKey` from JSON Schemas is optional if there's no default JSON library like in JavaScript, but can be included within some interface.
+A method for creating a `SchemaKey` from a [Self-describing JSON Schemas](/docs/pipeline-components-and-applications/iglu/common-architecture/self-describing-json-schemas/index.md) is optional if there's no default JSON library in the language.
 
-More information can be found in [Self-describing JSON Schemas](/docs/pipeline-components-and-applications/iglu/common-architecture/self-describing-json-schemas/index.md) and [Self-describing JSONs](/docs/pipeline-components-and-applications/iglu/common-architecture/self-describing-jsons/index.md) wiki pages.
+More information can be found in [Self-describing JSON Schemas](/docs/pipeline-components-and-applications/iglu/common-architecture/self-describing-json-schemas/index.md) and [Self-describing JSONs](/docs/pipeline-components-and-applications/iglu/common-architecture/self-describing-jsons/index.md) docs pages.
 
 ### SchemaMap
 
-This is almost isomorphic entity to `SchemaKey`, which also contains same information: vendor, name, format and version. But unlike `SchemaKey` it supposed to be attached only to Schemas instead of datums. In schemas same information usually has different representation and also version is always _full_ opposed to datum's possibly _partial_.
+This data structure is almost identical entity to `SchemaKey`, in that they both contain the same information: vendor, name, format and version. But unlike `SchemaKey` it is used to represent only Schemas instead of data. In schemas the same information usually has different representation and a version is always _full_ opposed as opposed to data's possibly _partial_.
 
 ### SchemaVer
 
-This is a part of `SchemaKey` and `SchemaMap` with information about semantic Schema version, basically triplet of MODEL, REVISION, ADDITION.
+This is a part of `SchemaKey` and `SchemaMap` with information about semantic Schema version, based on the triplet of MODEL, REVISION, ADDITION.
 
-Like, `SchemaKey` it should contain `parse` function with regular expressions as well as `asString` method.
+Like `SchemaKey` it should contain `parse` functions with validation,  as well as an `asString` method.
 
 It can either _full_ (e.g. `1-2-0`) or _partial_ (e.g. `1-?-?`) suited for schema inference.
 
-More information can be found in dedicated wiki page: [SchemaVer](/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver/index.md).
+More information can be found in the dedicated docs page: [SchemaVer](/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver/index.md).
 
 ### SchemaCriterion
 
-Last core data structure is `SchemaCriterion` which is a default way to filter Self-describing entities. Basically it represent `SchemaKey` divided into six parts, where last three (MODEL, REVISION, ADDITION) _can_ be unfilled, thus one can match all entities regardless parts which remain unfilled.
+The last core data structure is `SchemaCriterion` which is a default way to filter Self-describing entities. Basically it represent a `SchemaKey` divided into six parts, where the last three (MODEL, REVISION, ADDITION) _can_ be unfilled, thus one can match all entities regardless of parts which remain unfilled.
 
-`SchemaCriterion` also must contain regular expression, `parse` and `asString` (unfilled parts replaced with asterisks) functions. One other required function is `matches` which accepts `SchemaCriterion` and `SchemaKey` and returning boolean value indicating if key was matched. Bear in mind that criterions matching versions like `.../*-1-*` or `.../*-*-0` are absolutely valid, they're useful if want to match all initial Schemas.
+`SchemaCriterion` also must contain regular expression validation, `parse`, and `asString` (unfilled parts replaced with asterisks) functions. One other required function is `matches` which accepts `SchemaCriterion` and a `SchemaKey`, returning a boolean value indicating if the key was matched. Bear in mind that criterions matching versions like `.../*-1-*` or `.../*-*-0` are absolutely valid, they're useful if want to match all initial Schemas.
 
 ## Implementations
 
-Currently we have only [Scala Iglu Core](https://github.com/snowplow/iglu/wiki/Scala-Iglu-Core) which can be considered as reference implementation. Among described above data structures it includes type classes and container classes to improve type-safety. These type classes and containers are completely optional in other implementations.
+Currently we only have [Scala Iglu Core](https://github.com/snowplow/iglu/wiki/Scala-Iglu-Core) which can be considered as a reference implementation. Among the above described data structures it includes type classes and container classes to improve type-safety. These type classes and containers are completely optional in other implementations.

--- a/docs/pipeline-components-and-applications/iglu/common-architecture/schema-resolution/index.md
+++ b/docs/pipeline-components-and-applications/iglu/common-architecture/schema-resolution/index.md
@@ -4,56 +4,56 @@ date: "2021-03-26"
 sidebar_position: 400
 ---
 
-This page describes the Schema resolution algorithm which is standard for all Iglu clients. Currently only [Iglu Scala client](https://github.com/snowplow/iglu-scala-client) fully follow this algorithm, while other clients may miss some parts, but we're working on making their behavior consistent.
+This page describes the Schema resolution algorithm which is standard for all Iglu clients. Currently only [Iglu Scala client](https://github.com/snowplow/iglu-scala-client) fully follow this algorithm, while other clients may miss some parts.
 
 ## 1. Prerequisites
 
-Before going further it is important to understand basic Iglu client configuration and essential concepts like Resolver, Registry (or Repository), Schema. Here is a quick overview of these concepts, if you're familiar with them you may want to skip this section.
+Before going further it is important to understand basic Iglu client configuration and essential concepts like Resolver, Registry (or Repository), and Schema. Here is a quick overview of these concepts, if you're familiar with them you may want to skip this section.
 
-Iglu clients are configured via JSON object described in dedicated Schema called [resolver-config](https://github.com/snowplow/iglu-central/tree/master/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema). Here we'll be using JSON resolver configuration which is platform independent and most wide-spread.
+Iglu clients are configured via a JSON object described in a dedicated Schema called the [resolver-config](https://github.com/snowplow/iglu-central/tree/master/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema). Here we'll be using JSON resolver configuration which is platform independent and most wide-spread.
 
 ### 1.1 Resolver
 
-Resolver is an primary object of Iglu Client library, which contains all logic necessary to fetch requested Schema from appropriate registry (repository) and cache it properly. Resolver has two main properties: cache size (`cacheSize`) and list of registries (`repositories`).
+Resolver is an primary object of Iglu Client library, which contains all logic necessary to fetch the requested Schema from the appropriate registry (repository) and cache it properly. The resolver has two main properties: cache size (`cacheSize`) and list of registries (`repositories`).
 
 ### 1.2 Registries
 
-**NOTE:** term _repository_ was deprecated. _Registry_ is default term to use when referring to Schema storage. So far, we've not renamed all occurrences, so for now they can be used interchangeable.
+**NOTE:** the term _repository_ was deprecated. _Registry_ is the default term to use when referring to Schema storage. So far, we've not renamed all occurrences, so for now they can be used interchangeable.
 
-Each registry in resolver configuration has several values common for all types of registries, such as `name`, `vendorPrefixes` and `priority`. Also each registry has type, which is defined inside `connection` property. The only one important thing here about type of repository is that each type has its own priority hardcoded inside client library. Below we'll refer to this hard-coded priority by `classPriority` and to user-defined priority by `instancePriority` Usually, the "safer" registry - the higher `classPriority` it has, so local repositories are more preferable than remote.
+Each registry in the resolver configuration has several values which are common for all types of registries, such as `name`, `vendorPrefixes` and `priority`. Each registry also has a type which is defined inside the `connection` property. The only one important thing here about the type of repository is that each type has its own priority hardcoded inside client library. Below we'll refer to this hard-coded priority by `classPriority` and to user-defined priority by `instancePriority` Usually, the "safer" the registry,  the higher `classPriority` it has, so local repositories are more preferable than remote.
 
 ### 1.3 Cache
 
-All Iglu clients use internal cache to store registry responses. By virtue of it, it is absolutely safe to launch Hadoop/Spark jobs with Iglu client embedded as it will not generate enormous amount of IO calls.
+All Iglu clients use internal cache to store registry responses. By virtue of this, it is absolutely safe to launch Hadoop/Spark jobs with Iglu client embedded as it will not generate enormous amount of IO calls.
 
 #### 1.3.1 Cache algorithm
 
-Cache stores not just plain Schemas, but information about responses from each registry. It allows us to make different decisions depending on what exactly went wrong with particular request. Since Schema was successfuly fetched it will be stored until moment it get evicted by [LRU cache](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_(LRU)) algorithm. This eviction it turn happens only if cache map reached its limit (defined in `cacheSize`) and particular Schema wasn't requested for longer time than all other.
+Cache stores not just plain Schemas, but information about responses from each registry. It allows us to make different decisions depending on what exactly went wrong with a particular request. If a Schema was successfully fetched it will be stored until the moment it gets evicted by a [LRU cache](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_(LRU)) algorithm. This eviction only happens if the cache reached its limit (defined in `cacheSize`) and that particular Schema was least recently requested.
 
 #### 1.3.2 Cache TTL
 
-Since version 0.5.0, Iglu Scala Client supports `cacheTtl` property. It is especially useful for real-time pipelines as they can store "failure" for very long time and TTL is a mechanism to ensure that day-long data won't go to bad stream. Note however that client also tries to re-resolve successfully fetched schemas, this allows operators to patch (re-upload) schemas without bringing pipeline down (although it is not recommended).
+Since version 0.5.0, the Iglu Scala Client supports the `cacheTtl` (Cache Time To Live) property. It is especially useful for real-time pipelines as they can store "failure" for very long time and TTL is a mechanism to ensure that day-long data won't go to a bad stream. Note however that the client also tries to re-resolve successfully fetched schemas, this allows operators to patch (re-upload) schemas without bringing pipeline down (although it is not recommended).
 
-`cacheTtl` is available since [`1-0-2` version](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-2) of resolver config.
+`cacheTtl` is available since [version `1-0-2`](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-2) of the resolver config.
 
 ## 2. Lookup algorithm
 
-Overall, Schema Resolution algorithm can be described by following flowchart:
+Overall, the Schema Resolution algorithm can be described by following flowchart:
 
 ![](images/schema-resolution-flowchart.png)
 
-Few important things to note:
+A few important things to note:
 
-- If registry responded with "NotFound" error - "missing" value will be cached and this repository won't be queried again, until this "missing" value not evicted by LRU-algorithm
-- If registry responded with error other than "NotFound", for example "TimeoutError", "NetworkError", "ServerFault" etc - "needToRetry" value will be cached and Resolver will give this registry 3 chances more. After three failed lookups - "missing" value will be cached
-- These "missing" and "needToRetry" values in cache are per-registry, not per-schema, which means if `registryA` responded "NotFound" for Schema `iglu:com.acme/event/jsonschema/1-0-0` and `registryB` responded with TimeoutError - resolver will immediately abandon `registryA` and keep try to query `registryB` for 3 more times.
+- If registry responded with "NotFound" error - a "missing" value will be cached and this repository won't be queried again, until this "missing" value is evicted by LRU-algorithm, or the TTL
+- If the registry responded with error other than "NotFound", for example "TimeoutError", "NetworkError", "ServerFault" etc - the "needToRetry" value will be cached and the Resolver will give this registry 3 chances more. After three failed lookups the "missing" value will be cached
+- These "missing" and "needToRetry" values in cache are per-registry, not per-schema, which means if `registryA` responded "NotFound" for Schema `iglu:com.acme/event/jsonschema/1-0-0` and `registryB` responded with "TimeoutError", the resolver will immediately abandon `registryA` and keep trying to query `registryB` for 3 more times.
 
 ## 3. Registry priority
 
-For each particular Schema lookup, registries will be prioritized. In other words they will be sorted according following input parameters (ordered by their significance):
+For each particular Schema lookup, registries will be prioritized. In other words they will be sorted according to the following input parameters (ordered by their significance):
 
-- `vendorPrefix` - Resolver always will look first into those registries which `vendorPrefix`es matches `SchemaKey`'s vendor. It **does not** mean registries with unmatched `vendorPrefix` will be skipped, it means they will be queried last.
+- `vendorPrefix` - Resolver always looks first into those registries which `vendorPrefix`es matches `SchemaKey`'s vendor. It **does not** mean registries with unmatched `vendorPrefix` will be skipped, it means they will be queried last.
 - `classPriority` - hardcoded in client library value for each type of registry. It means that whatever high priority (low integer value) was set up in configuration for a particular registry - it will be overridden by `classPriority`, so embedded repository will always be checked before HTTP (unless priority influenced by `vendorPrefix`)
 - `instancePriority` - user-defined value. Influence only repositories within same `classPriority`.
 
-One important thing to note is that both priorities (`classPriority` and `instancePriority`) order registries in ascending order. That means lower number means higher priority. Think of it as ascending list of number: `[1,2,3,4]` - smaller will be always first.
+One important thing to note is that both priorities (`classPriority` and `instancePriority`) order registries in ascending order. That means lower numbers ==  higher priority. Think of it as ascending list of number: `[1,2,3,4]` - smaller will be always first.

--- a/docs/pipeline-components-and-applications/iglu/common-architecture/self-describing-jsons/index.md
+++ b/docs/pipeline-components-and-applications/iglu/common-architecture/self-describing-jsons/index.md
@@ -53,10 +53,8 @@ Notice the two main differences compared to our original JSON:
 
 1. There is a new `schema` field located at the root of the JSON which contains (in a space-efficient format) all the information required to uniquely identify the associated JSON Schema. The schema's URI follows the following pattern:
 
-![](images/iglu-schema-key.png)
+    ![](images/iglu-schema-key.png)
 
 1. The data contained in the original JSON has been encapsulated in a `data` field to prevent any accidental collisions should the JSON already have a `schema` field
 
 This way, our JSON becomes de facto self-describing, embedding a link to its JSON Schema.
-
-Back to [Common architecture](/docs/pipeline-components-and-applications/iglu/common-architecture/index.md).


### PR DESCRIPTION
Reading the iglu core pages I have tried to make them read more naturally and expand around points where relevant. I suspect I may end up changing this further in the future when I get to actually making a python client, but for now I believe this makes the pages easier to read.

Also fixes a list image indent typo. 

Low priority merge.