### PR TITLE
Deprecate Spark recovery, update Flink docs

### DIFF
--- a/docs/managing-data-quality/snowplow-event-recovery/running/flink/index.md
+++ b/docs/managing-data-quality/snowplow-event-recovery/running/flink/index.md
@@ -16,15 +16,45 @@ sbt flink/assembly
 
 #### Running
 
-Using flink CLI:
+Event recovery jobs are usually ran using our [dataflow-runner](https://github.com/snowplow/dataflow-runner) application. A configuration template for running is [available in the repository](https://github.com/snowplow-incubator/snowplow-event-recovery/blob/master/.dataflow-runner).
+
+To run a transient EMR cluster and execute the job using the templates, download [Flink dataflow-runner templates](https://github.com/snowplow-incubator/snowplow-event-recovery/blob/master/.dataflow-runner) from the repository and run:
 
 ```bash
-flink run \
-  snowplow-event-recovery-flink-0.2.0.jar \
-  --input s3://bad-rows-location/** \
-  --output recovered-kinesis-topic \  
-  --failedOutput s3://unrecovered-collector-payloads-location/ \
-  --unrecoverableOutput s3://unrecoverable-collector-payloads-location/ \
-  --config $JOB_CONFIG \
-  --resolver $RESOLVER_CONFIG
-```
+dataflow-runner run-transient \
+  --emr-playbook flink-playbook.json.tmpl \
+  --emr-config flink-cluster.json.tmpl \
+  --vars bucket,$BUCKET_INPUT,region,$AWS_REGION,subnet,$AWS_SUBNET,role,$AWS_IAM_ROLE,keypair,$AWS_KEYPAIR,client,$JOB_OWNER,version,$RECOVERY_VERSION,config,$RECOVERY_CONFIG,resolver,$IGLU_RESOLVER,output,$KINESIS_OUTPUT,inputdir,$BUCKET_INPUT_DIRECTORY,interval,$INTERVAL
+  ```
+Where:
+- `BUCKET_INPUT` - S3 bucket containing bad events to be recovered (eg. geoffs-bad-events)
+- `BUCKET_INPUT_DIRECTORY` - directory in the `BUCKET_INPUT` to use as the source for bad events
+- `AWS_REGION` - region in which the job is being ran (eg. eu-central-1)
+- `AWS_SUBNET` - network subnet to run the job in (eg. subnet-435010347a21886ab)
+- `AWS_IAM_ROLE` - AWS IAM role to assume while running the job (eg. geoffs-recovery-role)
+- `AWS_KEYPAIR` - AWS EC2 key pair to use for the instances (eg. geoffs-keypair)
+- `JOB_OWNER` - tag to use to mark the owner of the job (eg. goeff)
+- `RECOVERY_VERSION` - application version (eg. 0.6.0)
+- `RECOVERY_CONFIG` - recovery job config as described in [Concepts](../../0-2-concepts/index.md)
+- `IGLU_RESOLVER` - iglu resolver configuration as described in  [Concepts](../../0-2-concepts/index.md)
+- `KINESIS_OUTPUT` - Kinesis stream to output recovered events to
+- `INTERVAL` - job checkpointing interval (we recommend starting with 10 minutes and tuning to your job's characteristics)
+
+
+The job uses [checkpointing](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/datastream/fault-tolerance/checkpointing/) to allow for job restarts. Kinesis connector which is a part of the checkpointing mechanism [guarantees](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/connectors/datastream/kinesis/#kinesis-sinks-and-fault-tolerance) at-least-once delivery semantics and provides backpressure to the job.
+
+#### Monitoring
+
+EMR Flink Job emits a wide range of metrics through Cloudwatch Agent which is installed during cluster bootstrap using a provided script (see project repo's dataflow-runner directory). Custom metrics include:
+- number of unrecoverable events in the run: `taskmanager_container_XXXX_XXX__Process_0_events_unrecoverable`
+- number of failed recovery attempts: `taskmanager_container_XXXX_XXX__Process_0_events_failed`
+- number of recovered events: `taskmanager_container_XXXX_XXX__Process_0_events_recovered`
+- total number of events submitted for processing: `taskmanager_container_XXXX_XXX__Process_0_numRecordsIn`
+
+The metrics are delivered to `snowplow/event-recovery` Cloudwatch namespace.
+
+Given a one-second aggregation in Cloudwatch the diagram should show an always increasing metrics that should balance themselves up to total sum.
+
+:::note
+Flink's `numRecordsOut` metric for sinks does not reflect an actual number of records saved in the sink.
+:::

--- a/docs/managing-data-quality/snowplow-event-recovery/running/index.md
+++ b/docs/managing-data-quality/snowplow-event-recovery/running/index.md
@@ -22,7 +22,7 @@ The configuration consists of
   "data": {
     "iglu:com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/1-0-*": [
       {
-        "name": "pass through",
+        "name": "passthrough",
         "conditions": [],
         "steps": []
       }

--- a/docs/managing-data-quality/snowplow-event-recovery/running/spark/index.md
+++ b/docs/managing-data-quality/snowplow-event-recovery/running/spark/index.md
@@ -4,6 +4,10 @@ date: "2020-04-14"
 sidebar_position: 20
 ---
 
+:::danger
+Spark module is now deprecated. Kinesis integration is not as reliable as we'd like. We suggest migrating to [Flink module](../flink/index.md).
+:::
+
 The Spark job reads bad rows from an S3 location and stores the recovered payloads in Kinesis, unrecovered and unrecoverable in other S3 buckets.
 
 #### Building
@@ -16,201 +20,26 @@ sbt spark/assembly
 
 #### Running
 
-Using the JAR directly (which is hosted at `s3://snowplow-hosted-assets/3-enrich/snowplow-event-recovery/`):
+Event recovery jobs are usually ran using our [dataflow-runner](https://github.com/snowplow/dataflow-runner) application. A configuration templates for running is [available in the repository](https://github.com/snowplow-incubator/snowplow-event-recovery/blob/master/.dataflow-runner).
+
+To run a transient EMR cluster and execute the job using the templates, download [Spark dataflow-runner templates](https://github.com/snowplow-incubator/snowplow-event-recovery/blob/master/.dataflow-runner) from the repository and run:
 
 ```bash
-spark-submit \
-  --class com.snowplowanalytcs.snowplow.event.recovery.Main \
-  --master master-url \
-  --deploy-mode deploy-mode \
-  snowplow-event-recovery-spark-0.1.1.jar
-  --input s3://bad-rows-location/
-  --region eu-central-1
-  --output collector-payloads
-  --failedOutput s3://unrecovered-collector-payloads-location/
-  --unrecoverableOutput s3://unrecoverable-collector-payloads-location/
-  --config base64-encoded-configuration
-```
+dataflow-runner run-transient \
+  --emr-playbook spark-playbook.json.tmpl \
+  --emr-config spark-cluster.json.tmpl \
+  --vars bucket,$BUCKET_INPUT,region,$AWS_REGION,subnet,$AWS_SUBNET,role,$AWS_IAM_ROLE,keypair,$AWS_KEYPAIR,client,$JOB_OWNER,version,$RECOVERY_VERSION,config,$RECOVERY_CONFIG,resolver,$IGLU_RESOLVER,output,$KINESIS_OUTPUT,inputdir,$BUCKET_INPUT_DIRECTORY
+  ```
 
-Or through an EMR step:
-
-```bash
-aws emr add-steps --cluster-id j-XXXXXXXX --steps \
-  Name=snowplow-event-recovery,\
-  Type=CUSTOM_JAR,\
-  Jar=s3://snowplow-hosted-assets/3-enrich/snowplow-event-recovery/snowplow-event-recovery-spark-0.2.0.jar,\
-  MainClass=com.snowplowanalytics.snowplow.event.recovery.Main,\
-  Args=[--input,s3://bad-rows-location/,--region,eu-central-1,--output,collector-payloads,--failedOutput,s3://unrecovered-collector-payloads-location/,--unrecoverableOutput,s3://unrecoverable-collector-payloads-location/,--config,base64-encoded-configuration],\
-  ActionOnFailure=CONTINUE
-```
-
-Or using Dataflow Runner, with `emr-config.json`:
-
-```json
-{
-  "schema": "iglu:com.snowplowanalytics.dataflowrunner/ClusterConfig/avro/1-1-0",
-  "data": {
-    "name": "emr-recovery-cluster",
-    "logUri": "s3://logs/",
-    "region": "eu-central-1",
-    "credentials": {
-      "accessKeyId": "{{secret "aws-access-key-id"}}",
-      "secretAccessKey": "{{secret "aws-secret-access-key"}}"
-    },
-    "roles": {
-      "jobflow": "EMR_EC2_DefaultRole",
-      "service": "{{ prefix }}-event-recovery"
-    },
-    "ec2": {
-      "amiVersion": "5.17.0",
-      "keyName": "some-key-name",
-      "location": {
-        "vpc": {
-          "subnetId": "subnet-sample"
-        }
-      },
-      "instances": {
-        "master": {
-          "type": "m1.medium",
-          "ebsConfiguration": {
-            "ebsOptimized": true,
-            "ebsBlockDeviceConfigs": [
-              {
-                "volumesPerInstance": 12,
-                "volumeSpecification": {
-                  "iops": 8,
-                  "sizeInGB": 10,
-                  "volumeType": "gp2"
-                }
-              }
-            ]
-          }
-        },
-        "core": {
-          "type": "m1.medium",
-          "count": 1
-        },
-        "task": {
-          "type": "m1.medium",
-          "count": 0,
-          "bid": "0.015"
-        }
-      }
-    },
-    "tags": [
-      {
-        "key": "client",
-        "value": "com.snplow.eng"
-      },
-      {
-        "key": "job",
-        "value": "recovery"
-      }
-    ],
-    "applications": [ "Hadoop", "Spark" ]
-  }
-}
-```
-
-And `emr-playbook.json`:
-
-```json
-{
-  "schema": "iglu:com.snowplowanalytics.dataflowrunner/PlaybookConfig/avro/1-0-1",
-  "data": {
-    "region": "eu-west-1",
-    "credentials": {
-      "accessKeyId": "{{secret "aws-access-key-id"}}",
-      "secretAccessKey": "{{secret "aws-secret-access-key"}}"
-    },
-    "steps": [
-      {
-        "type": "CUSTOM_JAR",
-        "name": "Staging of bad rows",
-        "actionOnFailure": "CANCEL_AND_WAIT",
-        "jar": "/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar",
-        "arguments": [
-          "--src",
-          "s3n://${BUCKET_ID}/recovery/enriched/bad/run=2019-01-12-15-04-23/",
-          "--dest",
-          "s3n://${BUCKET_ID}/stage_01_19/"
-        ]
-      },
-      {
-        "type": "CUSTOM_JAR",
-        "name": "Move to HDFS",
-        "actionOnFailure": "CANCEL_AND_WAIT",
-        "jar": "/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar",
-        "arguments": [
-          "--src",
-          "s3n://${BUCKET_ID}/stage_01_19/",
-          "--dest",
-          "hdfs:///local/to-recover/",
-          "--outputCodec",
-          "none"
-        ]
-      },
-      {
-        "type": "CUSTOM_JAR",
-        "name": "snowplow-event-recovery",
-        "actionOnFailure": "CANCEL_AND_WAIT",
-        "jar": "command-runner.jar",
-        "arguments": [
-          "spark-submit",
-          "--class",
-          "com.snowplowanalytics.snowplow.event.recovery.Main",
-          "--master",
-          "yarn",
-          "--deploy-mode",
-          "cluster",
-          "s3://bad-rows/snowplow-event-recovery-spark-0.2.0.jar",
-          "--input",
-          "hdfs:///local/to-recover/",
-          "--output",
-          "good-events",
-          "--region",
-          "eu-central-1",
-          "--failedOutput",
-          "s3://bad-rows/left",
-          "--unrecoverableOutput",
-          "s3://bad-rows/left/unrecoverable",
-          "--resolver",
-          "eyJzY2hlbWEiOiJpZ2x1OmNvbS5zbm93cGxvd2FuYWx5dGljcy5pZ2x1L3Jlc29sdmVyLWNvbmZpZy9qc29uc2NoZW1hLzEtMC0xIiwiZGF0YSI6eyJjYWNoZVNpemUiOjAsInJlcG9zaXRvcmllcyI6W3sibmFtZSI6ICJJZ2x1IENlbnRyYWwiLCJwcmlvcml0eSI6IDAsInZlbmRvclByZWZpeGVzIjogWyAiY29tLnNub3dwbG93YW5hbHl0aWNzIiBdLCJjb25uZWN0aW9uIjogeyJodHRwIjp7InVyaSI6Imh0dHA6Ly9pZ2x1Y2VudHJhbC5jb20ifX19LHsibmFtZSI6IlByaXYiLCJwcmlvcml0eSI6MCwidmVuZG9yUHJlZml4ZXMiOlsiY29tLnNub3dwbG93YW5hbHl0aWNzIl0sImNvbm5lY3Rpb24iOnsiaHR0cCI6eyJ1cmkiOiJodHRwczovL3Jhdy5naXRodWJ1c2VyY29udGVudC5jb20vcGVlbC9zY2hlbWFzL21hc3RlciJ9fX1dfX0=",
-          "--config",
-          "eyJzY2hlbWEiOiJpZ2x1OmNvbS5zbm93cGxvd2FuYWx5dGljcy5zbm93cGxvdy9yZWNvdmVyaWVzL2pzb25zY2hlbWEvMi0wLTEiLCJkYXRhIjp7ImlnbHU6Y29tLnNub3dwbG93YW5hbHl0aWNzLnNub3dwbG93LmJhZHJvd3MvZW5yaWNobWVudF9mYWlsdXJlcy9qc29uc2NoZW1hLzEtMC0qIjpbeyJuYW1lIjoibWFpbi1mbG93IiwiY29uZGl0aW9ucyI6W10sInN0ZXBzIjpbXX1dLCJpZ2x1OmNvbS5zbm93cGxvd2FuYWx5dGljcy5zbm93cGxvdy5iYWRyb3dzL2FkYXB0ZXJfZmFpbHVyZXMvanNvbnNjaGVtYS8xLTAtKiI6W3sibmFtZSI6Im1haW4tZmxvdyIsImNvbmRpdGlvbnMiOltdLCJzdGVwcyI6W119XSwiaWdsdTpjb20uc25vd3Bsb3dhbmFseXRpY3Muc25vd3Bsb3cuYmFkcm93cy9zY2hlbWFfdmlvbGF0aW9ucy9qc29uc2NoZW1hLzEtMC0qIjpbeyJuYW1lIjoibWFpbi1mbG93IiwiY29uZGl0aW9ucyI6W10sInN0ZXBzIjpbXX1dLCJpZ2x1OmNvbS5zbm93cGxvd2FuYWx5dGljcy5zbm93cGxvdy5iYWRyb3dzL3RyYWNrZXJfcHJvdG9jb2xfdmlvbGF0aW9ucy9qc29uc2NoZW1hLzEtMC0qIjpbeyJuYW1lIjoibWFpbi1mbG93IiwiY29uZGl0aW9ucyI6W10sInN0ZXBzIjpbXX1dfX0="
-          
-        ]
-      }
-
-      {
-        "type": "CUSTOM_JAR",
-        "name": "Back to S3",
-        "actionOnFailure": "CANCEL_AND_WAIT",
-        "jar": "/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar",
-        "arguments": [
-          "--src",
-          "hdfs:///local/recovered/",
-          "--dest",
-          "s3n://${BUCKET_ID}/raw/"
-        ]
-      }
-    ],
-    "tags": [
-      {
-        "key": "client",
-        "value": "com.snowplowanalytics"
-      },
-      {
-        "key": "job",
-        "value": "recovery"
-      }
-    ]
-  }
-}
-```
-
-Run:
-
-```bash
-dataflow-runner run-transient --emr-config ./emr-config.json --emr-playbook ./emr-playbook.json
-```
+Where:
+- `BUCKET_INPUT` - S3 bucket containing bad events to be recovered (eg. geoffs-bad-events)
+- `BUCKET_INPUT_DIRECTORY` - directory in the `BUCKET_INPUT` to use as the source for bad events
+- `AWS_REGION` - region in which the job is being ran (eg. eu-central-1)
+- `AWS_SUBNET` - network subnet to run the job in (eg. subnet-435010347a21886ab)
+- `AWS_IAM_ROLE` - AWS IAM role to assume while running the job (eg. geoffs-recovery-role)
+- `AWS_KEYPAIR` - AWS EC2 key pair to use for the instances (eg. geoffs-keypair)
+- `JOB_OWNER` - tag to use to mark the owner of the job (eg. goeff)
+- `RECOVERY_VERSION` - application version (eg. 0.6.0)
+- `RECOVERY_CONFIG` - recovery job config as described in [Concepts](../../0-2-concepts/index.md)
+- `IGLU_RESOLVER` - iglu resolver configuration as described in  [Concepts](../../0-2-concepts/index.md)
+- `KINESIS_OUTPUT` - Kinesis stream to output recovered events to


### PR DESCRIPTION
This change makes a minor updates to reflect the current way of running recovery. We deprecate Spark and reintroduce Flink job.