### PR TITLE
Add postgres destination in the manual GCP setup

### DIFF
--- a/docs/getting-started-on-snowplow-open-source/setup-snowplow-on-gcp/setup-postgres-destination/index.md
+++ b/docs/getting-started-on-snowplow-open-source/setup-snowplow-on-gcp/setup-postgres-destination/index.md
@@ -1,0 +1,8 @@
+---
+title: "Setup Postgres Destination"
+sidebar_position: 70
+---
+
+Snowplow supports loading data into Postgres.
+
+In order to do this, you need to setup the [Postgres Loader](/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-postgres-loader/index.md), which can load enriched events from the enriched Pub/Sub topic, and load them into Postgres.

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-postgres-loader/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-postgres-loader/index.md
@@ -82,3 +82,5 @@ See [the configuration reference](/docs/pipeline-components-and-applications/loa
 ## Other
 
 Loader creates `events` table on the start and every other table when it first encounters its corresponding schema.
+
+You should ensure that the database and schema specified in the configuration exist before starting the loader. 


### PR DESCRIPTION
We specify BigQuery Loader and GCS loader as potential storage targets for a manual GCP pipeline setup, but do not mention the Postgres loader, so we add it here.

I set up the postgres loader for a GCP pipeline following the existing instructions, which seem to be up to date, but I thought it would be helpful to specify that although the loader will create the events table, that the database and schema supplied in the config do need to be created to be able to start the loader.