### PR TITLE
Add documentation for tracking screen views in React Native navigation frameworks

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/tracking-events/index.md
@@ -181,7 +181,7 @@ To track a ScreenViewEvent, use the `trackScreenViewEvent` tracker method. For e
 tracker.trackScreenViewEvent({
     name: 'my-screen-name',
     id: '5d79770b-015b-4af8-8c91-b2ed6faf4b1e',
-    type: 'carousel'
+    type: 'carousel',
     transitionType: 'basic'
 });
 ```
@@ -201,12 +201,12 @@ The tracker will automatically assign references to the previously tracked scree
 - `previousType`: (string) - The type of screen that was viewed (assigned automatically)
 - `transitionType`: (string) - The type of transition that led to the screen being viewed
 
-#### Tracking screen views in React Navigation
+##### Tracking screen views in React Navigation
 
 If you are using the [React Navigation](https://reactnavigation.org/) library for navigation in your app, you can implement automatic screen view tracking by adding a callback to your `NavigationContainer`.
 The steps are explained [in the documentation for React Navigation](https://reactnavigation.org/docs/screen-tracking/).
 
-#### Tracking screen views in React Native Navigation
+##### Tracking screen views in React Native Navigation
 
 When using the [React Native Navigation](https://wix.github.io/react-native-navigation/docs/before-you-start/) library for navigation in your app, you can automatically track screen views by registering a listener when your component appears on screen.
 Use the `Navigation.events().registerComponentDidAppearListener` callback to subscribe the listener and track screen views as [documented here](https://wix.github.io/react-native-navigation/api/events/#componentdidappear).

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/tracking-events/index.md
@@ -173,7 +173,7 @@ tracker.trackTimingEvent({
 
 #### Screen View
 
-Track the user viewing a screen within the application. This type of tracking is typically used when automatic screen view tracking is not suitable within your application.
+Track the user viewing a screen within the application.
 
 To track a ScreenViewEvent, use the `trackScreenViewEvent` tracker method. For example:
 
@@ -181,13 +181,12 @@ To track a ScreenViewEvent, use the `trackScreenViewEvent` tracker method. For e
 tracker.trackScreenViewEvent({
     name: 'my-screen-name',
     id: '5d79770b-015b-4af8-8c91-b2ed6faf4b1e',
-    type: 'carousel',
-    previousName: 'previous-screen',
-    previousId: '00d71340-342e-4f3d-b9fd-4de728ffba7a',
-    previousType: 'feed',
+    type: 'carousel'
     transitionType: 'basic'
 });
 ```
+
+The tracker will automatically assign references to the previously tracked screen view event in the `previousName`, `previousId`, and `previousType` properties.
 
 **Required properties**
 
@@ -197,10 +196,20 @@ tracker.trackScreenViewEvent({
 
 - `id`: (string) - The id(UUID) of screen that was viewed
 - `type`: (string) - The type of screen that was viewed
-- `previousName`: (string) - The name of the previous screen that was viewed
-- `previousId`: (string) - The id(UUID) of the previous screen that was viewed
-- `previousType`: (string) - The type of screen that was viewed
+- `previousName`: (string) - The name of the previous screen that was viewed (assigned automatically)
+- `previousId`: (string) - The id(UUID) of the previous screen that was viewed (assigned automatically)
+- `previousType`: (string) - The type of screen that was viewed (assigned automatically)
 - `transitionType`: (string) - The type of transition that led to the screen being viewed
+
+#### Tracking screen views in React Navigation
+
+If you are using the [React Navigation](https://reactnavigation.org/) library for navigation in your app, you can implement automatic screen view tracking by adding a callback to your `NavigationContainer`.
+The steps are explained [in the documentation for React Navigation](https://reactnavigation.org/docs/screen-tracking/).
+
+#### Tracking screen views in React Native Navigation
+
+When using the [React Native Navigation](https://wix.github.io/react-native-navigation/docs/before-you-start/) library for navigation in your app, you can automatically track screen views by registering a listener when your component appears on screen.
+Use the `Navigation.events().registerComponentDidAppearListener` callback to subscribe the listener and track screen views as [documented here](https://wix.github.io/react-native-navigation/api/events/#componentdidappear).
 
 #### Page View
 


### PR DESCRIPTION
This PR adds some references to documentation on how to automatically track screen views in two navigation frameworks used in React Native.