### PR TITLE
fix header links to yaml selectors

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/ecommerce/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/ecommerce/index.md
@@ -23,7 +23,7 @@ import DbtPackageInstallation from "@site/docs/reusable/dbt-package-installation
 
 ### 1. Adding the `selector.yml` file
 
-Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the e-commerce model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](#yaml-selectors) section.
+Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the e-commerce model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/index.md#yaml-selectors) section.
 
 These are defined in the `selectors.yml` file ([source](https://github.com/snowplow/dbt-snowplow-ecommerce/blob/main/selectors.yml)) within the package, however in order to use these selectors you will need to copy this file into your own dbt project directory. This is a top-level file and therefore should sit alongside your `dbt_project.yml` file. If you are using multiple packages in your project you will need to combine the contents of these into a single file.
 

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/media-player/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/media-player/index.md
@@ -34,7 +34,7 @@ If you are not starting the media player package at the same time as the web pac
 
 ### 1. Adding the `selector.yml` file
 
-Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the web model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](#yaml-selectors) section.
+Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the web model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/index.md#yaml-selectors) section.
 
 These are defined in the `selectors.yml` file ([source](https://github.com/snowplow/dbt-snowplow-media-player/blob/main/selectors.yml)) within the package, however in order to use these selections you will need to copy this file into your own dbt project directory. This is a top-level file and therefore should sit alongside your `dbt_project.yml` file. If you are using multiple packages in your project you will need to combine the contents of these into a single file.
 

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/mobile/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/mobile/index.md
@@ -22,7 +22,7 @@ import DbtPackageInstallation from "@site/docs/reusable/dbt-package-installation
 
 ### 1. Adding the `selector.yml` file
 
-Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the mobile model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](#yaml-selectors) section.
+Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the mobile model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/index.md#yaml-selectors) section.
 
 These are defined in the `selectors.yml` file ([source](https://github.com/snowplow/dbt-snowplow-mobile/blob/main/selectors.yml)) within the package, however in order to use these selections you will need to copy this file into your own dbt project directory. This is a top-level file and therefore should sit alongside your `dbt_project.yml` file. If you are using multiple packages in your project you will need to combine the contents of these into a single file.
 

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/normalize/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/normalize/index.md
@@ -18,7 +18,7 @@ import DbtPackageInstallation from "@site/docs/reusable/dbt-package-installation
 
 ### 1. Adding the `selector.yml` file
 
-Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the web model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](#yaml-selectors) section.
+Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the web model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/index.md#yaml-selectors) section.
 
 These are defined in the `selectors.yml` file ([source](https://github.com/snowplow/dbt-snowplow-normalize/blob/main/selectors.yml)) within the package, however in order to use these selections you will need to copy this file into your own dbt project directory. This is a top-level file and therefore should sit alongside your `dbt_project.yml` file. If you are using multiple packages in your project you will need to combine the contents of these into a single file.
 

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/web/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/web/index.md
@@ -23,7 +23,7 @@ import DbtPackageInstallation from "@site/docs/reusable/dbt-package-installation
 
 ### 1. Adding the `selector.yml` file
 
-Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the web model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](#yaml-selectors) section.
+Within the packages we have provided a suite of suggested selectors to run and test the models within the package together with the web model. This leverages dbt's [selector flag](https://docs.getdbt.com/reference/node-selection/syntax). You can find out more about each selector in the [YAML Selectors](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/index.md#yaml-selectors) section.
 
 These are defined in the `selectors.yml` file ([source](https://github.com/snowplow/dbt-snowplow-web/blob/main/selectors.yml)) within the package, however in order to use these selections you will need to copy this file into your own dbt project directory. This is a top-level file and therefore should sit alongside your `dbt_project.yml` file. If you are using multiple packages in your project you will need to combine the contents of these into a single file.
 


### PR DESCRIPTION
Fix links to yaml selectors as they currently point to an outdated location