### PR TITLE
Move downloading and running section from README into Igluctl docs

### DIFF
--- a/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md
+++ b/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md
@@ -4,6 +4,11 @@ date: "2021-01-21"
 sidebar_position: 10
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 Iglu is a schema repository for JSON Schema. A schema repository (sometimes called a registry) is like npm or Maven or git but holds data schemas instead of software or code. Iglu is used extensively in Snowplow.
 
 ## Igluctl
@@ -22,14 +27,28 @@ Iglu provides a CLI application, called igluctl which allows you to perform most
     - `table-check` - will check a given schema's table structure against schema
     - `table-migrate` is optional and allows removal of incompatible tables by migrating them as opposed to just "blacklisting".
 
-Download the latest Igluctl from GitHub releases:
+## Downloading and running Igluctl 
 
+Download the latest Igluctl from GitHub releases and unzip the file:
+
+<CodeBlock language="bash">{
+`$ wget https://github.com/snowplow/igluctl/releases/download/${versions.igluctl}/igluctl_${versions.igluctl}.zip
+$ unzip igluctl_${versions.igluctl}.zip
+`}</CodeBlock>
+
+To run Igluctl you can, for example, can pass the `--help` option to see information on the different commands and flags like this:
 ```bash
-$ wget https://github.com/snowplow/igluctl/releases/download/0.10.1/igluctl_0.10.1.zip
-$ unzip igluctl_0.10.1.zip
+$ ./igluctl --help
 ```
+:::note
+If you are on Windows, then you'll need to run Igluctl like this:
+```bash
+$ java -jar igluctl --help
+```
+Below and everywhere in documentation you'll find example commands without this `java -jar` prefix, so please remember to add it when running Igluctl.
+:::
 
-Note that Igluctl expects JRE 8 or later, and Iglu Server 0.6.0 or later to run.
+Note that Igluctl expects [JRE 8](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html) or later, and [Iglu Server](/docs/pipeline-components-and-applications/iglu/iglu-repositories/iglu-server/index.md) 0.6.0 or later to run.
 
 ## lint
 

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -20,5 +20,6 @@ export const versions = {
   enrich: '3.6.1',
   sqs2kinesis: '1.0.4',
   igluServer: '0.9.0',
+  igluctl: '0.10.2',
   snowplowMini: '0.15.1',
 }


### PR DESCRIPTION
There was a fair bit of duplication in Igluctl's README and here in the Igluctl docs. We shouldn't have duplicated info either way, but I think it makes sense for info about running/using Igluctl can live in docs, and info about developing Igluctl can live in the README.

I raised a [PR in Igluctl](https://github.com/snowplow/igluctl/pull/138) to remove duplication in the README. It wasn't all duplication. There was a point about how running Igluctl is different if you're on Windows vs OS X/Linux, so I've moved that point over to the docs. 

Here is the section that has been moved over:
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/3072877/214798952-087049d2-26ab-49ea-8af6-1e059e8cd274.png">
