### PR TITLE
Browser/JS: crossDomainLinker tips

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
@@ -313,31 +313,7 @@ import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 import CrossDomain from "@site/docs/reusable/javascript-tracker-cross-domain/_index.md"
 ```
 
-<CrossDomain>
-
-```javascript
-crossDomainLinker(function(linkElement) {
-  return linkElement.href.indexOf('javascript:') < 0;
-});
-```
-```javascript
-crossDomainLinker(function(linkElement) {
-  return linkElement.hostname !== "";
-});
-```
-```javascript
-crossDomainLinker(function (linkElement) {
-  return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
-});
-```
-
-```javascript
-trackPageView(); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
-if (/[?&]_sp=/.test(window.location.href)) {
-  history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
-}
-```
-</CrossDomain>
+<CrossDomain lang="browser" />
 
 #### Configuring the maximum payload size in bytes
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
@@ -127,7 +127,7 @@ Most browsers have a Do Not Track option which allows users to express a prefere
 
 #### Opt-out cookie
 
-It is possible to set an opt-out cookie in order not to track anything similarly to Do Not Track through `window.snowplow('setOptOutCookie', 'opt-out');` where ‘opt-out’ is the name of your opt-out cookie. If this cookie is set, cookies won’t be stored and events won’t be fired.
+It is possible to set an opt-out cookie in order not to track anything similarly to Do Not Track through `setOptOutCookie('opt-out');` where ‘opt-out’ is the name of your opt-out cookie. If this cookie is set, cookies won’t be stored and events won’t be fired.
 
 #### Anonymous Tracking
 
@@ -279,7 +279,7 @@ We recommend leaving the `bufferSize` as the default value of 1. This ensure tha
 If you have set `bufferSize` to greater than 1, you can flush the buffer using the `flushBuffer` method:
 
 ```javascript
-snowplow('flushBuffer');
+flushBuffer();
 ```
 
 For instance, if you wish to send several events at once, you might make the API calls to create the events and store them and then and call `flushBuffer` afterwards to ensure they are all sent before the user leaves the page.
@@ -345,8 +345,8 @@ If you want to decorate every link, regardless of its destination:
 Note that the above will decorate “links” which are actually just JavaScript actions (with an `href` of `"javascript:void(0)"`). To exclude these links:
 
 ```javascript
-snowplow('crossDomainLinker', function(linkElement) {
-  return linkElement.href.indexOf('javascript:') < 0;
+crossDomainLinker(function(linkElement) {
+  return linkElement.hostname !== "";
 });
 ```
 
@@ -355,7 +355,7 @@ Note that when the tracker loads, it does not immediately decorate links. Instea
 If further links get added to the page after the tracker has loaded, you can use the tracker’s `crossDomainLinker` method to add listeners again. (Listeners won’t be added to links which already have them.)
 
 ```javascript
-snowplow('crossDomainLinker', function (linkElement) {
+crossDomainLinker(function (linkElement) {
   return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
 });
 ```
@@ -394,7 +394,7 @@ If the optional `discoverRootDomain` field of the configuration object is set 
 Whenever tracker initialized on your domain – it will set domain-specific visitor’s cookies. By default, these cookies will be active for 2 years. You can change this duration using `cookieLifetime` configuration object parameter or `setVisitorCookieTimeout` method.
 
 ```javascript
-snowplow('newTracker', 'cf', '{{COLLECTOR_URL}}', {
+newTracker('cf', '{{COLLECTOR_URL}}', {
   cookieLifetime: 86400 * 31,
 });
 ```
@@ -402,7 +402,7 @@ snowplow('newTracker', 'cf', '{{COLLECTOR_URL}}', {
 or
 
 ```javascript
-snowplow('setVisitorCookieTimeout', 86400 * 30);  // 30 days
+setVisitorCookieTimeout(86400 * 30);  // 30 days
 ```
 
 If `cookieLifetime` is set to `0`, the cookie will expire at the end of the session (when the browser closes). If set to `-1`, the first-party cookies will be disabled.

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
@@ -309,58 +309,35 @@ import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 ```
 
 #### Configuring cross-domain tracking
-
-The JavaScript Tracker can add an additional parameter named “_sp” to the querystring of outbound links. Its value includes the domain user ID for the current page and the time at which the link was clicked. This makes these values visible in the “url” field of events sent by an instance of the JavaScript Tracker on the destination page. The enrichment process will use these values to populate the `refr_domain_userid` and `refr_dvce_tstamp` fields in Redshift for all events fired on the destination page.
-
-You can configure which links get decorated this way using the `crossDomainLinker` field of the configuration object. This field should be a function taking one argument (the link element) and return `true` if the link element should be decorated and false otherwise. For example, this function would only decorate those links whose destination is “[http://acme.de](http://acme.de/)” or whose HTML id is “crossDomainLink”:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
-  }
-}
+```mdx-code-block
+import CrossDomain from "@site/docs/reusable/javascript-tracker-cross-domain/_index.md"
 ```
 
-If you want to decorate every link to the domain github.com:
+<CrossDomain>
 
 ```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return /^https:\/\/github\.com/.test(linkElement.href);
-  }
-}
+crossDomainLinker(function(linkElement) {
+  return linkElement.href.indexOf('javascript:') < 0;
+});
 ```
-
-If you want to decorate every link, regardless of its destination:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return true;
-  }
-}
-```
-
-Note that the above will decorate “links” which are actually just JavaScript actions (with an `href` of `"javascript:void(0)"`). To exclude these links:
-
 ```javascript
 crossDomainLinker(function(linkElement) {
   return linkElement.hostname !== "";
 });
 ```
-
-Note that when the tracker loads, it does not immediately decorate links. Instead it adds event listeners to links which decorate them as soon as a user clicks on them or navigates to them using the keyboard. This ensures that the timestamp added to the querystring is fresh.
-
-If further links get added to the page after the tracker has loaded, you can use the tracker’s `crossDomainLinker` method to add listeners again. (Listeners won’t be added to links which already have them.)
-
 ```javascript
 crossDomainLinker(function (linkElement) {
   return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
 });
 ```
 
-_Warning_: If you enable link decoration, you should also make sure that at least one event is fired on the page. Firing an event causes the tracker to write the domain_userid to a cookie. If the cookie doesn’t exist when the user leaves the page, the tracker will generate a new ID for them when they return rather than keeping the old ID.
+```javascript
+trackPageView(); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
+if (/[?&]_sp=/.test(window.location.href)) {
+  history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
+}
+```
+</CrossDomain>
 
 #### Configuring the maximum payload size in bytes
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
@@ -44,12 +44,11 @@ Documentation for latest release
 
 The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
 
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
+- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
 
 ```mdx-code-block
-import v2Init from "@site/docs/reusable/javascript-tracker-v2-initialization-options/_index.md"
+import V2Init from "@site/docs/reusable/javascript-tracker-v2-initialization-options/_index.md"
 
-<v2Init/>
+<V2Init/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
@@ -360,34 +360,7 @@ import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 import CrossDomain from "@site/docs/reusable/javascript-tracker-cross-domain/_index.md"
 ```
 
-<CrossDomain>
-
-```javascript
-snowplow('crossDomainLinker', function(linkElement) {
-  return linkElement.href.indexOf('javascript:') < 0;
-});
-```
-```javascript
-snowplow('crossDomainLinker', function(linkElement) {
-  return linkElement.hostname !== "";
-});
-```
-```javascript
-snowplow('crossDomainLinker', function (linkElement) {
-  return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
-});
-```
-The URL updating code runs in a [Tracker Callback](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/advanced-usage/tracker-callbacks/index.md) to ensure it does not run before the page view event has a chance to capture the original URL.
-```javascript
-snowplow('trackPageView'); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
-snowplow(function(){
-  if (/[?&]_sp=/.test(window.location.href)) {
-    history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
-  }
-});
-```
-</CrossDomain>
-
+<CrossDomain lang="javascript" />
 
 #### Configuring the maximum payload size in bytes
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/index.md
@@ -356,57 +356,38 @@ import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 
 #### Configuring cross-domain tracking
 
-The JavaScript Tracker can add an additional parameter named “_sp” to the querystring of outbound links. Its value includes the domain user ID for the current page and the time at which the link was clicked. This makes these values visible in the “url” field of events sent by an instance of the JavaScript Tracker on the destination page. The enrichment process will use these values to populate the `refr_domain_userid` and `refr_dvce_tstamp` fields in Redshift for all events fired on the destination page.
-
-You can configure which links get decorated this way using the `crossDomainLinker` field of the configuration object. This field should be a function taking one argument (the link element) and return `true` if the link element should be decorated and false otherwise. For example, this function would only decorate those links whose destination is “[http://acme.de](http://acme.de/)” or whose HTML id is “crossDomainLink”:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
-  }
-}
+```mdx-code-block
+import CrossDomain from "@site/docs/reusable/javascript-tracker-cross-domain/_index.md"
 ```
 
-If you want to decorate every link to the domain github.com:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return /^https:\/\/github\.com/.test(linkElement.href);
-  }
-}
-```
-
-If you want to decorate every link, regardless of its destination:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return true;
-  }
-}
-```
-
-Note that the above will decorate “links” which are actually just JavaScript actions (with an `href` of `"javascript:void(0)"`). To exclude these links:
+<CrossDomain>
 
 ```javascript
 snowplow('crossDomainLinker', function(linkElement) {
   return linkElement.href.indexOf('javascript:') < 0;
 });
 ```
-
-Note that when the tracker loads, it does not immediately decorate links. Instead it adds event listeners to links which decorate them as soon as a user clicks on them or navigates to them using the keyboard. This ensures that the timestamp added to the querystring is fresh.
-
-If further links get added to the page after the tracker has loaded, you can use the tracker’s `crossDomainLinker` method to add listeners again. (Listeners won’t be added to links which already have them.)
-
+```javascript
+snowplow('crossDomainLinker', function(linkElement) {
+  return linkElement.hostname !== "";
+});
+```
 ```javascript
 snowplow('crossDomainLinker', function (linkElement) {
   return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
 });
 ```
+The URL updating code runs in a [Tracker Callback](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/advanced-usage/tracker-callbacks/index.md) to ensure it does not run before the page view event has a chance to capture the original URL.
+```javascript
+snowplow('trackPageView'); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
+snowplow(function(){
+  if (/[?&]_sp=/.test(window.location.href)) {
+    history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
+  }
+});
+```
+</CrossDomain>
 
-_Warning_: If you enable link decoration, you should also make sure that at least one event is fired on the page. Firing an event causes the tracker to write the domain_userid to a cookie. If the cookie doesn’t exist when the user leaves the page, the tracker will generate a new ID for them when they return rather than keeping the old ID.
 
 #### Configuring the maximum payload size in bytes
 

--- a/docs/reusable/javascript-tracker-cross-domain/_index.md
+++ b/docs/reusable/javascript-tracker-cross-domain/_index.md
@@ -156,7 +156,7 @@ You can do this using the [History API](https://developer.mozilla.org/en-US/docs
 <>{ props.lang === "browser" && <>
 
 ```javascript
--trackPageView(); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
+trackPageView(); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
 if (/[?&]_sp=/.test(window.location.href)) {
   history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
 }

--- a/docs/reusable/javascript-tracker-cross-domain/_index.md
+++ b/docs/reusable/javascript-tracker-cross-domain/_index.md
@@ -39,12 +39,46 @@ If you want to decorate every link, regardless of its destination:
 Note that the above will decorate “links” which are actually just JavaScript actions (with an `href` of `"javascript:void(0)"`), or links to email addresses or telephone numbers ([`mailto:`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_email_address) or [`tel:`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_telephone_numbers) schemes).
 To exclude these links, check them explicitly:
 
-<>{ props.children[0] }</>
+<>{ props.lang === "browser" && <>
+
+```javascript
+crossDomainLinker(function(linkElement) {
+  return linkElement.href.indexOf('javascript:') < 0;
+});
+```
+</>
+}</>
+<>{ props.lang === "javascript" && <>
+
+```javascript
+snowplow('crossDomainLinker', function(linkElement) {
+  return linkElement.href.indexOf('javascript:') < 0;
+});
+```
+</>
+}</>
 
 Alternatively, only count links that parse as web URLs by checking the link's [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/hostname).
 This should automatically exclude links that don't lead simply to other web pages.
 
-<>{ props.children[1] }</>
+<>{ props.lang === "browser" && <>
+
+```javascript
+crossDomainLinker(function(linkElement) {
+  return linkElement.hostname !== "";
+});
+```
+</>
+}</>
+<>{ props.lang === "javascript" && <>
+
+```javascript
+snowplow('crossDomainLinker', function(linkElement) {
+  return linkElement.hostname !== "";
+});
+```
+</>
+}</>
 
 :::note Opt-in vs opt-out
 
@@ -83,7 +117,24 @@ This ensures that the timestamp added to the querystring is fresh.
 
 If further links get added to the page after the tracker has loaded, you can use the tracker’s `crossDomainLinker` method to add listeners again. (Listeners won’t be added to links which already have them.)
 
-<>{ props.children[2] }</>
+<>{ props.lang === "browser" && <>
+
+```javascript
+crossDomainLinker(function (linkElement) {
+  return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
+});
+```
+</>
+}</>
+<>{ props.lang === "javascript" && <>
+
+```javascript
+snowplow('crossDomainLinker', function (linkElement) {
+  return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
+});
+```
+</>
+}</>
 
 :::caution Warning
 
@@ -102,9 +153,29 @@ This means after the next page is tracked, if the user copies the URL after the 
 
 You can do this using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState).
 
-<>{ props.children[3] }</>
+<>{ props.lang === "browser" && <>
 
-<>{ props.children[4] }</>
+```javascript
+-trackPageView(); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
+if (/[?&]_sp=/.test(window.location.href)) {
+  history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
+}
+```
+</>
+}</>
+<>{ props.lang === "javascript" && <>
+
+The URL updating code runs in a [Tracker Callback](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/advanced-usage/tracker-callbacks/index.md) to ensure it does not run before the page view event has a chance to capture the original URL.
+```javascript
+snowplow('trackPageView'); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
+snowplow(function(){
+  if (/[?&]_sp=/.test(window.location.href)) {
+    history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
+  }
+});
+```
+</>
+}</>
 
 This approach can work with other parameters (e.g. `utm_source`) but it is not recommended unless you are sure other systems have also already captured the parameter values for their own systems.
 Some systems may consider the URL update a single page application page change, and automatically fire additional page view events with this implementation, we suggest careful testing of this technique to ensure compatibility with your existing vendors.

--- a/docs/reusable/javascript-tracker-cross-domain/_index.md
+++ b/docs/reusable/javascript-tracker-cross-domain/_index.md
@@ -1,0 +1,112 @@
+The JavaScript Tracker can add an additional parameter named “_sp” to the querystring of outbound links.
+This process is called “link decoration”.
+The `_sp` value includes the domain user ID for the current page and the time at which the link was clicked (according to the device's clock).
+This makes these values visible in the “url” field of events sent by an instance of the JavaScript Tracker on the destination page.
+The enrichment process will use these values to populate the `refr_domain_userid` and `refr_dvce_tstamp` fields for all events fired on the destination page where the URL includes the `_sp` parameter.
+
+You can configure which links get decorated this way using the `crossDomainLinker` field of the configuration object.
+The value should be a function taking one argument (the link element) and return `true` if the link element should be decorated and `false` otherwise.
+For example, this function would only decorate those links whose destination is “[http://acme.de](http://acme.de/)” or whose HTML id is “crossDomainLink”:
+
+```javascript
+{
+  crossDomainLinker: function (linkElement) {
+    return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
+  }
+}
+```
+
+If you want to decorate every link to the domain github.com:
+
+```javascript
+{
+  crossDomainLinker: function (linkElement) {
+    return /^https:\/\/github\.com/.test(linkElement.href);
+  }
+}
+```
+
+If you want to decorate every link, regardless of its destination:
+
+```javascript
+{
+  crossDomainLinker: function (linkElement) {
+    return true;
+  }
+}
+```
+
+Note that the above will decorate “links” which are actually just JavaScript actions (with an `href` of `"javascript:void(0)"`), or links to email addresses or telephone numbers ([`mailto:`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_email_address) or [`tel:`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_telephone_numbers) schemes).
+To exclude these links, check them explicitly:
+
+<>{ props.children[0] }</>
+
+Alternatively, only count links that parse as web URLs by checking the link's [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/hostname).
+This should automatically exclude links that don't lead simply to other web pages.
+
+<>{ props.children[1] }</>
+
+:::note Opt-in vs opt-out
+
+Some of the above examples will also decorate any links to the same site the user is currently on.
+For most users we recommend explicitly allowing the list of domains you want to decorate, as well as ensuring that you only decorate links that are on a different domain to the current page.
+
+```javascript
+{
+  crossDomainLinker: function (linkElement) {
+    return linkElement.hostname !== location.hostname;
+  }
+}
+```
+
+If you have a shared configuration deployed across multiple sites, you may want to combine the approaches:
+
+```javascript
+{
+  crossDomainLinker: function (linkElement) {
+    var networkSites = [
+      "mysite.com",
+      "sistersite.com"
+    ];
+    return linkElement.hostname !== location.hostname && networkSites.indexOf(linkElement.hostname) > -1;
+  }
+}
+```
+
+This allows the same list of sites to be shared between each configuration, but link decoration will only occur when links are to different sites within the list.
+
+:::
+
+Note that when the tracker loads, it does not immediately decorate links.
+Instead, it adds event listeners to links which decorate them as soon as a user clicks on them or navigates to them using the keyboard.
+This ensures that the timestamp added to the querystring is fresh.
+
+If further links get added to the page after the tracker has loaded, you can use the tracker’s `crossDomainLinker` method to add listeners again. (Listeners won’t be added to links which already have them.)
+
+<>{ props.children[2] }</>
+
+:::caution Warning
+
+If you enable link decoration, you should also make sure that at least one event is fired on the page.
+Firing an event causes the tracker to write the `domain_userid` to a cookie.
+If the cookie doesn’t exist when the user leaves the page, the tracker will generate a new ID for them when they return, rather than keeping the old ID.
+
+:::
+
+:::tip Reduce Shared Link Decoration URLs
+
+If a user clicks a cross-site link and the URL is decorated with their `domain_userid`, and then they share that URL, other users will also have the parameters when they visit the shared page.
+
+Because enrichment populates dedicated fields with the parameter, and it doesn't get persisted through the user's session (it is essentially only on the landing page), you can choose to hide the parameter after the first event (e.g. Page view) is fired on the destination page without needing additional modeling to stitch the IDs.
+This means after the next page is tracked, if the user copies the URL after the tracking code has fired, it may not include the `_sp` parameter and get copied to other users they share it with.
+
+You can do this using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState).
+
+<>{ props.children[3] }</>
+
+<>{ props.children[4] }</>
+
+This approach can work with other parameters (e.g. `utm_source`) but it is not recommended unless you are sure other systems have also already captured the parameter values for their own systems.
+Some systems may consider the URL update a single page application page change, and automatically fire additional page view events with this implementation, we suggest careful testing of this technique to ensure compatibility with your existing vendors.
+
+:::

--- a/docs/reusable/javascript-tracker-v2-initialization-options/_index.md
+++ b/docs/reusable/javascript-tracker-v2-initialization-options/_index.md
@@ -354,63 +354,43 @@ The POST path that is used to send POST requests to a collector can be change wi
 
 ```mdx-code-block
 import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
+```
 
 <PostPath/>
-```
 
 #### Configuring cross-domain tracking
 
-The JavaScript Tracker can add an additional parameter named “_sp” to the querystring of outbound links. Its value includes the domain user ID for the current page and the time at which the link was clicked. This makes these values visible in the “url” field of events sent by an instance of the JavaScript Tracker on the destination page. The enrichment process will use these values to populate the `refr_domain_userid` and `refr_dvce_tstamp` fields in Redshift for all events fired on the destination page.
-
-You can configure which links get decorated this way using the `crossDomainLinker` field of the configuration object. This field should be a function taking one argument (the link element) and return `true` if the link element should be decorated and false otherwise. For example, this function would only decorate those links whose destination is “[http://acme.de](http://acme.de/)” or whose HTML id is “crossDomainLink”:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
-  }
-}
+```mdx-code-block
+import CrossDomain from "@site/docs/reusable/javascript-tracker-cross-domain/_index.md"
 ```
 
-If you want to decorate every link to the domain github.com:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return /^https:\/\/github\.com/.test(linkElement.href);
-  }
-}
-```
-
-If you want to decorate every link, regardless of its destination:
-
-```javascript
-{
-  crossDomainLinker: function (linkElement) {
-    return true;
-  }
-}
-```
-
-Note that the above will decorate “links” which are actually just JavaScript actions (with an `href` of `"javascript:void(0)"`). To exclude these links:
+<CrossDomain>
 
 ```javascript
 snowplow('crossDomainLinker', function(linkElement) {
   return linkElement.href.indexOf('javascript:') < 0;
 });
 ```
-
-Note that when the tracker loads, it does not immediately decorate links. Instead it adds event listeners to links which decorate them as soon as a user clicks on them or navigates to them using the keyboard. This ensures that the timestamp added to the querystring is fresh.
-
-If further links get added to the page after the tracker has loaded, you can use the tracker’s `crossDomainLinker` method to add listeners again. (Listeners won’t be added to links which already have them.)
-
+```javascript
+snowplow('crossDomainLinker', function(linkElement) {
+  return linkElement.hostname !== "";
+});
+```
 ```javascript
 snowplow('crossDomainLinker', function (linkElement) {
   return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
 });
 ```
-
-_Warning_: If you enable link decoration, you should also make sure that at least one event is fired on the page. Firing an event causes the tracker to write the domain_userid to a cookie. If the cookie doesn’t exist when the user leaves the page, the tracker will generate a new ID for them when they return rather than keeping the old ID.
+The URL updating code runs in a [Tracker Callback](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/advanced-usage/tracker-callbacks/index.md) to ensure it does not run before the page view event has a chance to capture the original URL.
+```javascript
+snowplow('trackPageView'); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
+snowplow(function(){
+  if (/[?&]_sp=/.test(window.location.href)) {
+    history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
+  }
+});
+```
+</CrossDomain>
 
 #### Configuring the maximum payload size in bytes
 

--- a/docs/reusable/javascript-tracker-v2-initialization-options/_index.md
+++ b/docs/reusable/javascript-tracker-v2-initialization-options/_index.md
@@ -364,33 +364,7 @@ import PostPath from "@site/docs/reusable/trackers-post-path-note/_index.md"
 import CrossDomain from "@site/docs/reusable/javascript-tracker-cross-domain/_index.md"
 ```
 
-<CrossDomain>
-
-```javascript
-snowplow('crossDomainLinker', function(linkElement) {
-  return linkElement.href.indexOf('javascript:') < 0;
-});
-```
-```javascript
-snowplow('crossDomainLinker', function(linkElement) {
-  return linkElement.hostname !== "";
-});
-```
-```javascript
-snowplow('crossDomainLinker', function (linkElement) {
-  return (linkElement.href === 'http://acme.de' || linkElement.id === 'crossDomainLink');
-});
-```
-The URL updating code runs in a [Tracker Callback](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/advanced-usage/tracker-callbacks/index.md) to ensure it does not run before the page view event has a chance to capture the original URL.
-```javascript
-snowplow('trackPageView'); // page URL is https://example.com/?example=123&_sp=6de9024e-17b9-4026-bd4d-efec50ae84cb.1680681134458
-snowplow(function(){
-  if (/[?&]_sp=/.test(window.location.href)) {
-    history.replaceState(history.state, "", window.location.replace(/&?_sp=[^&]+/, "")); // page URL is now https://example.com/?example=123
-  }
-});
-```
-</CrossDomain>
+<CrossDomain lang="javascript" />
 
 #### Configuring the maximum payload size in bytes
 


### PR DESCRIPTION
- Extract the `crossDomainLinker` information to a reusable component
- Be more explicit that at a minimum you usually want to not decorate the current domain
- Include a tip on hiding the `_sp` param to prevent data contamination when URLs are shared
- Also fixed some instances where the Browser docs were still using the JS tracker APIs that became clear while making these changes

It was tricky to get the slightly different code snippets to work properly with the reusable component (If there's a better way to do that I'm very open to it).

To see my changes to the JS v2 docs I had to fix the rendering issue there (think newer versions of docusaurus are stricter about the "component names must begin with upper case else it's just html" rule). Also tweaked the closing position of some `mdx-code-block` blocks as it gives better syntax highlighting for mdx components when only the imports are included and the actual components are rendered outside the backticks block.

RE: Ticket BCPF-418