### PR TITLE
Fix ruby tracker pages

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/ruby-tracker/adding-data-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/ruby-tracker/adding-data-events/index.md
@@ -4,6 +4,11 @@ date: "2021-10-19"
 sidebar_position: 20
 ---
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
 There are multiple ways to add extra data to your tracked events, adding richness and value to your dataset. Each of them involves a different class from the Ruby tracker.
 
 1. [Event context](#event-context) using SelfDescribingJson. Attach event context, describing anything you like, in the form of self-describing JSONs.
@@ -29,6 +34,9 @@ Once defined, an entity can be attached to any kind of event. This is also an im
 
 Example:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 # Tracking a screen view with context made up of two entities
 entity1 = SnowplowTracker::SelfDescribingJson.new(
@@ -45,8 +53,9 @@ entity2 = SnowplowTracker::SelfDescribingJson.new(
 
 tracker.track_screen_view(id: 'sci-123-abc', context: [entity1, entity2])
 ```
+  </TabItem>
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 # Tracking a screen view with context made up of two entities
@@ -65,7 +74,12 @@ entity2 = SnowplowTracker::SelfDescribingJson.new(
 tracker.track_screen_view(nil, 'sci-123-abc', [entity1, entity2])
 ```
 
-Note: the event context is always an array, even if you are only adding one entity.
+  </TabItem>
+</Tabs>
+
+:::note
+The event context is always an array, even if you are only adding one entity.
+:::
 
 ## Adding user and platform data with Subject
 
@@ -96,9 +110,18 @@ The following table lists all the properties that can be set via Subject. These 
 | `br_viewwidth` and `br_viewheight` | The browser viewport size |
 | `br_colordepth` | The browser color depth |
 
-Note: the methods for defining `domain_sessionid` and `domain_sessionidx` were added in tracker version 0.7.0.
+:::note
+The methods for defining `domain_sessionid` and `domain_sessionidx` were added in tracker version 0.7.0.
+:::
 
 Example:
+
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
+:::note
+The ability to add `Subject` objects to `track_x_event` method calls (option 1 below) was added in version 0.7.0.
+:::
 
 ```ruby
 # Creating a Subject and adding user data
@@ -118,10 +141,9 @@ tracker.set_subject(subject).track_page_view(page_url: 'www.example.com')
 tracker.set_user_id('12345').set_timezone('Europe/London')
 tracker.track_page_view(page_url: 'www.example.com')
 ```
+  </TabItem>
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
-
-Note: the ability to add Subjects to `track_x_event` method calls was added in version 0.7.0.
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 # Creating a Subject and adding user data
@@ -137,6 +159,8 @@ tracker.set_subject(subject).track_page_view('www.example.com')
 tracker.set_user_id('12345').set_timezone('Europe/London')
 tracker.track_page_view('www.example.com')
 ```
+  </TabItem>
+</Tabs>
 
 ### Cookie-based user properties
 

--- a/docs/collecting-data/collecting-from-own-applications/ruby-tracker/configuring-how-events-are-sent/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/ruby-tracker/configuring-how-events-are-sent/index.md
@@ -22,7 +22,8 @@ Example:
 
 ```ruby
 emitter1 = SnowplowTracker::Emitter.new(endpoint: 'collector.example.com')
-emitter2 = SnowplowTracker::AsyncEmitter.new(endpoint: 'collector2.example.com')
+emitter2 = SnowplowTracker::AsyncEmitter.new(endpoint: 'collector2.example.com',
+                                             options: { method: 'post' })
 emitter3 = SnowplowTracker::AsyncEmitter.new(endpoint: 'collector.elsewhere.com',
                                              options: { protocol: 'https' })
 
@@ -35,7 +36,8 @@ tracker.add_emitter(emitter3)
 
 ```ruby
 emitter1 = SnowplowTracker::Emitter.new('collector.example.com')
-emitter2 = SnowplowTracker::AsyncEmitter.new('collector2.example.com')
+emitter2 = SnowplowTracker::AsyncEmitter.new('collector2.example.com',
+                                             { method: 'post' })
 emitter3 = SnowplowTracker::AsyncEmitter.new('collector.elsewhere.com',
                                              { protocol: 'https' })
 
@@ -47,17 +49,17 @@ tracker.add_emitter(emitter3)
 
 Optional Emitter settings:
 
-| **Optional parameter** | **Description** |
-| --- | --- |
-| `path` | Override the default path for appending to the endpoint |
-| `protocol` | HTTP or HTTPS |
-| `port` | The port for the connection |
-| `method` | GET or POST |
-| `buffer_size` | The size of the buffer, i.e. the number of events to send at once |
-| `on_success` | A method to call if events were all sent successfully |
-| `on_failure` | A method to call if any events did not send |
-| `thread_count` | Number of threads to use (relevant to AsyncEmitters only) |
-| `logger` | Log somewhere other than STDERR |
+| **Optional parameter** | **Description** | **Default** |
+| --- | --- | --- |
+| `path` | Override the default path for appending to the endpoint | n/a|
+| `protocol` | `http` or `https` | `http` |
+| `port` | The port for the connection | n/a |
+| `method` | `get` or `post` | `get` |
+| `buffer_size` | The size of the buffer, i.e. the number of events to send at once | 1 |
+| `on_success` | A method to call if events were all sent successfully | n/a |
+| `on_failure` | A method to call if any events did not send | n/a |
+| `thread_count` | Number of threads to use (relevant to AsyncEmitters only) | 1 |
+| `logger` | Where to log | STDERR |
 
 Response status codes of 2xx or 3xx status codes are considered successful.
 

--- a/docs/collecting-data/collecting-from-own-applications/ruby-tracker/configuring-how-events-are-sent/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/ruby-tracker/configuring-how-events-are-sent/index.md
@@ -4,6 +4,11 @@ date: "2021-10-26"
 sidebar_position: 30
 ---
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
 When you [initialize your Tracker object](/docs/collecting-data/collecting-from-own-applications/ruby-tracker/getting-started/index.md#tracking-design-and-initialization), you will need to provide one or more Emitter objects. Remember that we advise using the Singleton pattern, to avoid constantly recreating your objects.
 
 There are two types of Emitter. The Emitter parent class can only send events synchronously. The AsyncEmitter subclass sends events asynchronously by default. We recommend you use the AsyncEmitter, to avoid slowing down your app.
@@ -11,6 +16,9 @@ There are two types of Emitter. The Emitter parent class can only send events sy
 Emitters and AsyncEmitters are initialized in the same way. An event collector endpoint is required, but there are various optional parameters that can also be set (see [API docs](https://snowplow.github.io/snowplow-ruby-tracker/SnowplowTracker/Emitter.html) and below table). A Tracker can have more than one associated Emitter or AsyncEmitter. These can be provided at Tracker initialization, or added later on.
 
 Example:
+
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
 
 ```ruby
 emitter1 = SnowplowTracker::Emitter.new(endpoint: 'collector.example.com')
@@ -21,8 +29,9 @@ emitter3 = SnowplowTracker::AsyncEmitter.new(endpoint: 'collector.elsewhere.com'
 tracker = SnowplowTracker::Tracker.new(emitters: [emitter1, emitter2])
 tracker.add_emitter(emitter3)
 ```
+  </TabItem>
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 emitter1 = SnowplowTracker::Emitter.new('collector.example.com')
@@ -33,6 +42,8 @@ emitter3 = SnowplowTracker::AsyncEmitter.new('collector.elsewhere.com',
 tracker = SnowplowTracker::Tracker.new([emitter1, emitter2])
 tracker.add_emitter(emitter3)
 ```
+  </TabItem>
+</Tabs>
 
 Optional Emitter settings:
 
@@ -56,6 +67,9 @@ You may want to force an emitter to send all events in its buffer, even if the b
 
 Example:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 # Synchronous flush
 tracker.flush
@@ -63,8 +77,9 @@ tracker.flush
 # Asynchronous flush
 tracker.flush(async: true)
 ```
+  </TabItem>
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 # Synchronous flush
@@ -73,6 +88,8 @@ tracker.flush
 # Asynchronous flush
 tracker.flush(true)
 ```
+  </TabItem>
+</Tabs>
 
 ### Logging
 

--- a/docs/collecting-data/collecting-from-own-applications/ruby-tracker/getting-started/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/ruby-tracker/getting-started/index.md
@@ -27,7 +27,9 @@ The main class of the Ruby tracker is the Tracker class. Trackers provide method
 
 Data about users, and which platform (e.g. server-side app or mobile) the event occurred on, are managed by Subject objects. A Subject can be added to each event, and Trackers always have an associated Subject. Other information can be added to events using Page, DeviceTimestamp or TrueTimestamp objects, as well as via event context. Event context is added via SelfDescribingJson objects.
 
-Note that the Ruby tracker version 0.7.0 had some breaking changes, specifically the addition of keyword arguments. If you are using version <0.7.0, look out for the dropdowns under code examples on these pages for the old API. Check out the tracker changelog [here](https://github.com/snowplow/snowplow-ruby-tracker/blob/master/CHANGELOG).
+:::note
+The Ruby tracker version 0.7.0 had some breaking changes, notably the addition of keyword arguments. Check out the tracker changelog [here](https://github.com/snowplow/snowplow-ruby-tracker/blob/master/CHANGELOG).
+:::
 
 ## Tracking design and initialization
 
@@ -37,7 +39,7 @@ We suggest implementing the Ruby tracker as a Singleton global object. This patt
 
 Note that the [Rails demo](https://github.com/snowplow-incubator/snowplow-ruby-tracker-examples) has both the Ruby and JavaScript trackers implemented. This combination of client- and server-side tracking can be highly effective and powerful. For example, you can discover how much effect adblockers are having on your tracking, by comparing the amount of client-side and server-side page view events you collect. It also allows you to track events in the most appropriate way for the event type. Check out this [blog post](https://snowplowanalytics.com/blog/2021/11/09/the-unrivaled-power-of-joining-client-and-server-side-tracking/) for more discussion about tracking client- and server-side.
 
-The Tracker must be initialized with an Emitter or the subclass AsyncEmitter (or an array of Emitters/AsyncEmitters). The only required argument for an Emitter/AsyncEmitter is the endpoint, i.e. the address of the event collector. See "[Configuring how events are sent](/docs/collecting-data/collecting-from-own-applications/ruby-tracker/configuring-how-events-are-sent/index.md)" for more information about configuring Emitters.
+The Tracker must be initialized with an Emitter or the subclass AsyncEmitter (or an array of Emitters/AsyncEmitters). The only required argument for an Emitter/AsyncEmitter is the endpoint, i.e. the address of the event collector.
 
 Initializing a tracker instance:
 
@@ -70,7 +72,11 @@ tracker = SnowplowTracker::Tracker.new([emitter])
 </Tabs>
 
 
-This Tracker will send events via GET to `http://collector.example.com/i`.
+This Tracker will send events via GET to `http://collector.example.com/i`. To use other settings, such as POST or HTTPS, see "[Configuring how events are sent](/docs/collecting-data/collecting-from-own-applications/ruby-tracker/configuring-how-events-are-sent/index.md)".
+
+:::caution
+Do not include the protocol (HTTP or HTTPS) in your collector address. It will be added automatically.
+:::
 
 At initialization, two Tracker parameters can be set which will be added to all events. The first is the Tracker `namespace`. This is especially useful to distinguish between events from different Trackers, if more than one is being used. The second user-set Tracker property is the `app_id`. This is the unique identifier for the site or application, and is particularly useful for distinguishing between events when Snowplow tracking has been implemented in multiple apps.
 

--- a/docs/collecting-data/collecting-from-own-applications/ruby-tracker/getting-started/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/ruby-tracker/getting-started/index.md
@@ -4,15 +4,14 @@ date: "2021-10-15"
 sidebar_position: 0
 ---
 
-## Installation
-
-The Snowplow Ruby Tracker is compatible with Ruby 2.1+, including 3.0+. To install it locally:
-
-```bash
-$ gem install snowplow-tracker
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 ```
 
-To add the Snowplow Tracker to your Ruby app or gem, add this line to your Gemfile:
+## Installation
+
+The Snowplow Ruby Tracker is compatible with Ruby 2.1+, including 3.0+. To add the Snowplow Tracker to your Ruby app or gem, add this line to your Gemfile:
 
 ```ruby
 gem 'snowplow-tracker', '~> 0.8.0'
@@ -42,6 +41,9 @@ The Tracker must be initialized with an Emitter or the subclass AsyncEmitter (or
 
 Initializing a tracker instance:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 require 'snowplow-tracker'
 
@@ -51,7 +53,9 @@ tracker = SnowplowTracker::Tracker.new(emitters: emitter)
 tracker = SnowplowTracker::Tracker.new(emitters: [emitter])
 ```
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  </TabItem>
+
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 require 'snowplow-tracker'
@@ -61,6 +65,10 @@ tracker = SnowplowTracker::Tracker.new(emitter)
 # or
 tracker = SnowplowTracker::Tracker.new([emitter])
 ```
+
+  </TabItem>
+</Tabs>
+
 
 This Tracker will send events via GET to `http://collector.example.com/i`.
 
@@ -72,6 +80,9 @@ The final initialization parameter is a setting for the base64-encoding of any J
 
 Initializing a tracker instance with all possible settings used:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 require 'snowplow-tracker'
 
@@ -79,10 +90,14 @@ SnowplowTracker::Tracker.new(emitters: SnowplowTracker::Emitter.new(endpoint: 'c
                              subject: SnowplowTracker::Subject.new,
                              namespace: 'tracker_no_encode',
                              app_id: 'rails_main',
-                             encode_base64: false)
+                             encode_base64: false
+                             )
 ```
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this-1)
+
+  </TabItem>
+
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 require 'snowplow-tracker'
@@ -91,8 +106,12 @@ SnowplowTracker::Tracker.new(SnowplowTracker::Emitter.new('collector.example.com
                              SnowplowTracker::Subject.new,
                              'tracker_no_encode',
                              'rails_main',
-                             false)
+                             false
+                             )
 ```
+
+  </TabItem>
+</Tabs>
 
 You can create as many Tracker instances as you like within your app; each one is completely sandboxed. For example, you may wish to send certain events to a different collector endpoint (using a different Emitter), or with a different JSON base64-encoding choice. Make sure you set different Tracker namespaces when using multiple instances.
 

--- a/docs/collecting-data/collecting-from-own-applications/ruby-tracker/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/ruby-tracker/tracking-events/index.md
@@ -4,6 +4,11 @@ date: "2021-10-15"
 sidebar_position: 10
 ---
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
 Snowplow has been built to enable you to track a wide range of events that occur when users interact with your websites and apps.
 
 We provide several built-in methods to help you track different kinds of events. The `track_x_event` methods range from single purpose methods, such as `track_page_view`, to the more complex but flexible `track_self_describing_event`, which can be used to track any kind of user behaviour. We strongly recommend using `track_self_describing_event` for your tracking, as it allows you to design custom event types to match your business requirements. This [post on our blog](https://snowplowanalytics.com/blog/2020/01/24/re-thinking-the-structure-of-event-data/), "Re-thinking the structure of event data" might be informative here.
@@ -51,6 +56,9 @@ The `track_self_describing_event` method has one required argument, which must b
 
 Example:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 self_desc_json = SnowplowTracker::SelfDescribingJson.new(
   "iglu:com.example_company/save_game/jsonschema/1-0-2",
@@ -65,7 +73,9 @@ self_desc_json = SnowplowTracker::SelfDescribingJson.new(
 tracker.track_self_describing_event(event_json: self_desc_json)
 ```
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  </TabItem>
+
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 self_desc_json = SnowplowTracker::SelfDescribingJson.new(
@@ -80,6 +90,9 @@ self_desc_json = SnowplowTracker::SelfDescribingJson.new(
 
 tracker.track_self_describing_event(self_desc_json)
 ```
+
+  </TabItem>
+</Tabs>
 
 You can track anything you want using this method, as long as you can describe it in a self-describing JSON schema.
 
@@ -99,6 +112,9 @@ As these fields are fairly arbitrary, we recommend following the advice in this 
 
 Example:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 tracker.track_struct_event(category: 'shop',
                            action: 'add-to-basket',
@@ -106,11 +122,16 @@ tracker.track_struct_event(category: 'shop',
                            value: 2)
 ```
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  </TabItem>
+
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 tracker.track_struct_event('shop', 'add-to-basket', nil, 'pcs', 2)
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Track page views with `track_page_view`
 
@@ -120,17 +141,25 @@ As a server-side language, your Ruby code won't automatically have access to the
 
 Example:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 tracker.track_page_view(page_url: 'www.example.com',
                         page_title: 'example',
                         referrer: 'www.referrer.com')
 ```
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  </TabItem>
+
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 tracker.track_page_view('www.example.com', 'example', 'www.referrer.com')
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Track screen views with `track_screen_view`
 
@@ -140,16 +169,24 @@ This method creates an `unstruct` event, by creating a SelfDescribingJson and ca
 
 Example:
 
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
+
 ```ruby
 tracker.track_screen_view(name: 'HUD > Save Game',
                           id: 'screen23')
 ```
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  </TabItem>
+
+  <TabItem value="old" label="Before v0.7.0">
 
 ```ruby
 tracker.track_screen_view('HUD > Save Game', 'screen23')
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Track eCommerce transactions with `track-ecommerce-transaction`
 
@@ -162,6 +199,9 @@ Broadly, the "transaction" hash contains the information about the order as a wh
 The "item" hash records each item's unique SKU identifier, value, and how many were purchased, as well as any further information which might be useful, such as its human-readable item name.
 
 Example:
+
+<Tabs groupId="version">
+  <TabItem value="current" label="v0.7.0+" default>
 
 ```ruby
 transaction = {
@@ -187,9 +227,13 @@ tracker.track_ecommerce_transaction(transaction: transaction,
                                     items: [item1, item2])
 ```
 
-[Using Ruby tracker <0.7.0? Expand this](#accordion-using-ruby-tracker-andlt070-expand-this)
+  </TabItem>
 
-Note: older versions of the Ruby tracker have a bug in `track_ecommerce_transaction`: hashes with symbols for keys are not accepted. The event will fail silently. You must use only string keys. This was fixed in version 0.7.0.
+  <TabItem value="old" label="Before v0.7.0">
+
+:::note
+Older versions of the Ruby tracker have a bug in `track_ecommerce_transaction`: hashes with symbols for keys are not accepted. The event will fail silently. You must use only string keys. This was fixed in version 0.7.0.
+:::
 
 ```ruby
 transaction = {
@@ -213,5 +257,8 @@ item2 = {
 }
 tracker.track_ecommerce_transaction(transaction, [item1, item2])
 ```
+
+  </TabItem>
+</Tabs>
 
 This will fire three events: one for the transaction as a whole, and one for each item. The `order_id` and `currency` fields in the `transaction` argument will also be attached to each of the item events.


### PR DESCRIPTION
The Ruby tracker docs got slightly broken during the Docusaurus migration. I've replaced the broken accordions with tabs. Also added some missing config details.