### PR TITLE
Proof of concept - custom snowplow Admonitions

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -19,3 +19,10 @@ Have you found yourself relying on “data exhaust” — data from arbitrary to
 * ✅ A unique approach based on **[schemas and validation](/docs/understanding-tracking-design/understanding-schemas-and-validation/index.md)** ensures your data is as clean as possible.
 * 🪄 **Over [15 enrichments](/docs/enriching-your-data/available-enrichments/index.md)** to get the most out of your data.
 * 🏭 Send data to **popular warehouses and streams** — Snowplow fits nicely within the [Modern Data Stack](https://snowplowanalytics.com/blog/2021/05/12/modern-data-stack/?utm_source=docs&utm_content=landing-page).
+
+
+:::snowplow
+
+Hello, world!
+
+:::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,6 +44,10 @@ async function createConfig() {
         {
           docs: {
             showLastUpdateTime: true,
+            admonitions: {
+              tag: ':::',
+              keywords: ['note', 'tip', 'info', 'caution', 'danger', 'snowplow'],
+            },
             editUrl: 'https://github.com/snowplow/documentation/tree/main/',
             remarkPlugins: [mdxMermaid.default, abbreviations],
             async sidebarItemsGenerator({

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -47,7 +47,7 @@
 /* You can override the default Infima variables here. */
 :root {
   --ifm-background-color: #f2f4f7;
-  --ifm-color-primary: #6638b8;
+  --ifm-color-primary: rgb(102, 56, 184);
   --ifm-color-primary-dark: #522d93;
   --ifm-color-primary-darker: #472781;
   --ifm-color-primary-darkest: #29164a;
@@ -347,4 +347,12 @@ abbr[data-title]:focus::after {
   font-size: 14px;
   z-index: 9998;
   padding: 3px 5px;
+}
+
+.alert--snowplow {
+	--ifm-alert-background-color:rgba(102, 56, 184,0.3);
+	--ifm-alert-background-color-highlight: rgba(102, 56, 184, 0.15);
+	--ifm-alert-foreground-color: var(--ifm-color-announcement);
+	--ifm-alert-border-color: var(--ifm-color-primary-darker);
+  color: var(--ifm-font-color-base);
 }

--- a/src/theme/Admonition/index.js
+++ b/src/theme/Admonition/index.js
@@ -1,0 +1,195 @@
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import Translate from '@docusaurus/Translate';
+import styles from './styles.module.css';
+function NoteIcon() {
+  return (
+    <svg viewBox="0 0 14 16">
+      <path
+        fillRule="evenodd"
+        d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
+      />
+    </svg>
+  );
+}
+function SnowplowIcon() {
+  return (
+    <svg width="25.453" height="23" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25.453 23">
+      <path stroke="#522d93" stroke-width="1px" d="M25.189 10.386L19.907 1.104a2.395 2.395 0 0 0 -0.817 -0.784 2.355 2.355 0 0 0 -1.08 -0.316h-3.938c-0.036 -0.005 -0.073 -0.005 -0.109 0H7.441a2.342 2.342 0 0 0 -1.08 0.317A2.382 2.382 0 0 0 5.548 1.108L0.264 10.386A2.454 2.454 0 0 0 0 11.495c0 0.386 0.091 0.766 0.264 1.109L5.549 21.891a2.392 2.392 0 0 0 0.813 0.788A2.352 2.352 0 0 0 7.441 23h10.569a2.351 2.351 0 0 0 1.08 -0.32 2.391 2.391 0 0 0 0.814 -0.788l5.284 -9.287a2.455 2.455 0 0 0 0.264 -1.109c0 -0.386 -0.091 -0.766 -0.264 -1.109zM19.25 1.49l1.929 3.391 -3.379 5.867 -2.212 -3.843a0.381 0.381 0 0 0 -0.138 -0.139 0.374 0.374 0 0 0 -0.188 -0.051h-4.39l3.362 -5.942h3.777a1.615 1.615 0 0 1 0.699 0.214 1.641 1.641 0 0 1 0.537 0.502l0.003 0.002zm-6.283 9.651l-2.106 -3.659h4.185l2.108 3.658 -4.186 0.001zm-0.688 0.371l-2.082 3.618 -2.09 -3.636 2.081 -3.618 2.09 3.636zm0.666 0.402h4.163l-2.068 3.596h-4.179l2.084 -3.596zM6.209 1.49a1.63 1.63 0 0 1 0.536 -0.499 1.604 1.604 0 0 1 0.697 -0.211h5.913l-3.358 5.934H3.235L6.209 1.49zM0.924 10.772l1.871 -3.29h6.741l-2.199 3.817a0.388 0.388 0 0 0 0 0.389l2.199 3.822H2.795l-1.873 -3.286a1.687 1.687 0 0 1 -0.163 -0.725c0 -0.251 0.056 -0.499 0.163 -0.725l0.002 -0.002zm6.517 11.455a1.615 1.615 0 0 1 -0.7 -0.218 1.642 1.642 0 0 1 -0.536 -0.507l-2.975 -5.224h6.741l3.391 5.948h-5.921zm11.805 -0.725a1.641 1.641 0 0 1 -0.536 0.507 1.615 1.615 0 0 1 -0.7 0.218h-3.768l-3.392 -5.951h4.406c0.066 0 0.131 -0.018 0.188 -0.051a0.381 0.381 0 0 0 0.138 -0.139l2.195 -3.81 3.374 5.881 -1.906 3.346zm5.284 -9.287l-2.939 5.169 -3.362 -5.862 3.389 -5.877 2.917 5.125a1.688 1.688 0 0 1 0.163 0.725c0 0.251 -0.056 0.499 -0.163 0.725" fill="#522d93"/>
+    </svg>
+);
+}
+function TipIcon() {
+  return (
+    <svg viewBox="0 0 12 16">
+      <path
+        fillRule="evenodd"
+        d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"
+      />
+    </svg>
+  );
+}
+function DangerIcon() {
+  return (
+    <svg viewBox="0 0 12 16">
+      <path
+        fillRule="evenodd"
+        d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"
+      />
+    </svg>
+  );
+}
+function InfoIcon() {
+  return (
+    <svg viewBox="0 0 14 16">
+      <path
+        fillRule="evenodd"
+        d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+      />
+    </svg>
+  );
+}
+function CautionIcon() {
+  return (
+    <svg viewBox="0 0 16 16">
+      <path
+        fillRule="evenodd"
+        d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+      />
+    </svg>
+  );
+}
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+const AdmonitionConfigs = {
+  note: {
+    infimaClassName: 'secondary',
+    iconComponent: NoteIcon,
+    label: (
+      <Translate
+        id="theme.admonition.note"
+        description="The default label used for the Note admonition (:::note)">
+        note
+      </Translate>
+    ),
+  },
+  tip: {
+    infimaClassName: 'success',
+    iconComponent: TipIcon,
+    label: (
+      <Translate
+        id="theme.admonition.tip"
+        description="The default label used for the Tip admonition (:::tip)">
+        tip
+      </Translate>
+    ),
+  },
+  danger: {
+    infimaClassName: 'danger',
+    iconComponent: DangerIcon,
+    label: (
+      <Translate
+        id="theme.admonition.danger"
+        description="The default label used for the Danger admonition (:::danger)">
+        danger
+      </Translate>
+    ),
+  },
+  info: {
+    infimaClassName: 'info',
+    iconComponent: InfoIcon,
+    label: (
+      <Translate
+        id="theme.admonition.info"
+        description="The default label used for the Info admonition (:::info)">
+        info
+      </Translate>
+    ),
+  },
+  caution: {
+    infimaClassName: 'warning',
+    iconComponent: CautionIcon,
+    label: (
+      <Translate
+        id="theme.admonition.caution"
+        description="The default label used for the Caution admonition (:::caution)">
+        caution
+      </Translate>
+    ),
+  },
+  snowplow: {
+    infimaClassName: 'snowplow',
+    iconComponent: SnowplowIcon,
+    label: (
+      <Translate
+        id="theme.admonition.snowplow"
+        description="The default label used for the snowplow admonition (:::snowplow)">
+        snowplow
+      </Translate>
+    ),
+  },
+};
+// Legacy aliases, undocumented but kept for retro-compatibility
+const aliases = {
+  secondary: 'note',
+  important: 'info',
+  success: 'tip',
+  warning: 'danger'
+};
+function getAdmonitionConfig(unsafeType) {
+  const type = aliases[unsafeType] ?? unsafeType;
+  const config = AdmonitionConfigs[type];
+  if (config) {
+    return config;
+  }
+  console.warn(
+    `No admonition config found for admonition type "${type}". Using Info as fallback.`,
+  );
+  return AdmonitionConfigs.info;
+}
+// Workaround because it's difficult in MDX v1 to provide a MDX title as props
+// See https://github.com/facebook/docusaurus/pull/7152#issuecomment-1145779682
+function extractMDXAdmonitionTitle(children) {
+  const items = React.Children.toArray(children);
+  const mdxAdmonitionTitle = items.find(
+    (item) =>
+      React.isValidElement(item) &&
+      item.props?.mdxType === 'mdxAdmonitionTitle',
+  );
+  const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>;
+  return {
+    mdxAdmonitionTitle,
+    rest,
+  };
+}
+function processAdmonitionProps(props) {
+  const {mdxAdmonitionTitle, rest} = extractMDXAdmonitionTitle(props.children);
+  return {
+    ...props,
+    title: props.title ?? mdxAdmonitionTitle,
+    children: rest,
+  };
+}
+export default function Admonition(props) {
+  const {children, type, title, icon: iconProp} = processAdmonitionProps(props);
+  const typeConfig = getAdmonitionConfig(type);
+  const titleLabel = title ?? typeConfig.label;
+  const {iconComponent: IconComponent} = typeConfig;
+  const icon = iconProp ?? <IconComponent />;
+  return (
+    <div
+      className={clsx(
+        ThemeClassNames.common.admonition,
+        ThemeClassNames.common.admonitionType(props.type),
+        'alert',
+        `alert--${typeConfig.infimaClassName}`,
+        styles.admonition,
+      )}>
+      <div className={styles.admonitionHeading}>
+        <span className={styles.admonitionIcon}>{icon}</span>
+        {titleLabel}
+      </div>
+      <div className={styles.admonitionContent}>{children}</div>
+    </div>
+  );
+}

--- a/src/theme/Admonition/styles.module.css
+++ b/src/theme/Admonition/styles.module.css
@@ -1,0 +1,31 @@
+.admonition {
+  margin-bottom: 1em;
+}
+
+.admonitionHeading {
+  font: var(--ifm-heading-font-weight) var(--ifm-h5-font-size) /
+    var(--ifm-heading-line-height) var(--ifm-heading-font-family);
+  text-transform: uppercase;
+  margin-bottom: 0.3rem;
+}
+
+.admonitionHeading code {
+  text-transform: none;
+}
+
+.admonitionIcon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.4em;
+}
+
+.admonitionIcon svg {
+  display: inline-block;
+  height: 1.6em;
+  width: 1.6em;
+  fill: var(--ifm-alert-foreground-color);
+}
+
+.admonitionContent > :last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Proof of concept idea for custom snowplow admonitions, you could in theory have ones per product (although we only have one logo..., open source could at least be different), but the idea is you could use these to callout specifics of the Snowplow Product? Example on the main page

Some things to note:
- Currently the element has to be ejected and edited quite a bit, in the future (canary version https://docusaurus.io/docs/next/markdown-features/admonitions#custom-admonition-type-components) this will be easier and not require the ejection
- I upped the thickness of the snowplow logo svg as it is not very visible at that size otherwise, I did this via the stroke argument
- The colours feel quite thick, I also couldn't get it to work by putting it into the ejected css so had to add it to the main one.

Recommendation would be to wait for the next version of docusaurus where this will be easier, rather than implement it this way, but as a proof of concept hopefully it's useful.