### PR TITLE
JS Trackers: clarify behavior of updatePageActivity method

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracking-events/index.md
@@ -123,7 +123,7 @@ The page view and every subsequent page ping will have both a static_context and
 
 As well as tracking page views, we can monitor whether a user continues to engage with a page over time, and record how he / she digests content on the page over time.
 
-That is accomplished using 'page ping' events. If activity tracking is enabled, the web page is monitored to see if a user is engaging with it. (E.g. is the tab in focus, does the mouse move over the page, does the user scroll etc.) If any of these things occur in a set period of time, a page ping event fires, and records the maximum scroll left / right and up / down in the last ping period. If there is no activity in the page (e.g. because the user is on a different tab in his / her browser), no page ping fires.
+That is accomplished using 'page ping' events. If activity tracking is enabled, the web page is monitored to see if a user is engaging with it. (E.g. is the tab in focus, does the mouse move over the page, does the user scroll, is `updatePageActivity` called, etc.) If any of these things occur in a set period of time, a page ping event fires, and records the maximum scroll left / right and up / down in the last ping period. If there is no activity in the page (e.g. because the user is on a different tab in his / her browser), no page ping fires.
 
 #### `enableActivityTracking`
 
@@ -262,13 +262,15 @@ We are using `visibilitychange` events as `beforeunload` isn't a reliable option
 
 #### `updatePageActivity`
 
-You can also trigger a page ping manually with:
+You can also mark the user as active with:
 
 ```javascript
 import { updatePageActivity } from '@snowplow/browser-tracker';
 
 updatePageActivity();
 ```
+
+On the next interval after this call, a ping will be generated even if the user had no other activity.
 
 This is particularly useful when a user is passively engaging with your content, e.g. watching a video.
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracking-specific-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracking-specific-events/index.md
@@ -144,7 +144,7 @@ The page view and every subsequent page ping will have both a static_context and
 
 As well as tracking page views, we can monitor whether a user continues to engage with a page over time, and record how he / she digests content on the page over time.
 
-That is accomplished using 'page ping' events. If activity tracking is enabled, the web page is monitored to see if a user is engaging with it. (E.g. is the tab in focus, does the mouse move over the page, does the user scroll etc.) If any of these things occur in a set period of time, a page ping event fires, and records the maximum scroll left / right and up / down in the last ping period. If there is no activity in the page (e.g. because the user is on a different tab in his / her browser), no page ping fires.
+That is accomplished using 'page ping' events. If activity tracking is enabled, the web page is monitored to see if a user is engaging with it. (E.g. is the tab in focus, does the mouse move over the page, does the user scroll, is `updatePageActivity` called, etc.) If any of these things occur in a set period of time, a page ping event fires, and records the maximum scroll left / right and up / down in the last ping period. If there is no activity in the page (e.g. because the user is on a different tab in his / her browser), no page ping fires.
 
 #### `enableActivityTracking`
 
@@ -231,11 +231,13 @@ We are using `visibilitychange` events as `beforeunload` isn't a reliable option
 
 #### `updatePageActivity`
 
-You can also trigger a page ping manually with:
+You can also mark the user as active with:
 
 ```javascript
 snowplow('updatePageActivity');
 ```
+
+On the next interval after this call, a ping will be generated even if the user had no other activity.
 
 This is particularly useful when a user is passively engaging with your content, e.g. watching a video.
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracking-events/index.md
@@ -117,7 +117,7 @@ The page view and every subsequent page ping will have both a static_context and
 
 As well as tracking page views, we can monitor whether a user continues to engage with a page over time, and record how he / she digests content on the page over time.
 
-That is accomplished using 'page ping' events. If activity tracking is enabled, the web page is monitored to see if a user is engaging with it. (E.g. is the tab in focus, does the mouse move over the page, does the user scroll etc.) If any of these things occur in a set period of time, a page ping event fires, and records the maximum scroll left / right and up / down in the last ping period. If there is no activity in the page (e.g. because the user is on a different tab in his / her browser), no page ping fires.
+That is accomplished using 'page ping' events. If activity tracking is enabled, the web page is monitored to see if a user is engaging with it. (E.g. is the tab in focus, does the mouse move over the page, does the user scroll, is `updatePageActivity` called, etc.) If any of these things occur in a set period of time, a page ping event fires, and records the maximum scroll left / right and up / down in the last ping period. If there is no activity in the page (e.g. because the user is on a different tab in his / her browser), no page ping fires.
 
 #### `enableActivityTracking`
 
@@ -246,11 +246,13 @@ We are using `visibilitychange` events as `beforeunload` isn't a reliable option
 
 #### `updatePageActivity`
 
-You can also trigger a page ping manually with:
+You can also mark the user as active with:
 
 ```javascript
 snowplow('updatePageActivity');
 ```
+
+On the next interval after this call, a ping will be generated even if the user had no other activity.
 
 This is particularly useful when a user is passively engaging with your content, e.g. watching a video.
 


### PR DESCRIPTION
The original language implies that calling `updatePageActivity` will explicitly fire a `page_ping` event, however it just sets the flag so that on the next ping interval a ping _will_ be fired.

These are distinct behaviours as you are free to call updatePageActivity as much as you like without flooding your pipeline with an event each time.