### PR TITLE
Enrich: remove KPL

### DIFF
--- a/docs/pipeline-components-and-applications/enrichment-components/monitoring/index.md
+++ b/docs/pipeline-components-and-applications/enrichment-components/monitoring/index.md
@@ -76,7 +76,7 @@ Sentry monitoring is configured by setting the `monitoring.sentry.dsn` key in�
 
 ## Cloudwatch (for enrich-kinesis)
 
-It's possible to send KCL and KPL metrics to Cloudwatch by adding this section to the config file:
+It's possible to send KCL metrics to Cloudwatch by adding this section to the config file:
 
 ```json
 "monitoring": {


### PR DESCRIPTION
We dropped KPL but we still mention KPL metrics in the docs, as stated on [discourse](https://discourse.snowplow.io/t/enricher-kpl-metrics-in-cloudwatch/8262/2).