### PR TITLE
Update Unity tracker docs for version 0.7.0

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/unity-tracker/emitter/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/unity-tracker/emitter/index.md
@@ -6,10 +6,11 @@ sidebar_position: 50
 
 The Emitter object is responsible for sending and storing all events.
 
-We have two emitters available currently:
+We have three emitters available currently:
 
 - `SyncEmitter` : Slow blocking synchronous operation, useful for testing but should not be used in production.
 - `AsyncEmitter` : Fully asynchronous operation which uses the ThreadPool to perform all of its operations.
+- `WebGlEmitter` : Emitter implementing the async API that is compatible with WebGL.
 
 ### Constructor
 

--- a/docs/collecting-data/collecting-from-own-applications/unity-tracker/initialization/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/unity-tracker/initialization/index.md
@@ -23,10 +23,14 @@ You should now be able to setup the Tracker!
 To instantiate a Tracker in your code (can be global or local to the process being tracked) simply instantiate the Tracker interface with the following:
 
 ```csharp
-// Create Emitter and Tracker
-IEmitter e1 = new AsyncEmitter ("com.collector.acme")
-Tracker t1 = new Tracker(e1, "Namespace", "AppId");
+// Create Emitter – to support WebGL, make sure to use the WebGlEmitter
+IEmitter emitter = Application.platform == RuntimePlatform.WebGLPlayer 
+        ? new WebGlEmitter("com.collector.acme", HttpProtocol.HTTPS, HttpMethod.POST)
+        : new AsyncEmitter("com.collector.acme", HttpProtocol.HTTPS, HttpMethod.POST);
+
+// Create a Tracker instance with the Emitter
+Tracker tracker = new Tracker(emitter, "Namespace", "AppId");
 
 // Start the Tracker
-t1.StartEventTracking();
+tracker.StartEventTracking();
 ```

--- a/docs/collecting-data/collecting-from-own-applications/unity-tracker/session/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/unity-tracker/session/index.md
@@ -6,6 +6,9 @@ sidebar_position: 70
 
 The Session object is responsible for maintaining persistent data around user sessions over the life-time of an application.
 
+Session information is persisted using file storage on most platforms except for tvOS and WebGL.
+On those two platforms, session information is stored in [`PlayerPrefs`](https://docs.unity3d.com/ScriptReference/PlayerPrefs.html).
+
 ### Constructor
 
 | **Argument Name** | **Description** | **Required?** | **Default** |

--- a/docs/collecting-data/collecting-from-own-applications/unity-tracker/setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/unity-tracker/setup/index.md
@@ -8,7 +8,7 @@ sidebar_position: 10
 
 ### Tracker compatibility
 
-The Snowplow Unity Tracker has been built and tested using Unity 2021.3 on Windows, Linux, OSX, iOS and Android. It is built using .NET Standard 2.0 and requires at least Unity 2018.1.
+The Snowplow Unity Tracker has been built and tested using Unity 2021.3 on Windows, Linux, OSX, iOS, Android, tvOS, and WebGL. It is built using .NET Standard 2.0 and requires at least Unity 2018.1.
 
 It is not currently compatible with the WebPlayer.
 

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -18,7 +18,7 @@ export const versions = {
   rubyTracker: '0.8.0',
   rustTracker: '0.2.0',
   scalaTracker: '2.0.0',
-  unityTracker: '0.6.3',
+  unityTracker: '0.7.0',
   webViewTracker: '0.2.0',
 
   // Core pipeline


### PR DESCRIPTION
Updates the tracker version and adds information about the new emitter for WebGL.