### PR TITLE
Add information to .NET tracker docs how to configure global and event subject

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/net-tracker/event-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/net-tracker/event-tracking/index.md
@@ -197,7 +197,7 @@ SelfDescribingJson eventData = new SelfDescribingJson("iglu:com.acme/save_game/j
 // Track your event with your custom event data
 t1.Track(new SelfDescribing()
     .SetEventData(eventData)
-    .Build();
+    .Build());
 
 // OR
 
@@ -206,7 +206,7 @@ t1.Track(new SelfDescribing()
     .SetCustomContext(contextList)
     .SetTrueTimestamp(1423583655000)
     .SetEventId("uid-1")
-    .Build();
+    .Build());
 ```
 
 For more on JSON schema, see the [blog post](https://snowplowanalytics.com/blog/2014/05/15/introducing-self-describing-jsons/).

--- a/docs/collecting-data/collecting-from-own-applications/net-tracker/subject/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/net-tracker/subject/index.md
@@ -17,6 +17,33 @@ s1.SetLang("en-gb");
 s1.SetScreenResolution(1920, 1080);
 ```
 
+There are two ways to provide the subject information:
+
+1. Globally for all tracked events. This is useful in client-side applications where all tracked events relate to the same user and share the same properties.
+2. For each event individually. This is useful in server-side applications where each event might relate to a different user.
+
+To configure a global subject, pass it to the tracker during initialization:
+
+```csharp
+var globalSubject = new Subject().SetPlatform(Platform.Mob).SetLang("EN");
+
+Tracker.Tracker.Instance.Start(emitter: emitter, subject: globalSubject, trackerNamespace: "some namespace", appId: "some appid", l: logger);
+```
+
+To pass the subject along with tracked events:
+
+```csharp
+Subject eventSubject = new Subject().SetUserId("Kevin Gleason");
+
+Tracker.Instance.Track(
+    new Structured()
+        .SetCategory("shop")
+        .SetAction("add-to-basket")
+        .Build(),
+    eventSubject
+);
+```
+
 ### `SetUserId`
 
 You can set the user ID to any string:


### PR DESCRIPTION
Adds missing code snippets showing how to set the subject information on the tracker as well as on the event level in the .NET tracker.