### PR TITLE
JS: Mention required Collector config for postPath

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
@@ -302,11 +302,11 @@ The POST path that is used to send POST requests to a collector can be change wi
 
 `postPath` defaults to the standard path: `/com.snowplowanalytics.snowplow/tp2`
 
-Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol.
-The collector configuration must be updated (via [Snowplow Console](/docs/using-the-snowplow-console/accessing-collector-configuration/index.md) or [Collector Configuration](/docs/pipeline-components-and-applications/stream-collector/configure/index.md#configuring-custom-paths)) to support the new path _before_ you send events to it with this setting.
-Sending to an unmapped path will cause events to not be received by the collector, or in some cases, collected but fail validation during enrichment.
+```mdx-code-block
+import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 
-Care must be taken to ensure that requests are supported by your collector configuration or redirected to the collector at the correct endpoint (normally this is `/com.snowplowanalytics.snowplow/tp2`).
+<PostPath/>
+```
 
 #### Configuring cross-domain tracking
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
@@ -302,7 +302,9 @@ The POST path that is used to send POST requests to a collector can be change wi
 
 `postPath` defaults to the standard path: `/com.snowplowanalytics.snowplow/tp2`
 
-Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol. The collector configuration must be updated to support this path.
+Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol.
+The collector configuration must be updated (via [Snowplow Console](/docs/using-the-snowplow-console/accessing-collector-configuration/index.md) or [Collector Configuration](/docs/pipeline-components-and-applications/stream-collector/configure/index.md#configuring-custom-paths)) to support the new path _before_ you send events to it with this setting.
+Sending to an unmapped path will cause events to not be received by the collector, or in some cases, collected but fail validation during enrichment.
 
 Care must be taken to ensure that requests are supported by your collector configuration or redirected to the collector at the correct endpoint (normally this is `/com.snowplowanalytics.snowplow/tp2`).
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
@@ -49,7 +49,7 @@ The documentation listed here is for Version 2 of the JavaScript Tracker. Versio
 \- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
 
 ```mdx-code-block
-import Block1512 from "@site/docs/reusable/untitled-reusable-block-26/_index.md"
+import v2Init from "@site/docs/reusable/javascript-tracker-v2-initialization-options/_index.md"
 
-<Block1512/>
+<v2Init/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
@@ -348,7 +348,9 @@ The POST path that is used to send POST requests to a collector can be change wi
 
 `postPath` defaults to the standard path: `/com.snowplowanalytics.snowplow/tp2`
 
-Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol. The collector configuration must be updated to support this path.
+Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol.
+The collector configuration must be updated (via [Snowplow Console](/docs/using-the-snowplow-console/accessing-collector-configuration/index.md) or [Collector Configuration](/docs/pipeline-components-and-applications/stream-collector/configure/index.md#configuring-custom-paths)) to support the new path _before_ you send events to it with this setting.
+Sending to an unmapped path will cause events to not be received by the collector, or in some cases, collected but fail validation during enrichment.
 
 Care must be taken to ensure that requests are supported by your collector configuration or redirected to the collector at the correct endpoint (normally this is `/com.snowplowanalytics.snowplow/tp2`).
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
@@ -348,11 +348,11 @@ The POST path that is used to send POST requests to a collector can be change wi
 
 `postPath` defaults to the standard path: `/com.snowplowanalytics.snowplow/tp2`
 
-Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol.
-The collector configuration must be updated (via [Snowplow Console](/docs/using-the-snowplow-console/accessing-collector-configuration/index.md) or [Collector Configuration](/docs/pipeline-components-and-applications/stream-collector/configure/index.md#configuring-custom-paths)) to support the new path _before_ you send events to it with this setting.
-Sending to an unmapped path will cause events to not be received by the collector, or in some cases, collected but fail validation during enrichment.
+```mdx-code-block
+import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 
-Care must be taken to ensure that requests are supported by your collector configuration or redirected to the collector at the correct endpoint (normally this is `/com.snowplowanalytics.snowplow/tp2`).
+<PostPath/>
+```
 
 #### Configuring cross-domain tracking
 

--- a/docs/reusable/javascript-tracker-v2-initialization-options/_index.md
+++ b/docs/reusable/javascript-tracker-v2-initialization-options/_index.md
@@ -128,7 +128,7 @@ The Snowplow JavaScript tracker offers two techniques where tracking can be done
 Recommended configurations when using `anonymousTracking`:
 
 ```javascript
-anonymousTracking: true, 
+anonymousTracking: true,
 stateStorageStrategy: 'cookieAndLocalStorage'
 ```
 
@@ -352,11 +352,11 @@ The POST path that is used to send POST requests to a collector can be change wi
 
 `postPath` defaults to the standard path: `/com.snowplowanalytics.snowplow/tp2`
 
-Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol.
-The collector configuration must be updated (via [Snowplow Console](/docs/using-the-snowplow-console/accessing-collector-configuration/index.md) or [Collector Configuration](/docs/pipeline-components-and-applications/stream-collector/configure/index.md#configuring-custom-paths)) to support the new path _before_ you send events to it with this setting.
-Sending to an unmapped path will cause events to not be received by the collector, or in some cases, collected but fail validation during enrichment.
+```mdx-code-block
+import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 
-Care must be taken to ensure that requests are supported by your collector configuration or redirected to the collector at the correct endpoint (normally this is `/com.snowplowanalytics.snowplow/tp2`).
+<PostPath/>
+```
 
 #### Configuring cross-domain tracking
 

--- a/docs/reusable/trackers-post-path-note/_index.md
+++ b/docs/reusable/trackers-post-path-note/_index.md
@@ -1,0 +1,9 @@
+:::note
+
+Changing `postPath` is non-standard behavior that does not conform to the default collector protocol.
+The collector configuration must be updated (via [Snowplow Console](/docs/using-the-snowplow-console/accessing-collector-configuration/index.md) or [Collector Configuration](/docs/pipeline-components-and-applications/stream-collector/configure/index.md#configuring-custom-paths)) to support the new path _before_ you send events to it with this setting.
+Sending to an unmapped path will cause events to not be received by the collector, or in some cases, collected but fail validation during enrichment.
+
+Care must be taken to ensure that requests are supported by your collector configuration or redirected to the collector at the correct endpoint (normally this is `/com.snowplowanalytics.snowplow/tp2`).
+
+:::

--- a/docs/reusable/untitled-reusable-block-26/_index.md
+++ b/docs/reusable/untitled-reusable-block-26/_index.md
@@ -352,7 +352,9 @@ The POST path that is used to send POST requests to a collector can be change wi
 
 `postPath` defaults to the standard path: `/com.snowplowanalytics.snowplow/tp2`
 
-Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol. The collector configuration must be updated to support this path.
+Note: changing `postPath` is non-standard behavior that does not conform to the default collector protocol.
+The collector configuration must be updated (via [Snowplow Console](/docs/using-the-snowplow-console/accessing-collector-configuration/index.md) or [Collector Configuration](/docs/pipeline-components-and-applications/stream-collector/configure/index.md#configuring-custom-paths)) to support the new path _before_ you send events to it with this setting.
+Sending to an unmapped path will cause events to not be received by the collector, or in some cases, collected but fail validation during enrichment.
 
 Care must be taken to ensure that requests are supported by your collector configuration or redirected to the collector at the correct endpoint (normally this is `/com.snowplowanalytics.snowplow/tp2`).
 


### PR DESCRIPTION
Be more explicit that you need to configure the Collector before you use the `postPath` configuration option in the JS trackers.

Provides links to the respective Collector configuration docs to be super clear. Previously these were mostly only mentioned on https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/example-requests/