### PR TITLE
Fix dangling underscores in Data Structures API docs

### DIFF
--- a/docs/understanding-tracking-design/managing-data-structures-via-the-api-2/index.md
+++ b/docs/understanding-tracking-design/managing-data-structures-via-the-api-2/index.md
@@ -79,6 +79,7 @@ See the [detailed API documentation](https://console.snowplowanalytics.com/api/m
 To use the commands to retrieve information about a specific Data Structure, you need to encode its identifying parameters (`organization ID`, `vendor`, `name` and `format`) and hash it with SHA-256.
 
 **Example:**  
+
 | Parameter | Value |
 |-----------|-------|
 | Organization ID | `38e97db9-f3cb-404d-8250-cd227506e544` |

--- a/docs/understanding-tracking-design/managing-data-structures-via-the-api-2/index.md
+++ b/docs/understanding-tracking-design/managing-data-structures-via-the-api-2/index.md
@@ -74,18 +74,18 @@ Use this request to retrieve all versions of a specific data structure by its ha
 
 See the [detailed API documentation](https://console.snowplowanalytics.com/api/msc/v1/docs) for all options.
 
-Generating a data structure hash
+#### Generating a data structure hash
 
 To use the commands to retrieve information about a specific Data Structure, you need to encode its identifying parameters (`organization ID`, `vendor`, `name` and `format`) and hash it with SHA-256.
 
 **Example:**  
-`organization ID: _38e97db9-f3cb-404d-8250-cd227506e544_`  
-`vendor_: com.acme.event_`  
-`schema name: _search_`  
-`format: _jsonschema_` 
+`organization ID: 38e97db9-f3cb-404d-8250-cd227506e544`  
+`vendor: com.acme.event`  
+`schema name: search`  
+`format: jsonschema` 
 
 First concatenate the information with a dash (-) as the separator:  
-`_38e97db9-f3cb-404d-8250-cd227506e544_-_com.acme.event_-_search_-jsonschema`
+`38e97db9-f3cb-404d-8250-cd227506e544-com.acme.event-search-jsonschema`
 
 And then hash them with SHA-256 to receive: `a41ef92847476c1caaf5342c893b51089a596d8ecd28a54d3f22d922422a6700`
 

--- a/docs/understanding-tracking-design/managing-data-structures-via-the-api-2/index.md
+++ b/docs/understanding-tracking-design/managing-data-structures-via-the-api-2/index.md
@@ -79,10 +79,12 @@ See the [detailed API documentation](https://console.snowplowanalytics.com/api/m
 To use the commands to retrieve information about a specific Data Structure, you need to encode its identifying parameters (`organization ID`, `vendor`, `name` and `format`) and hash it with SHA-256.
 
 **Example:**  
-`organization ID: 38e97db9-f3cb-404d-8250-cd227506e544`  
-`vendor: com.acme.event`  
-`schema name: search`  
-`format: jsonschema` 
+| Parameter | Value |
+|-----------|-------|
+| Organization ID | `38e97db9-f3cb-404d-8250-cd227506e544` |
+| Vendor | `com.acme.event` |
+| Schema name | `search` |
+| Format | `jsonschema` |
 
 First concatenate the information with a dash (-) as the separator:  
 `38e97db9-f3cb-404d-8250-cd227506e544-com.acme.event-search-jsonschema`


### PR DESCRIPTION
@rahul-snowplow made me notice that a section of the "Managing Data Structures via the API" page contained some instructions that were not working. Turned out there were some dangling `_` in there, I guess it happened when we migrated the docs over to this repo. Once fixed, the hash was actually matching the correct values