### PR TITLE
Add placeholder pages for LaunchDarkly GTM-SS Tag

### DIFF
--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/index.md
@@ -1,6 +1,5 @@
 ---
 title: "LaunchDarkly Tag for GTM SS"
-date: "2023-03-07"
 sidebar_position: 600
 ---
 

--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/index.md
@@ -1,0 +1,8 @@
+---
+title: "LaunchDarkly Tag for GTM SS"
+date: "2023-03-07"
+sidebar_position: 600
+---
+
+
+## Coming soon!

--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/launchdarkly-tag-configuration/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/launchdarkly-tag-configuration/index.md
@@ -1,0 +1,7 @@
+---
+title: "LaunchDarkly Tag Configuration"
+date: "2023-03-07"
+sidebar_position: 100
+---
+
+## Coming soon!

--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/launchdarkly-tag-configuration/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/launchdarkly-tag-configuration/index.md
@@ -1,6 +1,5 @@
 ---
 title: "LaunchDarkly Tag Configuration"
-date: "2023-03-07"
 sidebar_position: 100
 ---
 


### PR DESCRIPTION
Not sure if best practice, the reason for doing so is to ensure the pages are there before the repository goes public.