### PR TITLE
Add support for abbr tags on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -319,3 +319,30 @@ img.shield {
   border-radius: var(--ifm-alert-border-radius);
   transition: 0.4s cubic-bezier(.38,.14,.58,1) all;
 }
+
+abbr[title] {
+  position: relative;
+
+  /* ensure consistent styling across browsers */
+  text-decoration: underline dotted;
+}
+
+abbr[title]:hover::after,
+abbr[title]:focus::after {
+  content: attr(title);
+
+  /* position tooltip like the native one */
+  position: absolute;
+  left: 0;
+  bottom: -30px;
+  width: auto;
+  white-space: nowrap;
+
+  /* style tooltip */
+  background-color: #1e1e1e;
+  color: #fff;
+  border-radius: 3px;
+  box-shadow: 1px 1px 5px 0 rgba(0,0,0,0.4);
+  font-size: 14px;
+  padding: 3px 5px;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -80,6 +80,7 @@
   --ifm-color-primary-lightest: #b198df;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --ifm-font-color-base: rgb(218, 221, 225);
+  --ifm-font-color-base-inverse: #000000
 }
 
 [data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
@@ -339,8 +340,8 @@ abbr[data-title]:focus::after {
   white-space: nowrap;
 
   /* style tooltip */
-  background-color: #1e1e1e;
-  color: #fff;
+  background-color: var(--ifm-font-color-base);
+  color: var(--ifm-font-color-base-inverse);
   border-radius: 3px;
   box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
   font-size: 14px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -323,7 +323,7 @@ img.shield {
 
 abbr[data-title] {
   position: relative;
-
+  cursor: help;
   /* ensure consistent styling across browsers */
   text-decoration: underline dotted;
 }
@@ -331,7 +331,7 @@ abbr[data-title] {
 abbr[data-title]:hover::after,
 abbr[data-title]:focus::after {
   content: attr(data-title);
-
+  font-weight: normal;
   /* position tooltip like the native one */
   position: absolute;
   left: 0;
@@ -345,5 +345,6 @@ abbr[data-title]:focus::after {
   border-radius: 3px;
   box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
   font-size: 14px;
+  z-index: 9998;
   padding: 3px 5px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -320,16 +320,16 @@ img.shield {
   transition: 0.4s cubic-bezier(.38,.14,.58,1) all;
 }
 
-abbr[title] {
+abbr[data-title] {
   position: relative;
 
   /* ensure consistent styling across browsers */
   text-decoration: underline dotted;
 }
 
-abbr[title]:hover::after,
-abbr[title]:focus::after {
-  content: attr(title);
+abbr[data-title]:hover::after,
+abbr[data-title]:focus::after {
+  content: attr(data-title);
 
   /* position tooltip like the native one */
   position: absolute;
@@ -342,7 +342,7 @@ abbr[title]:focus::after {
   background-color: #1e1e1e;
   color: #fff;
   border-radius: 3px;
-  box-shadow: 1px 1px 5px 0 rgba(0,0,0,0.4);
+  box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
   font-size: 14px;
   padding: 3px 5px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -80,7 +80,7 @@
   --ifm-color-primary-lightest: #b198df;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --ifm-font-color-base: rgb(218, 221, 225);
-  --ifm-font-color-base-inverse: #000000
+  --ifm-font-color-base-inverse: #000000;
 }
 
 [data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {

--- a/src/remark/abbreviations.js
+++ b/src/remark/abbreviations.js
@@ -26,7 +26,7 @@ const plugin = () => {
         const split = node.value.split(find)
         if (split.length > 1) {
           const replaced = split.map(token => config[token] ?
-            { type: 'html', value: `<abbr title="${config[token]}">${token}</abbr>` } :
+            { type: 'html', value: `<abbr data-title="${config[token]}">${token}</abbr>` } :
             { ...node, value: token }
           )
           return replaced


### PR DESCRIPTION
Adds support to the abbreviations to work on mobile as currently they do nothing.

We both know I didn't work this out myself https://bitsofco.de/making-abbr-work-for-touchscreen-keyboard-mouse/ + https://stackoverflow.com/questions/34276581/display-abbr-and-acronym-on-mobile-devices

I can't make it delay the pop-up like OG abbr did...