### PR TITLE
iOS and Android trackers version 5.2.0

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/plugins/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/plugins/index.md
@@ -115,7 +115,7 @@ plugin.entities(
 The `filter` callback enables you to add custom logic that decides whether a given event should be tracked or not.
 This can for example enable you to intercept events automatically tracked by the tracker and skip some of them.
 The callback returns true in case the event should be tracked and false otherwise.
-It also accepts the optional `schemas` array as the `entities` callback to only be applied to events with those schemas.
+It also accepts the same optional `schemas` array as the `entities` callback to only be applied to events with those schemas.
 
 The following code will apply to all screen view events and only accept ones with the name "Home Screen", other screen view events will be discarded:
 

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/plugins/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/plugins/index.md
@@ -161,7 +161,7 @@ plugin.filter(
 ### Inspecting events after they are tracked
 
 To inspect events after they are tracked, you can make use of the `afterTrack` callback.
-It also accepts the optional `schemas` array as the `entities` and `filter` callbacks to filter events.
+It also accepts the same optional `schemas` array as the `entities` and `filter` callbacks to filter events.
 
 <Tabs groupId="platform" queryString>
   <TabItem value="ios" label="iOS" default>

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/remote-configuration/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/remote-configuration/index.md
@@ -49,7 +49,8 @@ Snowplow.setup(
   remoteConfiguration: remoteConfig,
   defaultConfiguration: defaultConfig,
   defaultConfigurationVersion: 1,
-  onSuccess: successCallback)
+  onSuccess: successCallback
+)
 ```
 
   </TabItem>
@@ -111,6 +112,7 @@ On app startup, the Snowplow tracker initializer will attempt to download the re
 Meanwhile, it will initialize the tracker instance (or multiple tracker instances) based on the last cached configuration.
 The cached configuration is the last configuration downloaded remotely.
 If it's not available, the tracker initializer will spin up the default configuration passed as a parameter.
+
 Every time the initializer successfully initializes the tracker instances it calls a callback passing the list of activated namespaces and the state of the configuration which represents the source where the configuration was retrieved from (using default values, cache, or fetched from the remote endpoint).
 The callback can be used for last minute settings at runtime once the tracker has been instanced.
 

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/remote-configuration/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/remote-configuration/index.md
@@ -45,7 +45,11 @@ let successCallback: ([String]?) -> Void = { namespaces, state in
 }
 
 // Set up tracker with remote configuration
-Snowplow.setup(remoteConfiguration: remoteConfig, defaultConfiguration: defaultConfig, onSuccess: successCallback)
+Snowplow.setup(
+  remoteConfiguration: remoteConfig,
+  defaultConfiguration: defaultConfig,
+  defaultConfigurationVersion: 1,
+  onSuccess: successCallback)
 ```
 
   </TabItem>
@@ -63,7 +67,10 @@ val defaultConfig: List<ConfigurationBundle> =
 
 // Set up tracker with remote configuration
 Snowplow.setup(
-    applicationContext, remoteConfig, defaultConfig
+  context = applicationContext,
+  remoteConfiguration = remoteConfig,
+  defaultBundles = defaultConfig,
+  defaultBundleVersion = 1
 ) { 
   // This optional callback can be used for last minute, post-configuration, updates once the tracker instance is enabled and configured.
   configurationPair: Pair<List<String>, ConfigurationState?>? ->
@@ -86,7 +93,11 @@ NetworkConfiguration defaultNetworkConfig = new NetworkConfiguration("https://sn
 List<ConfigurationBundle> defaultConfig = Lists.listOf(new ConfigurationBundle("defaultNamespace", defaultNetworkConfig));
 
 // Set up tracker with remote configuration
-Snowplow.setup(getApplicationContext(), remoteConfig, defaultConfig, configurationPair -> {
+Snowplow.setup(getApplicationContext(),
+  remoteConfig,
+  defaultConfig,
+  1, // version of the default configuration
+  configurationPair -> {
   // This optional callback can be used for last minute, post-configuration, updates once the tracker instance is enabled and configured.
   List<String> namespaces = configurationPair.first;
   ConfigurationState configurationState = configurationPair.second; // either cached, default or fetched from the remote endpoint
@@ -96,11 +107,30 @@ Snowplow.setup(getApplicationContext(), remoteConfig, defaultConfig, configurati
   </TabItem>
 </Tabs>
 
-On app startup, the Snowplow tracker initializer will attempt to download the remote configuration file. Meanwhile, it will initialize the tracker instance (or multiple tracker instances) based on the last cached configuration. The cached configuration is the last configuration downloaded remotely. If it's not available, the tracker initializer will spin up the default configuration passed as a parameter. Every time the initializer successfully initializes the tracker instances it calls a callback passing the list of activated namespaces and the state of the configuration which represents the source where the configuration was retrieved from (using default values, cache, or fetched from the remote endpoint). The callback can be used for last minute settings at runtime once the tracker has been instanced.
+On app startup, the Snowplow tracker initializer will attempt to download the remote configuration file.
+Meanwhile, it will initialize the tracker instance (or multiple tracker instances) based on the last cached configuration.
+The cached configuration is the last configuration downloaded remotely.
+If it's not available, the tracker initializer will spin up the default configuration passed as a parameter.
+Every time the initializer successfully initializes the tracker instances it calls a callback passing the list of activated namespaces and the state of the configuration which represents the source where the configuration was retrieved from (using default values, cache, or fetched from the remote endpoint).
+The callback can be used for last minute settings at runtime once the tracker has been instanced.
 
-The `defaultConfiguration` parameter takes a list of `ConfigurationBundle` objects. Each one represents a tracker instance and it's own configuration. Each tracker instance is identified by a `namespace` which is a parameter required in each `ConfigurationBundle`.
+## Default configuration
 
-The optional `onSuccess` callback is called for each successful configuration. For example, if the tracker has a cached configuration and it's downloading a new configuration, first the `onSuccess` callback will be called for the cached configuration and then it will be called when the downloaded configuration is applied. When it happens the cached configuration is substituted with the downloaded one.
+The default configuration will be used right after calling the `setup()` method in case there is no cached configuration (one that was fetched from the remote endpoint and stored in a cache file).
+
+The `defaultConfiguration` parameter takes a list of `ConfigurationBundle` objects.
+Each one represents a tracker instance and it's own configuration.
+Each tracker instance is identified by a `namespace` which is a parameter required in each `ConfigurationBundle`.
+
+The optional `defaultConfigurationVersion` parameter specifies the version of the default configuration.
+If the fetched remote configuration has version lower or equal to the default configuration, it will not be used.
+
+## On success callback
+
+The optional `onSuccess` callback is called for each successful configuration.
+
+For example, if the tracker has a cached configuration and it's downloading a new configuration, first the `onSuccess` callback will be called for the cached configuration and then it will be called when the downloaded configuration is applied.
+When it happens the cached configuration is substituted with the downloaded one.
 
 ## The remote configuration file
 

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/installation-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/installation-tracking/index.md
@@ -42,3 +42,31 @@ TrackerConfiguration trackerConfig = new TrackerConfiguration("appId")
 
   </TabItem>
 </Tabs>
+
+## Android-only: Tracking referrer information from the Google Play Referrer library
+
+The Google Play Referrer library is a tool provided by Google for Android developers to track and capture referral information when a user installs or updates an app from the Google Play Store.
+It allows developers to gather valuable insights about the sources that drive app installations, such as ad campaigns, referral links, or marketing efforts.
+
+When an app is installed or updated, the Google Play Referrer library retrieves the referral information from the Google Play Store and provides it to the app.
+This information includes the referrer URL, which can contain parameters or tracking codes that identify the specific referral source.
+
+The Android tracker can make use of the library to retrieve the referral information.
+It attaches the information in an entity attached to the install event.
+The entity uses the `iglu:com.android.installreferrer.api/referrer_details/jsonschema/1-0-0` schema with the following properties:
+
+Property | Type | Description
+--|--|--
+`installReferrer` | String | The referrer URL of the installed package
+`referrerClickTimestamp` | Datetime | The timestamp when referrer click happens
+`installBeginTimestamp` | Datetime | The timestamp when installation begins
+`googlePlayInstantParam` | Boolean | Boolean indicating if the user has interacted with the app's instant experience in the past 7 days
+
+To enable tracking the entity, you will need to have `installAutotracking` enabled and add the following line to the dependencies section of the `build.gradle` file in your app:
+
+```gradle
+dependencies {
+    ...
+    implementation "com.android.installreferrer:installreferrer:2.2"
+}
+```

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -1,12 +1,12 @@
 export const versions = {
   // Trackers
-  androidTracker: '5.1.0',
+  androidTracker: '5.2.0',
   dotNetTracker: '1.2.1',
   cppTracker: '1.0.0',
   flutterTracker: '0.3.0',
   golangTracker: '3.0.0',
   googleAmpTracker: '1.0.3',
-  iosTracker: '5.1.0',
+  iosTracker: '5.2.0',
   javaTracker: '1.0.0',
   javaScriptTracker: '3.10.1',
   luaTracker: '0.2.0',


### PR DESCRIPTION
Updates the documentation for the mobile trackers version 5.2 adding the following info:

* new default configuration version parameter in remote config
* new Android install referrer entity