### PR TITLE
Replace bind mounts with -v in Docker examples

### DIFF
--- a/docs/destinations/forwarding-events/snowbridge/testing/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/testing/index.md
@@ -61,12 +61,12 @@ The output (in `output.txt`) will contain more than the data itself. There will 
 
 ### Adding configuration
 
-To add a specific configuration to test, create a configuration file (`config.hcl`) and pass it to the Docker container. You will need to [mount the file](https://docs.docker.com/storage/bind-mounts/) and set the `SNOWBRIDGE_CONFIG_FILE` environment variable to the path _inside_ the container:
+To add a specific configuration to test, create a configuration file (`config.hcl`) and pass it to the Docker container. You will need to pass the file to the container and set the `SNOWBRIDGE_CONFIG_FILE` environment variable to the path _inside_ the container:
 
 <CodeBlock language="bash">{
 `cat data.tsv | docker run -i \\
-    --mount type=bind,source=$(pwd)/config.hcl,target=/tmp/config.hcl \\
-    --env SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl \\
+    -v $(pwd)/config.hcl:/tmp/config.hcl \\
+    -e SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl \\
     snowplow/snowbridge:${versions.snowbridge} > output.txt`
 }</CodeBlock>
 
@@ -82,9 +82,9 @@ You can add custom scripts by mounting a file, similarly to the above. Assuming 
 
 <CodeBlock language="bash">{
 `cat data.tsv | docker run -i \\
-    --mount type=bind,source=$(pwd)/config.hcl,target=/tmp/config.hcl \\
-    --mount type=bind,source=$(pwd)/script.js,target=/tmp/script.js \\
-    --env SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl \\
+    -v $(pwd)/config.hcl:/tmp/config.hcl \\
+    -v $(pwd)/script.js:/tmp/script.js \\
+    -e SNOWBRIDGE_CONFIG_FILE=/tmp/config.hcl \\
     snowplow/snowbridge:${versions.snowbridge} > output.txt`
 }</CodeBlock>
 

--- a/docs/enriching-your-data/available-enrichments/custom-javascript-enrichment/testing/index.md
+++ b/docs/enriching-your-data/available-enrichments/custom-javascript-enrichment/testing/index.md
@@ -25,7 +25,7 @@ For example, if your enrichment code is in `script.js` in the current directory,
 
 <CodeBlock language="bash">{
 `docker run -p 9090:9090 \\
-  --mount type=bind,source=$(pwd)/script.js,destination=/config/enrichments/script.js \\
+  -v $(pwd)/script.js:/config/enrichments/script.js \\
   snowplow/snowplow-micro:${versions.snowplowMicro}`
 }</CodeBlock>
 
@@ -130,8 +130,8 @@ This command will add both the script and the schema to Micro:
 
 <CodeBlock language="bash">{
 `docker run -p 9090:9090 \\
-  --mount type=bind,source=$(pwd)/schemas,destination=/config/iglu-client-embedded/schemas \\
-  --mount type=bind,source=$(pwd)/script.js,destination=/config/enrichments/script.js \\
+  -v $(pwd)/schemas:/config/iglu-client-embedded/schemas \\
+  -v $(pwd)/script.js:/config/enrichments/script.js \\
   snowplow/snowplow-micro:${versions.snowplowMicro}`
 }</CodeBlock>
 

--- a/docs/getting-started-with-micro/adding-schemas/index.md
+++ b/docs/getting-started-with-micro/adding-schemas/index.md
@@ -91,12 +91,6 @@ Next, you will need to place the schemas in `/config/iglu-client-embedded/` insi
 
 <CodeBlock language="bash">{
 `docker run -p 9090:9090 \\
-  --mount type=bind,source=$(pwd)/schemas,destination=/config/iglu-client-embedded/schemas \\
+  -v $(pwd)/schemas:/config/iglu-client-embedded/schemas \\
   snowplow/snowplow-micro:${versions.snowplowMicro}`
 }</CodeBlock>
-
-:::tip
-
-You can read more about bind mounts in the [Docker documentation](https://docs.docker.com/storage/bind-mounts/).
-
-:::

--- a/docs/getting-started-with-micro/advanced-usage/index.md
+++ b/docs/getting-started-with-micro/advanced-usage/index.md
@@ -15,18 +15,18 @@ import TabItem from '@theme/TabItem';
 
 While in most cases HTTP is sufficient, you may want to enable HTTPS in Micro (for an example of when that’s useful, see [Locally resolving an existing domain name to Micro](/docs/getting-started-with-micro/remote-usage/index.md#locally-resolving-an-existing-domain-name-to-micro)).
 
-You will need an SSL/TLS certificate in [PKCS 12](https://en.wikipedia.org/wiki/PKCS_12) format (`.p12`). Pass your certificate file and its password to the container (using a [bind mount](https://docs.docker.com/storage/bind-mounts/) and an [environment variable](https://docs.docker.com/compose/environment-variables/)). Don’t forget to expose the HTTPS port (by default, 9543):
+You will need an SSL/TLS certificate in [PKCS 12](https://en.wikipedia.org/wiki/PKCS_12) format (`.p12`). Pass your certificate file and its password to the container. Don’t forget to expose the HTTPS port (by default, 9543):
 
 <CodeBlock language="bash">{
 `docker run -p 9090:9090 -p 9543:9543 \\
-  --mount type=bind,source=$(pwd)/my-certificate.p12,destination=/config/ssl-certificate.p12 \\
+  -v $(pwd)/my-certificate.p12:/config/ssl-certificate.p12 \\
   -e MICRO_SSL_CERT_PASSWORD=... \\
   snowplow/snowplow-micro:${versions.snowplowMicro}`
 }</CodeBlock>
 
 :::note
 
-For the certificate, the path inside the container must be exactly `/config/ssl-certificate.p12`.
+For the certificate, the path inside the container (the part after `:`) must be exactly `/config/ssl-certificate.p12`.
 
 :::
 
@@ -48,11 +48,11 @@ If you are just looking to add custom schemas or connect to your private Iglu re
 
 :::
 
-Pass your configuration file to the container (using a [bind mount](https://docs.docker.com/storage/bind-mounts/)) and instruct Micro to use it:
+Pass your configuration file to the container and instruct Micro to use it:
 
 <CodeBlock language="bash">{
 `docker run -p 9090:9090 \\
-  --mount type=bind,source=$(pwd)/iglu.json,destination=/config/iglu.json \\
+  -v $(pwd)/iglu.json:/config/iglu.json \\
   snowplow/snowplow-micro:${versions.snowplowMicro} \\
   --iglu /config/iglu.json`
 }</CodeBlock>
@@ -84,11 +84,11 @@ https://github.com/snowplow-incubator/snowplow-micro/blob/master/example/micro.c
 
 </details>
 
-Pass your configuration file to the container (using a [bind mount](https://docs.docker.com/storage/bind-mounts/)) and instruct Micro to use it:
+Pass your configuration file to the container and instruct Micro to use it:
 
 <CodeBlock language="bash">{
 `docker run -p 9090:9090 \\
-  --mount type=bind,source=$(pwd)/micro.conf,destination=/config/micro.conf \\
+  -v $(pwd)/micro.conf:/config/micro.conf \\
   snowplow/snowplow-micro:${versions.snowplowMicro} \\
   --collector-config /config/micro.conf`
 }</CodeBlock>

--- a/docs/getting-started-with-micro/configuring-enrichments/index.md
+++ b/docs/getting-started-with-micro/configuring-enrichments/index.md
@@ -32,17 +32,17 @@ https://github.com/snowplow/enrich/blob/master/config/enrichments/ip_lookups.jso
 
 Put this file somewhere on the machine where you are running Micro, let’s say `my-enrichments/ip_lookups.json`. (Feel free to add any other configurations to `my-enrichments`).
 
-Now you will need to pass this directory to the Docker container (using a [bind mount](https://docs.docker.com/storage/bind-mounts/)):
+Now you will need to pass this directory to the Docker container:
 
 <CodeBlock language="bash">{
 `docker run -p 9090:9090 \\
-  --mount type=bind,source=$(pwd)/my-enrichments,destination=/config/enrichments \\
+  -v $(pwd)/my-enrichments:/config/enrichments \\
   snowplow/snowplow-micro:${versions.snowplowMicro}`
 }</CodeBlock>
 
 :::note
 
-The directory _inside_ the container (what goes after `destination=`) must be exactly `/config/enrichments`.
+The directory _inside_ the container (what goes after `:`) must be exactly `/config/enrichments`.
 
 :::
 

--- a/docs/getting-started-with-micro/remote-usage/index.md
+++ b/docs/getting-started-with-micro/remote-usage/index.md
@@ -149,7 +149,7 @@ If you need HTTPS (substitute your Collector domain for `c.example.com`):
 
 <CodeBlock language="bash">{
 `docker run -p 80:9090 -p 443:9543 \\
-  --mount type=bind,source=$(pwd)/c.example.com.p12,destination=/config/ssl-certificate.p12 \\
+  -v $(pwd)/c.example.com.p12:/config/ssl-certificate.p12 \\
   -e MICRO_SSL_CERT_PASSWORD=changeit \\
   snowplow/snowplow-micro:${versions.snowplowMicro}`
 }</CodeBlock>

--- a/docs/managing-data-quality/testing-and-qa-workflows/set-up-automated-testing-with-snowplow-micro/index.md
+++ b/docs/managing-data-quality/testing-and-qa-workflows/set-up-automated-testing-with-snowplow-micro/index.md
@@ -93,7 +93,7 @@ If you wanted to use `docker run` instead of `docker-compose`, the same step 
 
 <CodeBlock language="yaml">{
 `- name: Start Micro
-    run: docker run --mount type=bind,source=$(pwd)/micro,destination=/config -p 9090:9090 snowplow/snowplow-micro:${versions.snowplowMicro} --collector-config /config/micro.conf --iglu /config/iglu.json & \\
+    run: docker run -v $(pwd)/micro:/config -p 9090:9090 snowplow/snowplow-micro:${versions.snowplowMicro} --collector-config /config/micro.conf --iglu /config/iglu.json & \\
     working-directory: snowplow-micro-examples`
 }</CodeBlock>
 


### PR DESCRIPTION
I realized these also work. No idea why we were pushing the arcane bind mount syntax.