### PR TITLE
JS Trackers: More DocCardLists

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/advanced-usage/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/advanced-usage/index.md
@@ -5,3 +5,9 @@ sidebar_position: 4000
 ---
 
 This section covers the more advanced elements of the JavaScript Tracker.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+```
+
+<DocCardList/>

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/index.md
@@ -6,8 +6,11 @@ sidebar_position: 200
 
 ```mdx-code-block
 import Block2895 from "@site/docs/reusable/untitled-reusable-block-35/_index.md"
-
-<Block2895/>
+import DocCardList from '@theme/DocCardList';
 ```
 
+<Block2895/>
+
 The Browser Tracker is available via npm as `@snowplow/browser-tracker` and the associated plugins as `@snowplow/browser-plugin-*`.
+
+<DocCardList/>

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/index.md
@@ -6,6 +6,9 @@ sidebar_position: 1000
 
 ```mdx-code-block
 import Block5966 from "@site/docs/reusable/javascript-tracker-release-badge-v3/_index.md"
+import DocCardList from '@theme/DocCardList';
+```
 
 <Block5966/>
-```
+
+<DocCardList/>

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/callbacks/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/callbacks/index.md
@@ -4,13 +4,11 @@ date: "2020-02-26"
 sidebar_position: 0
 ---
 
-Documentation for latest release
+```mdx-code-block
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 If you call `snowplow` with a function as the argument, the function will be executed when sp.js loads:
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/getting-the-most-out-of-performance-timing/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/getting-the-most-out-of-performance-timing/index.md
@@ -4,13 +4,11 @@ date: "2020-02-26"
 sidebar_position: 30
 ---
 
-Documentation for latest release
+```mdx-code-block
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 The `domComplete`, `loadEventStart`, and `loadEventEnd` metrics in the NavigationTiming API are set to 0 until after every script on the page has finished executing, including sp.js. This means that the corresponding fields in the PerformanceTiming reported by the tracker will be 0. To get around this limitation, you can wrap all Snowplow code in a `setTimeout` call:
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/index.md
@@ -6,8 +6,11 @@ sidebar_position: 60
 
 ```mdx-code-block
 import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+import DocCardList from '@theme/DocCardList';
 ```
 
 <DeprecatedV2/>
 
 This section covers the more advanced elements of the JavaScript Tracker.
+
+<DocCardList/>

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/index.md
@@ -4,12 +4,10 @@ date: "2020-02-21"
 sidebar_position: 60
 ---
 
-Documentation for latest release
+```mdx-code-block
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 This section covers the more advanced elements of the JavaScript Tracker.

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/optional-timestamp-argument/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/optional-timestamp-argument/index.md
@@ -4,13 +4,11 @@ date: "2021-03-24"
 sidebar_position: -10
 ---
 
-Documentation for latest release
+```mdx-code-block
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 Since 2.7.0 each `track...()` method supports an optional timestamp as its final argument; this allows you to manually override the timestamp attached to this event. The timestamp should be in milliseconds since the Unix epoch.
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/index.md
@@ -7,6 +7,7 @@ sidebar_position: 1100
 ```mdx-code-block
 import Block2895 from "@site/docs/reusable/untitled-reusable-block-35/_index.md"
 import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+import DocCardList from '@theme/DocCardList';
 ```
 
 <Block2895/>
@@ -14,3 +15,5 @@ import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/
 <DeprecatedV2/>
 
 The JavaScript Tracker supports both synchronous and asynchronous tags. We recommend the asynchronous tags in nearly all instances, as these do not slow down page load times.
+
+<DocCardList/>

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/index.md
@@ -6,16 +6,11 @@ sidebar_position: 1100
 
 ```mdx-code-block
 import Block2895 from "@site/docs/reusable/untitled-reusable-block-35/_index.md"
-
-<Block2895/>
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
 ```
 
-Documentation for latest release
+<Block2895/>
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 The JavaScript Tracker supports both synchronous and asynchronous tags. We recommend the asynchronous tags in nearly all instances, as these do not slow down page load times.

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/index.md
@@ -4,10 +4,9 @@ date: "2020-02-21"
 sidebar_position: 30
 ---
 
-Documentation for latest release
+```mdx-code-block
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
+<DeprecatedV2/>
 
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/index.md
@@ -6,7 +6,9 @@ sidebar_position: 30
 
 ```mdx-code-block
 import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+import DocCardList from '@theme/DocCardList';
 ```
 
 <DeprecatedV2/>
 
+<DocCardList/>

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
@@ -36,19 +36,12 @@ _Click [here](https://github.com/snowplow/snowplow/wiki/1-General-parameters-fo
 
 ```mdx-code-block
 import Block3067 from "@site/docs/reusable/untitled-reusable-block-41/_index.md"
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+import V2Init from "@site/docs/reusable/javascript-tracker-v2-initialization-options/_index.md"
+```
 
 <Block3067/>
-```
 
-Documentation for latest release
-
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
-
-```mdx-code-block
-import V2Init from "@site/docs/reusable/javascript-tracker-v2-initialization-options/_index.md"
+<DeprecatedV2/>
 
 <V2Init/>
-```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/loading/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/loading/index.md
@@ -4,18 +4,13 @@ date: "2020-03-03"
 sidebar_position: 0
 ---
 
-Documentation for latest release
-
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
-
 ```mdx-code-block
 import Block1508 from "@site/docs/reusable/untitled-reusable-block-25/_index.md"
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
+
+<DeprecatedV2/>
 
 <Block1508/>
-```
 
 Once the tracker is loaded via the tag, you can move on to [initializing the tracker](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md).

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/managing-multiple-trackers/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/managing-multiple-trackers/index.md
@@ -4,13 +4,11 @@ date: "2020-03-03"
 sidebar_position: 40
 ---
 
-Documentation for latest release
+```mdx-code-block
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 You have more than one tracker instance running on the same page at once. This may be useful if you want to log events to different collectors. By default, any Snowplow method you call will be executed by every tracker you have created so far. You can override this behavior and specify which trackers will execute a Snowplow method. To do this, change the method name by adding a colon followed by a list of tracker names separated by semicolons.
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/other-parameters-2/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracker-setup/other-parameters-2/index.md
@@ -4,13 +4,11 @@ date: "2020-03-03"
 sidebar_position: 20
 ---
 
-Documentation for latest release
+```mdx-code-block
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
+```
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 #### Toggling Anonymous Tracking (2.15.0+)
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracking-specific-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/tracking-specific-events/index.md
@@ -36,17 +36,13 @@ _Click [here](https://github.com/snowplow/snowplow/wiki/2-Specific-event-tracki
 
 ```mdx-code-block
 import Block3067 from "@site/docs/reusable/untitled-reusable-block-41/_index.md"
+import DeprecatedV2 from "@site/docs/reusable/javascript-tracker-v2-deprecation/_index.md"
 
-<Block3067/>
 ```
 
-Documentation for latest release
+<Block3067/>
 
-The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
-
-\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
-
-\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+<DeprecatedV2/>
 
 Snowplow has been built to enable users to track a wide range of events that occur when consumers interact with their websites and webapps.
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/google-tag-manager.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/google-tag-manager.md
@@ -2,7 +2,7 @@
 
 You can use the HTTP target to send events to Google Tag Manager Server Side, where the [Snowplow Client tag](/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/index.md) is installed.
 
-To do this, you will need to include a [transformation](/docs/destinations/forwarding-events/snowbridge/concepts/transformations/index.md) that converts your events to JSON — [`spEnrichedToJson`](/docs/destinations/forwarding-events/snowbridge/configuration/transformations/snowplow-builtin/spEnrichedToJson.md).
+To do this, you will need to include a [transformation](/docs/destinations/forwarding-events/snowbridge/concepts/transformations/index.md) that converts your events to JSON — [`spEnrichedToJson`](/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md).
 
 Here’s an example configuration. Replace `<your-gtm-host>` with the hostname of your Google Tag Manager instance, and — optionally — `<preview-token>` with your preview mode token.
 

--- a/docs/reusable/javascript-tracker-v2-deprecation/_index.md
+++ b/docs/reusable/javascript-tracker-v2-deprecation/_index.md
@@ -1,0 +1,9 @@
+:::info Documentation for latest release
+
+The documentation listed here is for Version 2 of the JavaScript Tracker. Version 3 is now available and upgrading is recommended.
+
+\- [Documentation for Version 3](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md)
+
+\- [v2 to v3 Migration Guide](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/v2-to-v3-migration-guide/index.md)
+
+:::


### PR DESCRIPTION
Per the repo analytics dashboard's "Collecting Data" feedback:

> [Where’s the v2 docs?](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/)

> [API docs](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/)

I'm assuming this is because those pages are basically stubs and it's not obvious you need to check the navigation on the left to see the content. The existing DocCardLists component adds tiles and is a good fit for these otherwise pretty empty pages so I've added it there.

This PR:
- adds cards to the pages in question linking to their categories' pages, which include links to the generated API docs
- adds cards to other "stub" pages in those sections where relevant
- move the tracker v3 announcement present on most tracker v2 pages to a reusable block, and isolated it in an admonition so it's more clearly not a part of the actual v2 doc content and is easier to update when v4 drops
- fix a random path issue that brakes the build on my local for some reason?

Also while making these changes I notice that the v2 tracker is still marked ["Actively Maintained"](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/), @igneel64 should we consider downgrading this to just "Maintained" per [the classification](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/tracker-maintenance-classification/) ?