### PR TITLE
Correct link to Postgres Terraform Registry module

### DIFF
--- a/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-postgres-loader/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-postgres-loader/index.md
@@ -14,7 +14,7 @@ With Snowplow Postgres Loader you can load enriched data or plain self-describin
 
 ## Available on Terraform Registry
 
-[![](https://img.shields.io/static/v1?label=Terraform&message=Registry&color=7B42BC&logo=terraform)](https://registry.terraform.io/modules/snowplow-devops/s3-loader-kinesis-ec2/aws/latest)
+[![](https://img.shields.io/static/v1?label=Terraform&message=Registry&color=7B42BC&logo=terraform)](https://registry.terraform.io/modules/snowplow-devops/postgres-loader-kinesis-ec2/aws/latest)
 
 A Terraform module which deploys the Snowplow Postgres Loader on AWS EC2 for use with Kinesis. For installing in other environments, please see the other installation options below.
 


### PR DESCRIPTION
The page https://docs.snowplow.io/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-postgres-loader/ has a Terraform Registry link which points to the S3 Loader (https://registry.terraform.io/modules/snowplow-devops/s3-loader-kinesis-ec2/aws/latest) instead of the Postgres Loader (https://registry.terraform.io/modules/snowplow-devops/postgres-loader-kinesis-ec2/aws/latest).