### PR TITLE
Widen the TOC on non-doc pages

### DIFF
--- a/src/theme/MDXPage/index.js
+++ b/src/theme/MDXPage/index.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import MDXContent from '@theme/MDXContent';
+import TOC from '@theme/TOC';
+import styles from './styles.module.css';
+export default function MDXPage(props) {
+  const {content: MDXPageContent} = props;
+  const {
+    metadata: {title, description, frontMatter},
+  } = MDXPageContent;
+  const {wrapperClassName, hide_table_of_contents: hideTableOfContents} =
+    frontMatter;
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        wrapperClassName ?? ThemeClassNames.wrapper.mdxPages,
+        ThemeClassNames.page.mdxPage,
+      )}>
+      <PageMetadata title={title} description={description} />
+      <Layout>
+        <main className="container container--fluid margin-vert--lg">
+          <div className={clsx('row', styles.mdxPageWrapper)}>
+            <div className={clsx('col', !hideTableOfContents && 'col--7')}>
+              <article>
+                <MDXContent>
+                  <MDXPageContent />
+                </MDXContent>
+              </article>
+            </div>
+            {!hideTableOfContents && MDXPageContent.toc.length > 0 && (
+              <div className="col col--3">
+                <TOC
+                  toc={MDXPageContent.toc}
+                  minHeadingLevel={frontMatter.toc_min_heading_level}
+                  maxHeadingLevel={frontMatter.toc_max_heading_level}
+                />
+              </div>
+            )}
+          </div>
+        </main>
+      </Layout>
+    </HtmlClassNameProvider>
+  );
+}

--- a/src/theme/MDXPage/styles.module.css
+++ b/src/theme/MDXPage/styles.module.css
@@ -1,0 +1,3 @@
+.mdxPageWrapper {
+  justify-content: center;
+}


### PR DESCRIPTION
Ran `npm run swizzle @docusaurus/theme-classic MDXPage -- --eject --danger` and edited the resulting file.