### PR TITLE
Update docs for C++ tracker version 2

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/c-tracker/initialisation/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/c-tracker/initialisation/index.md
@@ -11,7 +11,7 @@ Designing how and what to track in your app is an important decision. Check out 
 Import the C++ Tracker library and use the `snowplow` namespace like so:
 
 ```cpp
-#include "snowplow/snowplow.hpp"
+#include <snowplow/snowplow.hpp>
 
 using namespace snowplow;
 ```
@@ -161,7 +161,7 @@ The third option to initialise a new tracker is to instantiate it and the relate
 The following example takes you through the steps needed to initialize a storage, emitter, subject, client session, and tracker:
 
 ```cpp
-#include "snowplow/snowplow.hpp"
+#include <snowplow/snowplow.hpp>
 
 // 1. create storage for event queue and session information
 auto storage = std::make_shared<SqliteStorage>("sp.db");

--- a/docs/collecting-data/collecting-from-own-applications/c-tracker/upgrading-to-newer-versions/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/c-tracker/upgrading-to-newer-versions/index.md
@@ -6,6 +6,14 @@ sidebar_position: 100
 
 This page gives instructions for upgrading to newer versions of the C++ tracker.
 
+## Upgrading to v2.0.0
+
+There have been the following breaking changes:
+
+* CMake minimum version changed 3.14 -> 3.15
+* libcurl has been removed as a dependency of Snowplow on macOS and the CURL HTTP client is no longer available on macOS. If a project that is using Snowplow as a subdirectory relies on getting libcurl through Snowplow then it will fail now.
+* Also, sqlite3, libcurl, libuuid are now private dependencies. If a project relies on getting the sqlite3/libcurl/libuuid include paths through the Snowplow tracker library, then it will fail now.
+
 ## Upgrading to v1.0.0
 
 The package added support for the cmake build system. You may make use of this and import the package in your cmake build configuration. Importing source code by copying files is still supported. However, please note that the code was moved from the `src` folder to the `include` folder and you will need to import the sqlite3 and nlohmann/json dependencies on your own and update their location in `include/snowplow/thirdparty/sqlite3.hpp` and `include/snowplow/thirdparty/json.hpp` files. See instructions on [the Setup page](/docs/collecting-data/collecting-from-own-applications/c-tracker/setup/index.md) for more information.

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -2,7 +2,7 @@ export const versions = {
   // Trackers
   androidTracker: '5.1.0',
   dotNetTracker: '1.2.1',
-  cppTracker: '1.0.0',
+  cppTracker: '2.0.0',
   flutterTracker: '0.3.0',
   golangTracker: '3.0.0',
   googleAmpTracker: '1.0.3',


### PR DESCRIPTION
Update installation instructions with the new install option in v2. Add a section to the migration guide.