### PR TITLE
Highlight offerings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ The sidebar on the left follows [file structure](https://github.com/snowplow/doc
 
 To control the position of a section in the sidebar, go to the `index.md` file for that section and adjust the `sidebar_position` attribute at the top (see [this example](https://github.com/snowplow/documentation/blob/main/docs/tutorials/index.md)). Sidebar positions are just numbers, and you can use any number as long as the order is correct.
 
+### Offerings
+
+Some documentation is only relevant to a particular offering. You can indicate it like this:
+```
+---
+title: ...
+...
+sidebar_custom_props:
+  offerings:
+    - enterprise
+    - cloud
+...
+---
+```
+
+This will result in an icon appearing in the sidebar, as well as an automatic banner on the page, specifying that the docs only apply to a given offering.
+
+The available values are: `enterprise`, `cloud`, `opensource`. You can speficy just one value or combine several (currently, `enterprise` + `cloud` is the only supported combination, see `src/css/custom.css`). Do not specify all three values at once — if a piece of documentation is relevant to all offerings, there should be no `offerings` property as that’s the default.
+
+Whenever the same functionality can be achieved in multiple offerings but in a different way (e.g. managing schemas), create a parent folder (“Managing schemas”) that’s offering-neutral, and then add offering-specific pages inside it. This way, other pages can link to the generic page without having to specify different methods for different offerings.
+
 ### Links
 
 For links within this documentation, please end the link with `/index.md`. This way all links will be checked, and you’ll get an error if a link is broken at any point.

--- a/docs/discovering-data/tracking-catalog/index.md
+++ b/docs/discovering-data/tracking-catalog/index.md
@@ -2,6 +2,9 @@
 title: "Tracking catalog"
 date: "2022-10-26"
 sidebar_position: 0
+sidebar_custom_props:
+  offerings:
+    - enterprise
 description: "The Tracking Catalog will provide your team with easy and self serve access to the events you’re tracking, creating greater transparency and autonomy. This can help improve the data culture in your organisation and foster a more collaborative approach to create Data Products."
 ---
 

--- a/docs/modeling-your-data/running-data-models-via-snowplow-bdp/index.md
+++ b/docs/modeling-your-data/running-data-models-via-snowplow-bdp/index.md
@@ -2,6 +2,9 @@
 title: "Running data models via Snowplow BDP"
 date: "2020-12-01"
 sidebar_position: 30
+sidebar_custom_props:
+  offerings:
+    - enterprise
 ---
 
 ```mdx-code-block

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,18 +13,32 @@
 
 const swap = (allItems, linkItems) => {
   const result = allItems.flatMap((item) => {
-    if (item.customProps?.header) {
-      const header = {
-        type: 'html',
-        value: item.customProps.header,
-        defaultStyle: true,
-        className: 'header',
-      }
-      return [header, { ...item, items: swap(item.items, linkItems) }]
-    }
+    const header = item.customProps?.header ? [{
+      type: 'html',
+      value: item.customProps.header,
+      defaultStyle: true,
+      className: 'header',
+    }] : []
+
+    const className = item.customProps?.offerings ?
+      [item.className || '', ...item.customProps.offerings].join(' ') :
+      item.className
 
     if (item.type === 'category') {
-      return [{ ...item, items: swap(item.items, linkItems) }]
+      if (item.items.length > 0) return [...header, {
+        ...item,
+        className,
+        items: swap(item.items, linkItems)
+      }]
+      // a workaround for empty category pages not respecting className
+      // see https://discord.com/channels/398180168688074762/867060369087922187/1068508121091293264
+      return [...header, {
+        type: 'doc',
+        id: item.link.id,
+        label: item.label,
+        className,
+        customProps: item.customProps,
+      }]
     }
 
     if (linkItems[item.id]) {
@@ -33,13 +47,13 @@ const swap = (allItems, linkItems) => {
           type: 'link',
           label: linkItems[item.id].sidebar_label ?? linkItems[item.id].title,
           href: linkItems[item.id].href,
-          className: linkItems[item.id].sidebar_class_name,
+          className,
           customProps: linkItems[item.id].sidebar_custom_props,
         },
       ]
     }
 
-    return [item]
+    return [{...item, className}]
   })
 
   return result

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -244,6 +244,84 @@ table h3 {
   line-height: 20px;
 }
 
+li.enterprise > div > a::before,
+li.enterprise > a::before,
+li.cloud > div > a::before,
+li.cloud > a::before,
+li.opensource > div > a::before,
+li.opensource > a::before {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.5em;
+}
+
+article.enterprise > a > p::before,
+article.cloud > a > p::before,
+article.opensource > a > p::before {
+  display: inline-block;
+  vertical-align: bottom;
+  margin-right: 0.3em;
+}
+
+li.enterprise > div > a::before,
+li.enterprise > a::before,
+article.enterprise > a > p::before {
+  content: '🏭';
+}
+li.cloud > div > a::before,
+li.cloud > a::before,
+article.cloud > a > p::before {
+  content: '☁️';
+}
+li.enterprise.cloud > div > a::before,
+li.enterprise.cloud > a::before,
+article.enterprise.cloud > a > p::before {
+  content: '🏭 ☁️';
+}
+li.opensource > div > a::before,
+li.opensource > a::before,
+article.opensource > a > p::before {
+  content: '🛠️';
+}
+
+a.menu__link, a.card {
+  position: relative;
+}
+.enterprise a:hover::after,
+.cloud a:hover::after,
+.opensource a:hover::after {
+  position: absolute;
+  left: 0;
+  bottom: -30px;
+  width: auto;
+  white-space: nowrap;
+  transform: none;
+  background-color: var(--ifm-font-color-base);
+  color: var(--ifm-font-color-base-inverse);
+  border-radius: 3px;
+  box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
+  font-size: 14px;
+  z-index: 9998;
+  padding: 3px 5px;
+}
+a.card:hover::after {
+  top: 2rem;
+  left: 2rem;
+  bottom: auto;
+}
+.enterprise a:hover::after {
+  content: '🏭: For Snowplow BDP Enterprise customers';
+}
+.cloud a:hover::after {
+  content: '☁️: For Snowplow BDP Cloud customers';
+}
+.enterprise.cloud a:hover::after {
+  content: '🏭 ☁️: For Snowplow BDP customers';
+}
+.opensource a:hover::after {
+  content: '🛠️: For Snowplow Open Source users';
+}
+
 .breadcrumbs__item:not(:last-child):after {
   content: '/';
   background: none;

--- a/src/theme/DocCardList/index.js
+++ b/src/theme/DocCardList/index.js
@@ -1,0 +1,31 @@
+// npm run swizzle @docusaurus/theme-classic DocCardList -- --eject
+// This is marked as a “safe” swizzle by Docusaurus.
+// See below for the changed part.
+import React from 'react';
+import clsx from 'clsx';
+import {
+  useCurrentSidebarCategory,
+  filterDocCardListItems,
+} from '@docusaurus/theme-common';
+import DocCard from '@theme/DocCard';
+function DocCardListForCurrentSidebarCategory({className}) {
+  const category = useCurrentSidebarCategory();
+  return <DocCardList items={category.items} className={className} />;
+}
+export default function DocCardList(props) {
+  const {items, className} = props;
+  if (!items) {
+    return <DocCardListForCurrentSidebarCategory {...props} />;
+  }
+  const filteredItems = filterDocCardListItems(items);
+  return (
+    <section className={clsx('row', className)}>
+      {filteredItems.map((item, index) => (
+        // changed part: add the item class to the card
+        <article key={index} className={`col col--6 margin-bottom--lg ${item.className || ''}`}>
+          <DocCard item={item} />
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -5,6 +5,12 @@ import Head from '@docusaurus/Head'
 import { useSidebarBreadcrumbs } from '@docusaurus/theme-common/internal'
 import _ from 'lodash'
 
+const offeringNames = {
+  enterprise: "Snowplow BDP Enterprise",
+  cloud: "Snowplow BDP Cloud",
+  opensource: "Snowplow Open Source",
+}
+
 export default function MDXContentWrapper(props) {
   let breadcrumbs;
   try {
@@ -18,6 +24,7 @@ export default function MDXContentWrapper(props) {
 
   const legacy = _.some(_.initial(breadcrumbs), item => item.customProps?.legacy)
   const outdated = !legacy && _.some(_.initial(breadcrumbs), item => item.customProps?.outdated)
+  const offerings = _.find(breadcrumbs, item => item.customProps?.offerings)
 
   if (outdated) {
     const latest = _.last(_.takeWhile(breadcrumbs, item => !item.customProps?.outdated)).href
@@ -25,6 +32,16 @@ export default function MDXContentWrapper(props) {
       <Admonition type="caution" key="outdated">
         You are reading documentation for an outdated version. Here’s the{' '}
         <a href={latest}>latest one</a>!
+      </Admonition>
+    )
+  }
+
+  if (offerings) {
+    const names = offerings.customProps.offerings.map(o => offeringNames[o])
+    admonitions.push(
+      <Admonition type="info" key="offering">
+        This documentation only applies to <strong>{names.join(' and ')}</strong>.
+        See the <a href="/docs/feature-comparison/">feature comparison</a> page for more information about the different Snowplow offerings.
       </Admonition>
     )
   }


### PR DESCRIPTION
This PR adds a mechanism to automatically highlight different offerings (BDP Enterprise, BDP Cloud, Open Source) and updates a couple of pages to demo this. Updating the remaining pages will come in a different PR.

# Guiding principles

* Make it clear what is in the paid product and what is in the free product
* Help Open Source users discover compelling paid functionality
* Help customers skip what is only relevant to Open Source users
* Automatic signposting in the sidebar, cards _and_ each offering-specific page (including subpages)
* Make it possible to add an offering selector that would filter the sidebar (future work)
* Make it possible to integrate with search facets (future work)
* Make it possible to discard Open Source specific content in Zendesk Federated search (future work)

# Information architecture

There were a few options:
* ~Completely separate sidebars for Enterprise, Cloud, Open Source~  — does not help Open Source users discover BDP functionality. Also it would be a lot of effort to reuse common pages, which is the majority of the content.
* ~Within each task (e.g. “Managing data structures”), add subcategories for Enterprise, Cloud, Open Source~ — for content that is only in one offering, e.g. Tracking Catalog, this approach awkwardly adds unnecessary dropdowns in the sidebar.
* **Keep existing structure but label pages / categories with an icon** — lightweight, flexible and achieves all goals

# Propagating the offering for a page

There were a few options:
* ~Use directory structure or file names (e.g. `/enterprise/...` or `/enterprise--...`)~ — discarded because we would need to change URLs every time we adjust what is available where
* **Use `sidebar_custom_props`** — clean, achieves all goals (we might still want to change the URLs for open source content to exclude it from Zendesk, but that can be always done in the future)


# Styling the sidebar

There were a few options:
* ~Swizzle the sidebar item~ — unsafe and generated an awful lot of code which would likely create problems when we upgrade Docusaurus
* ~Add the icons to the label in `sidebars.js`~ — workable, but still does not allow to add a tooltip
* **Add icons and tooltips fully via CSS** — a bit meh but achieves all goals