### PR TITLE
Add documentation for iOS and Android media tracking APIs

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/media-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/media-tracking/index.md
@@ -1,0 +1,56 @@
+---
+title: "Media tracking"
+sidebar_position: 100
+---
+
+# Media tracking
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Media from "@site/docs/reusable/media/_index.md"
+```
+
+<Tabs groupId="platform" queryString>
+  <TabItem value="ios" label="iOS" default>
+
+<Media tracker="ios" />
+
+### Auto-tracking events from AVPlayer
+
+The tracker is able to automatically track media events from the [AVPlayer media player](https://developer.apple.com/documentation/avfoundation/avplayer).
+
+The following events are tracked:
+
+* play events
+* pause events
+* seek end events
+* ping events
+* percent progress events (if configured)
+* buffer start events
+* end event
+* error event
+
+The following snippets starts media tracking an AVPlayer instance (`player`):
+
+```swift
+let mediaTracking = tracker.media.startMediaTracking(
+    player: player,
+    configuration: MediaTrackingConfiguration(id: "XXXX")
+)
+```
+
+You can use the `MediaTrackingConfiguration` to further configure the media tracking.
+
+  </TabItem>
+  <TabItem value="android" label="Android (Kotlin)">
+
+<Media tracker="android-kotlin" />
+
+  </TabItem>
+  <TabItem value="android-java" label="Android (Java)">
+
+<Media tracker="android-java" />
+
+  </TabItem>
+</Tabs>

--- a/docs/reusable/media/_index.md
+++ b/docs/reusable/media/_index.md
@@ -155,6 +155,21 @@ startMediaTracking({ id });
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let id = "XXXXX"
+let tracker = Snowplow.defaultTracker()
+let mediaTracking = tracker.media.startMediaTracking(id: id)
+`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`// TODO: not implemented yet for Kotlin`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`// TODO: not implemented yet for Java`}
+</CodeBlock>)}</>
+
 Use the `endMediaTracking` call to end media tracking. This will clear the local state for the media tracking and stop any background updates.
 
 <>{(props.tracker == 'js-tag') && (<CodeBlock language="javascript">
@@ -164,6 +179,10 @@ Use the `endMediaTracking` call to end media tracking. This will clear the local
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`import { endMediaTracking } from "@snowplow/browser-plugin-media";
 endMediaTracking({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`tracker.media.endMediaTracking(id: id)`}
 </CodeBlock>)}</>
 
 ### Configuration
@@ -219,6 +238,25 @@ startMediaTracking({
 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let player = MediaPlayer()
+    .currentTime(0) // The current playback time
+    .duration(150.0) // A double-precision floating-point value indicating the duration of the media in seconds
+    .ended(false) // If playback of the media has ended
+    .livestream(false) // If the media is live
+    .label("Sample video") // A human-readable title for the media
+    .loop(false) // If the video should restart after ending
+    .mediaType(.video) // Type of media content
+    .muted(false) // If the media element is muted
+    .paused(true) // If the media element is paused
+    .pictureInPicture(false) // If the media is in picture-in-picture mode
+    .playbackRate(1.0) // Playback rate (1 is normal)
+    .quality("1080p") // The quality level of the playback
+    .volume(100) // Volume level
+let mediaTracking = tracker.media.startMediaTracking(id: id, player: player)
+`}
+</CodeBlock>)}</>
+
 #### Media ping events
 
 Media ping events (not to be confused with page ping events, see below) are events sent in a regular interval while media tracking is active.
@@ -242,6 +280,13 @@ This can be configured as follows:
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let configuration = MediaTrackingConfiguration(id: id)
+    .pingInterval(30)
+let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
+`}
+</CodeBlock>)}</>
+
 The ping events are sent in an interval that is unrelated to the media playback.
 However, to prevent sending too many events while the player is paused in background (e.g., in a background tab), there is a limit to how many ping events can be sent while the media is paused.
 By default, this is set to 1, but it is configurable:
@@ -261,6 +306,13 @@ By default, this is set to 1, but it is configurable:
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let configuration = MediaTrackingConfiguration(id: id)
+    .maxPausedPings(3)
+let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
+`}
+</CodeBlock>)}</>
+
 You can disable ping events as follows:
 
 <>{(props.tracker == 'js-tag') && (<CodeBlock language="javascript">
@@ -269,6 +321,13 @@ You can disable ping events as follows:
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`startMediaTracking({ id, pings: false });
+`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let configuration = MediaTrackingConfiguration(id: id)
+    .pings(false)
+let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
 `}
 </CodeBlock>)}</>
 
@@ -312,6 +371,13 @@ Tracking the media player session entity with all media events is enabled by def
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let configuration = MediaTrackingConfiguration(id: id)
+    .session(false)
+let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
+`}
+</CodeBlock>)}</>
+
 #### Percentage progress events
 
 Percentage progress events are tracked when the playback reaches some percentage boundaries.
@@ -323,6 +389,13 @@ To send percentage progress events, set the percentage boundaries when they shou
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`startMediaTracking({ id, boundaries: [10, 25, 50, 75] });
+`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let configuration = MediaTrackingConfiguration(id: id)
+    .boundaries([10, 25, 50, 75])
+let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
 `}
 </CodeBlock>)}</>
 
@@ -340,6 +413,13 @@ In case you want to discard some of the events that are tracked during the media
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`import { MediaEventType } from "@snowplow/browser-plugin-media";
 startMediaTracking({ id, captureEvents: [MediaEventType.Play] });
+`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let configuration = MediaTrackingConfiguration(id: id)
+    .captureEvents([MediaPlayEvent.self])
+let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
 `}
 </CodeBlock>)}</>
 
@@ -373,6 +453,18 @@ They will be added to all events tracked in the media tracking.
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let configuration = MediaTrackingConfiguration(id: id)
+    .entities([
+        SelfDescribingJson(
+            schema: "iglu:org.schema/video/jsonschema/1-0-0",
+            andData: ["creativeId": "1234"]
+        )
+    ])
+let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
+`}
+</CodeBlock>)}</>
+
 ## Updating playback properties
 
 Updates stored attributes of the media player such as the current playback.
@@ -393,6 +485,10 @@ updateMediaTracking({
     player: { currentTime: 10 }
 });
 `}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.update(player: MediaPlayer().currentTime(10.0))`}
 </CodeBlock>)}</>
 
 ## Tracking media events
@@ -424,6 +520,10 @@ trackMediaSeekEnd({
     id,
     media: { currentTime: 30.0 }
 });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaSeekEndEvent(), media: MediaPlayer().currentTime(30.0)`}
 </CodeBlock>)}</>
 
 #### Update ad and ad break properties
@@ -460,6 +560,15 @@ trackMediaAdStart({
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let ad = MediaAd(adId: "1234") // Unique identifier for the ad
+    .name("Podcast Ad") // Friendly name of the ad
+    .creativeId("4321") // The ID of the ad creative
+    .duration(15) // Length of the video ad in seconds
+    .skippable(true) // Indicating whether skip controls are made available to the end user
+mediaTracking.track(MediaAdStartEvent(), ad: ad)`}
+</CodeBlock>)}</>
+
 <>{(props.tracker == 'js-tag') && (<CodeBlock language="javascript">
 {`window.snowplow('trackMediaAdBreakStart', {
     id,
@@ -484,6 +593,14 @@ trackMediaAdBreakStart({
     }
 });
 `}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`let adBreak = MediaAdBreak(breakId: "2345") // An identifier for the ad break
+    .name("pre-roll") // Ad break name
+    .podSize(2) // The number of ads to be played within the ad break
+    .breakType(.linear) // Type of ads within the break
+mediaTracking.track(MediaAdBreakStartEvent(), adBreak: adBreak)`}
 </CodeBlock>)}</>
 
 #### Add context entities to tracked event
@@ -517,6 +634,18 @@ trackMediaPlay({
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaPlayEvent().entities([
+    SelfDescribingJson(
+        schema: "iglu:org.schema/video/jsonschema/1-0-0",
+        andData: [
+            "creativeId": "1234"
+        ]
+    )
+]))`}
+
+</CodeBlock>)}</>
+
 ### Available event types
 
 #### Events for controlling the playback
@@ -531,6 +660,10 @@ Tracks a media player ready event that is fired when the media tracking is succe
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaReady({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaReadyEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -550,6 +683,10 @@ Tracking this event will automatically set the `paused` property in the media pl
 {`trackMediaPlay({ id });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaPlayEvent())`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/play_event/jsonschema/1-0-0`.
 
@@ -565,6 +702,10 @@ Tracking this event will automatically set the `paused` property in the media pl
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaPause({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaPauseEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -584,6 +725,10 @@ Tracking this event will automatically set the `ended` and `paused` properties i
 {`trackMediaEnd({ id });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaEndEvent())`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/end_event/jsonschema/1-0-0`.
 
@@ -601,6 +746,10 @@ If multiple seek start events are tracked after each other (without a seek end e
 {`trackMediaSeekStart({ id });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaSeekStartEvent())`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/seek_start_event/jsonschema/1-0-0`.
 
@@ -614,6 +763,10 @@ Tracks a media player seek end event sent when a seek operation completes.
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaSeekEnd({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaSeekEndEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -643,6 +796,10 @@ The `newRate` is passed when tracking the event and is automatically updated in 
 {`trackMediaPlaybackRateChange({ id, newRate: 1.5 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaPlaybackRateChangeEvent(newRate: 1.5))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/playback_rate_change_event/jsonschema/1-0-0`.
 
@@ -668,6 +825,10 @@ The `newVolume` is passed when tracking the event and is automatically updated i
 {`trackMediaVolumeChange({ id, newVolume: 80 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaVolumeChangeEvent(newVolume: 80))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/volume_change_event/jsonschema/1-0-0`.
 
@@ -689,6 +850,10 @@ The `fullscreen` value is passed when tracking the event and is automatically up
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaFullscreenChange({ id, fullscreen: true });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaFullscreenChangeEvent(fullscreen: true))`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -714,6 +879,10 @@ The `pictureInPicture` value is passed when tracking the event and is automatica
 {`trackMediaPictureInPictureChange({ id, pictureInPicture: true });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaPictureInPictureChangeEvent(pictureInPicture: true))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/picture_in_picture_change_event/jsonschema/1-0-0`.
 
@@ -733,6 +902,10 @@ Tracking this event will increase the counter of `adBreaks` in the session entit
 {`trackMediaAdBreakStart({ id });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdBreakStartEvent())`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_break_start_event/jsonschema/1-0-0`.
 
@@ -746,6 +919,10 @@ Tracks a media player ad break end event that signals the end of an ad break.
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaAdBreakEnd({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdBreakEndEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -763,6 +940,10 @@ Tracking this event will increase the counter of `ads` in the session entity.
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaAdStart({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdStartEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -788,6 +969,10 @@ Tracking this event will increase the counter of `adsSkipped` in the session ent
 {`trackMediaAdSkip({ id, percentProgress: 60 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdSkipEvent(percentProgress: 60))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_skip_event/jsonschema/1-0-0`.
 
@@ -809,6 +994,10 @@ The event schema has one required property – it is set automatically to 25%:
 {`trackMediaAdFirstQuartile({ id });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdFirstQuartileEvent())`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_quartile_event/jsonschema/1-0-0`.
 
@@ -828,6 +1017,10 @@ The event schema has one required property – it is set automatically to 50%:
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaAdMidpoint({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdMidpointEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -852,6 +1045,10 @@ The event schema has one required property – it is set automatically to 75%:
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdThirdQuartileEvent())`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_quartile/jsonschema/1-0-0`.
 
@@ -865,6 +1062,10 @@ Tracks a media player ad complete event that signals the ad creative was played 
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaAdComplete({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdCompleteEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -890,6 +1091,10 @@ Tracking this event will increase the counter of `adsClicked` in the session ent
 {`trackMediaAdClick({ id, percentProgress: 30 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdClickEvent(percentProgress: 30))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_click_event/jsonschema/1-0-0`.
 
@@ -911,6 +1116,10 @@ The event schema has one optional property:
 {`trackMediaAdPause({ id, percentProgress: 30 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdPauseEvent(percentProgress: 30))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_pause_event/jsonschema/1-0-0`.
 
@@ -924,6 +1133,10 @@ Tracks a media player ad resume event fired when the user resumed playing the ad
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaAdResume({ id, percentProgress: 30 });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaAdResumeEvent(percentProgress: 30))`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -945,6 +1158,10 @@ The tracker will calculate the time since this event until either the buffer end
 {`trackMediaBufferStart({ id });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaBufferStartEvent())`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/buffer_start_event/jsonschema/1-0-0`.
 
@@ -958,6 +1175,10 @@ Tracks a media player buffering end event fired when the the player finishes buf
 
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`trackMediaBufferEnd({ id });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaBufferEndEvent())`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -1000,6 +1221,15 @@ The `newQuality` is passed when tracking the event and is automatically updated 
 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaQualityChangeEvent(
+    newQuality: "1080p",
+    bitrate: 1000,
+    framesPerSecond: 30,
+    automatic: false,
+))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/quality_change_event/jsonschema/1-0-0`.
 
@@ -1033,6 +1263,13 @@ The event schema has the following properties:
 });`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(MediaErrorEvent(
+    errorCode: "500",
+    errorDescription: "Failed to load media",
+))`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/error_event/jsonschema/1-0-0`.
 
@@ -1059,4 +1296,11 @@ When tracked within the context of a media tracking, the tracker will attach the
         data: { foo: 'bar' },
     },
 });`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'ios') && (<CodeBlock language="swift">
+{`mediaTracking.track(SelfDescribing(
+    schema: "iglu:com.acme/event/jsonschema/1-0-0",
+    payload: ["foo": "bar"]
+))`}
 </CodeBlock>)}</>

--- a/docs/reusable/media/_index.md
+++ b/docs/reusable/media/_index.md
@@ -151,23 +151,25 @@ window.snowplow('startMediaTracking', { id });`}
 <>{(props.tracker == 'js-browser') && (<CodeBlock language="javascript">
 {`import { startMediaTracking } from "@snowplow/browser-plugin-media";
 const id = 'XXXXX'; // randomly generated ID
-startMediaTracking({ id });
-`}
+startMediaTracking({ id });`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`let id = "XXXXX"
 let tracker = Snowplow.defaultTracker()
-let mediaTracking = tracker.media.startMediaTracking(id: id)
-`}
+let mediaTracking = tracker.media.startMediaTracking(id: id)`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
-{`// TODO: not implemented yet for Kotlin`}
+{`val id = "XXXXX"
+val tracker = Snowplow.defaultTracker
+val mediaTracking = tracker?.media?.startMediaTracking(id)`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'android-java') && (<CodeBlock language="java">
-{`// TODO: not implemented yet for Java`}
+{`String id = "XXXXX";
+TrackerController tracker = Snowplow.getDefaultTracker();
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(id, null);`}
 </CodeBlock>)}</>
 
 Use the `endMediaTracking` call to end media tracking. This will clear the local state for the media tracking and stop any background updates.
@@ -183,6 +185,14 @@ endMediaTracking({ id });`}
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`tracker.media.endMediaTracking(id: id)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`tracker?.media?.endMediaTracking(id)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`tracker.getMedia().endMediaTracking(id);`}
 </CodeBlock>)}</>
 
 ### Configuration
@@ -257,6 +267,41 @@ let mediaTracking = tracker.media.startMediaTracking(id: id, player: player)
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val player = MediaPlayerEntity(
+    currentTime = 0.0, // The current playback time
+    duration = 150.0, // A double-precision floating-point value indicating the duration of the media in seconds
+    ended = false, // If playback of the media has ended
+    livestream = false, // If the media is live
+    label = "Sample video", // A human-readable title for the media
+    loop = false, // If the video should restart after ending
+    mediaType = MediaType.Video, // Type of media content
+    muted = false, // If the media element is muted
+    paused = true, // If the media element is paused
+    pictureInPicture = false, // If the media is in picture-in-picture mode
+    playbackRate = 1.0, // Playback rate (1 is normal)
+    quality = "1080p", // The quality level of the playback
+    volume = 100 // Volume level
+)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaPlayerEntity player = new MediaPlayerEntity();
+player.setCurrentTime(0.0); // The current playback time
+player.setDuration(150.0); // A double-precision floating-point value indicating the duration of the media in seconds
+player.setEnded(false); // If playback of the media has ended
+player.setLivestream(false); // If the media is live
+player.setLabel("Sample video"); // A human-readable title for the media
+player.setLoop(false); // If the video should restart after ending
+player.setMediaType(MediaType.Video); // Type of media content
+player.setMuted(false); // If the media element is muted
+player.setPaused(true); // If the media element is paused
+player.setPictureInPicture(false); // If the media is in picture-in-picture mode
+player.setPlaybackRate(1.0); // Playback rate (1 is normal)
+player.setQuality("1080p"); // The quality level of the playback
+player.setVolume(100); // Volume level`}
+</CodeBlock>)}</>
+
 #### Media ping events
 
 Media ping events (not to be confused with page ping events, see below) are events sent in a regular interval while media tracking is active.
@@ -287,6 +332,20 @@ let mediaTracking = tracker.media.startMediaTracking(configuration: configuratio
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val configuration = MediaTrackingConfiguration(
+    id = id,
+    pingInterval = 30
+)
+val mediaTracking = tracker?.media?.startMediaTracking(configuration)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaTrackingConfiguration configuration = new MediaTrackingConfiguration(id, null);
+configuration.setPingInterval(30);
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(configuration);`}
+</CodeBlock>)}</>
+
 The ping events are sent in an interval that is unrelated to the media playback.
 However, to prevent sending too many events while the player is paused in background (e.g., in a background tab), there is a limit to how many ping events can be sent while the media is paused.
 By default, this is set to 1, but it is configurable:
@@ -313,6 +372,20 @@ let mediaTracking = tracker.media.startMediaTracking(configuration: configuratio
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val configuration = MediaTrackingConfiguration(
+    id = id,
+    maxPausedPings = 3
+)
+val mediaTracking = tracker?.media?.startMediaTracking(configuration)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaTrackingConfiguration configuration = new MediaTrackingConfiguration(id, null);
+configuration.setMaxPausedPings(3);
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(configuration);`}
+</CodeBlock>)}</>
+
 You can disable ping events as follows:
 
 <>{(props.tracker == 'js-tag') && (<CodeBlock language="javascript">
@@ -329,6 +402,20 @@ You can disable ping events as follows:
     .pings(false)
 let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
 `}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val configuration = MediaTrackingConfiguration(
+    id = id,
+    pings = false
+)
+val mediaTracking = tracker?.media?.startMediaTracking(configuration)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaTrackingConfiguration configuration = new MediaTrackingConfiguration(id, null);
+configuration.setPings(false);
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(configuration);`}
 </CodeBlock>)}</>
 
 Media ping events have the following schema:
@@ -378,6 +465,20 @@ let mediaTracking = tracker.media.startMediaTracking(configuration: configuratio
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val configuration = MediaTrackingConfiguration(
+    id = id,
+    session = false
+)
+val mediaTracking = tracker?.media?.startMediaTracking(configuration)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaTrackingConfiguration configuration = new MediaTrackingConfiguration(id, null);
+configuration.setSession(false);
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(configuration);`}
+</CodeBlock>)}</>
+
 #### Percentage progress events
 
 Percentage progress events are tracked when the playback reaches some percentage boundaries.
@@ -397,6 +498,20 @@ To send percentage progress events, set the percentage boundaries when they shou
     .boundaries([10, 25, 50, 75])
 let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
 `}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val configuration = MediaTrackingConfiguration(
+    id = id,
+    boundaries = listOf(10, 25, 50, 75),
+)
+val mediaTracking = tracker?.media?.startMediaTracking(configuration)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaTrackingConfiguration configuration = new MediaTrackingConfiguration(id, null);
+configuration.setBoundaries(Arrays.asList(10, 25, 50, 75));
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(configuration);`}
 </CodeBlock>)}</>
 
 Percentage progress events have the following schema:
@@ -421,6 +536,20 @@ startMediaTracking({ id, captureEvents: [MediaEventType.Play] });
     .captureEvents([MediaPlayEvent.self])
 let mediaTracking = tracker.media.startMediaTracking(configuration: configuration)
 `}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val configuration = MediaTrackingConfiguration(
+    id = id,
+    captureEvents = listOf(MediaPlayEvent::class)
+)
+val mediaTracking = tracker?.media?.startMediaTracking(configuration)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaTrackingConfiguration configuration = new MediaTrackingConfiguration(id, null);
+configuration.setCaptureEvents(Collections.singletonList(MediaPlayEvent.class));
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(configuration);`}
 </CodeBlock>)}</>
 
 #### Add context entities to all events
@@ -465,6 +594,32 @@ let mediaTracking = tracker.media.startMediaTracking(configuration: configuratio
 `}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val configuration = MediaTrackingConfiguration(
+    id = id,
+    entities = listOf(
+        SelfDescribingJson(
+            schema = "iglu:org.schema/video/jsonschema/1-0-0",
+            data = mapOf("creativeId" to "1234")
+        )
+    )
+)
+val mediaTracking = tracker?.media?.startMediaTracking(configuration)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaTrackingConfiguration configuration = new MediaTrackingConfiguration(id, null);
+configuration.setEntities(Collections.singletonList(
+        new SelfDescribingJson(
+                "iglu:org.schema/video/jsonschema/1-0-0",
+                new HashMap<String, Object>() {{
+                    put("creativeId", "1234");
+                }}
+        )
+));
+MediaTracking mediaTracking = tracker.getMedia().startMediaTracking(configuration);`}
+</CodeBlock>)}</>
+
 ## Updating playback properties
 
 Updates stored attributes of the media player such as the current playback.
@@ -489,6 +644,16 @@ updateMediaTracking({
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.update(player: MediaPlayer().currentTime(10.0))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.update(player = MediaPlayerEntity(currentTime = 10.0))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaPlayerEntity player = new MediaPlayerEntity();
+player.setCurrentTime(10.0);
+mediaTracking.update(player, null, null);`}
 </CodeBlock>)}</>
 
 ## Tracking media events
@@ -524,6 +689,16 @@ trackMediaSeekEnd({
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaSeekEndEvent(), media: MediaPlayer().currentTime(30.0)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaSeekEndEvent(), player = MediaPlayerEntity(currentTime = 30.0))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaPlayerEntity player = new MediaPlayerEntity();
+player.setCurrentTime(30.0);
+mediaTracking.track(new MediaSeekEndEvent(), player, null, null);`}
 </CodeBlock>)}</>
 
 #### Update ad and ad break properties
@@ -569,6 +744,26 @@ trackMediaAdStart({
 mediaTracking.track(MediaAdStartEvent(), ad: ad)`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val ad = MediaAdEntity(
+    adId = "1234",
+    name = "Podcast Ad",
+    creativeId = "4321",
+    duration = 15.0,
+    skippable = true
+)
+mediaTracking?.track(MediaAdStartEvent(), ad = ad)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaAdEntity ad = new MediaAdEntity("1234");
+ad.setName("Podcast Ad");
+ad.setCreativeId("4321");
+ad.setDuration(15.0);
+ad.setSkippable(true);
+mediaTracking.track(new MediaAdStartEvent(), null, ad, null);`}
+</CodeBlock>)}</>
+
 <>{(props.tracker == 'js-tag') && (<CodeBlock language="javascript">
 {`window.snowplow('trackMediaAdBreakStart', {
     id,
@@ -591,8 +786,7 @@ trackMediaAdBreakStart({
         podSize: 2, // The number of ads to be played within the ad break
         breakType: MediaPlayerAdBreakType.Linear, // Type of ads within the break
     }
-});
-`}
+});`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
@@ -601,6 +795,24 @@ trackMediaAdBreakStart({
     .podSize(2) // The number of ads to be played within the ad break
     .breakType(.linear) // Type of ads within the break
 mediaTracking.track(MediaAdBreakStartEvent(), adBreak: adBreak)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`val adBreak = MediaAdBreakEntity(
+    name = "pre-roll",
+    breakId = "2345",
+    podSize = 2,
+    breakType = MediaAdBreakType.Linear
+)
+mediaTracking?.track(MediaAdBreakStartEvent(), adBreak = adBreak)`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaAdBreakEntity adBreak = new MediaAdBreakEntity("2345");
+adBreak.setName("pre-roll");
+adBreak.setPodSize(2);
+adBreak.setBreakType(MediaAdBreakType.Linear);
+mediaTracking.track(new MediaAdBreakStartEvent(), null, null, adBreak);`}
 </CodeBlock>)}</>
 
 #### Add context entities to tracked event
@@ -643,7 +855,28 @@ trackMediaPlay({
         ]
     )
 ]))`}
+</CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaPlayEvent().entities(listOf(
+    SelfDescribingJson(
+        schema = "iglu:org.schema/video/jsonschema/1-0-0",
+        data = mapOf("creativeId" to "1234")
+    ),
+)))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(
+        new MediaPlayEvent().entities(Collections.singletonList(
+                new SelfDescribingJson(
+                        "iglu:org.schema/video/jsonschema/1-0-0",
+                        new HashMap<String, Object>() {{
+                            put("creativeId", "1234");
+                        }}
+                )
+        )), null, null, null
+);`}
 </CodeBlock>)}</>
 
 ### Available event types
@@ -664,6 +897,14 @@ Tracks a media player ready event that is fired when the media tracking is succe
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaReadyEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaReadyEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaReadyEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -687,6 +928,14 @@ Tracking this event will automatically set the `paused` property in the media pl
 {`mediaTracking.track(MediaPlayEvent())`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaPlayEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaPlayEvent(), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/play_event/jsonschema/1-0-0`.
 
@@ -706,6 +955,14 @@ Tracking this event will automatically set the `paused` property in the media pl
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaPauseEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaPauseEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaPauseEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -729,6 +986,14 @@ Tracking this event will automatically set the `ended` and `paused` properties i
 {`mediaTracking.track(MediaEndEvent())`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaEndEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaEndEvent(), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/end_event/jsonschema/1-0-0`.
 
@@ -750,6 +1015,14 @@ If multiple seek start events are tracked after each other (without a seek end e
 {`mediaTracking.track(MediaSeekStartEvent())`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaSeekStartEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaSeekStartEvent(), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/seek_start_event/jsonschema/1-0-0`.
 
@@ -767,6 +1040,14 @@ Tracks a media player seek end event sent when a seek operation completes.
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaSeekEndEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaSeekEndEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaSeekEndEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -800,6 +1081,14 @@ The `newRate` is passed when tracking the event and is automatically updated in 
 {`mediaTracking.track(MediaPlaybackRateChangeEvent(newRate: 1.5))`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaPlaybackRateChangeEvent(newRate = 1.5))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaPlaybackRateChangeEvent(null, 1.5), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/playback_rate_change_event/jsonschema/1-0-0`.
 
@@ -829,6 +1118,14 @@ The `newVolume` is passed when tracking the event and is automatically updated i
 {`mediaTracking.track(MediaVolumeChangeEvent(newVolume: 80))`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaVolumeChangeEvent(newVolume = 80))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaVolumeChangeEvent(null, 80), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/volume_change_event/jsonschema/1-0-0`.
 
@@ -854,6 +1151,14 @@ The `fullscreen` value is passed when tracking the event and is automatically up
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaFullscreenChangeEvent(fullscreen: true))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaFullscreenChangeEvent(fullscreen = true))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaFullscreenChangeEvent(true), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -883,6 +1188,14 @@ The `pictureInPicture` value is passed when tracking the event and is automatica
 {`mediaTracking.track(MediaPictureInPictureChangeEvent(pictureInPicture: true))`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaPictureInPictureChangeEvent(pictureInPicture = true))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaPictureInPictureChangeEvent(true), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/picture_in_picture_change_event/jsonschema/1-0-0`.
 
@@ -906,6 +1219,14 @@ Tracking this event will increase the counter of `adBreaks` in the session entit
 {`mediaTracking.track(MediaAdBreakStartEvent())`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdBreakStartEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdBreakStartEvent(), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_break_start_event/jsonschema/1-0-0`.
 
@@ -923,6 +1244,14 @@ Tracks a media player ad break end event that signals the end of an ad break.
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaAdBreakEndEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdBreakEndEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdBreakEndEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -944,6 +1273,14 @@ Tracking this event will increase the counter of `ads` in the session entity.
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaAdStartEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdStartEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdStartEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -973,6 +1310,14 @@ Tracking this event will increase the counter of `adsSkipped` in the session ent
 {`mediaTracking.track(MediaAdSkipEvent(percentProgress: 60))`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdSkipEvent(percentProgress = 33))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdSkipEvent(33), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_skip_event/jsonschema/1-0-0`.
 
@@ -998,6 +1343,14 @@ The event schema has one required property – it is set automatically to 25%:
 {`mediaTracking.track(MediaAdFirstQuartileEvent())`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdFirstQuartileEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdFirstQuartileEvent(), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_quartile_event/jsonschema/1-0-0`.
 
@@ -1021,6 +1374,14 @@ The event schema has one required property – it is set automatically to 50%:
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaAdMidpointEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdMidpointEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdMidpointEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -1049,6 +1410,14 @@ The event schema has one required property – it is set automatically to 75%:
 {`mediaTracking.track(MediaAdThirdQuartileEvent())`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdThirdQuartileEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdThirdQuartileEvent(), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_quartile/jsonschema/1-0-0`.
 
@@ -1066,6 +1435,14 @@ Tracks a media player ad complete event that signals the ad creative was played 
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaAdCompleteEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdCompleteEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdCompleteEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -1095,6 +1472,14 @@ Tracking this event will increase the counter of `adsClicked` in the session ent
 {`mediaTracking.track(MediaAdClickEvent(percentProgress: 30))`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdClickEvent(percentProgress = 33))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdClickEvent(33), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_click_event/jsonschema/1-0-0`.
 
@@ -1120,6 +1505,14 @@ The event schema has one optional property:
 {`mediaTracking.track(MediaAdPauseEvent(percentProgress: 30))`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdPauseEvent(percentProgress = 33))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdPauseEvent(33), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/ad_pause_event/jsonschema/1-0-0`.
 
@@ -1137,6 +1530,14 @@ Tracks a media player ad resume event fired when the user resumed playing the ad
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaAdResumeEvent(percentProgress: 30))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaAdResumeEvent(percentProgress = 33))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaAdResumeEvent(33), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -1162,6 +1563,14 @@ The tracker will calculate the time since this event until either the buffer end
 {`mediaTracking.track(MediaBufferStartEvent())`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaBufferStartEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaBufferStartEvent(), null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/buffer_start_event/jsonschema/1-0-0`.
 
@@ -1179,6 +1588,14 @@ Tracks a media player buffering end event fired when the the player finishes buf
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaBufferEndEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaBufferEndEvent())`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new MediaBufferEndEvent(), null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -1230,6 +1647,24 @@ The `newQuality` is passed when tracking the event and is automatically updated 
 ))`}
 </CodeBlock>)}</>
 
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaQualityChangeEvent(
+    newQuality = "1080p",
+    bitrate = 1000,
+    framesPerSecond = 60,
+    automatic = false
+))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaQualityChangeEvent event = new MediaQualityChangeEvent();
+event.setNewQuality("1080p");
+event.setBitrate(1000);
+event.setFramesPerSecond(60);
+event.setAutomatic(false);
+mediaTracking.track(event, null, null, null);`}
+</CodeBlock>)}</>
+
 *Schema:*
 `iglu:com.snowplowanalytics.snowplow.media/quality_change_event/jsonschema/1-0-0`.
 
@@ -1266,8 +1701,25 @@ The event schema has the following properties:
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
 {`mediaTracking.track(MediaErrorEvent(
     errorCode: "500",
+    errorName: "forbidden",
     errorDescription: "Failed to load media",
 ))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(MediaErrorEvent(
+    errorCode = "500",
+    errorName = "forbidden",
+    errorDescription = "Failed to load media"
+))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`MediaErrorEvent event = new MediaErrorEvent();
+event.setErrorCode("500");
+event.setErrorName("forbidden");
+event.setErrorDescription("Failed to load media");
+mediaTracking.track(event, null, null, null);`}
 </CodeBlock>)}</>
 
 *Schema:*
@@ -1303,4 +1755,20 @@ When tracked within the context of a media tracking, the tracker will attach the
     schema: "iglu:com.acme/event/jsonschema/1-0-0",
     payload: ["foo": "bar"]
 ))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
+{`mediaTracking?.track(SelfDescribing(
+    "iglu:com.acme/event/jsonschema/1-0-0",
+    mapOf("foo" to "bar")
+))`}
+</CodeBlock>)}</>
+
+<>{(props.tracker == 'android-java') && (<CodeBlock language="java">
+{`mediaTracking.track(new SelfDescribing(
+        "iglu:com.acme/event/jsonschema/1-0-0",
+        new HashMap<String, Object>() {{
+            put("foo", "bar");
+        }}
+), null, null, null);`}
 </CodeBlock>)}</>

--- a/docs/reusable/media/_index.md
+++ b/docs/reusable/media/_index.md
@@ -1,6 +1,7 @@
 ```mdx-code-block
 import CodeBlock from '@theme/CodeBlock';
 import TOCInline from '@theme/TOCInline';
+import Admonition from '@theme/Admonition';
 ```
 
 <!-- Note: Docusaurus mermaid theme does not yet support renderAsync required by the timeline diagram, so using a pre-built SVG -->
@@ -304,8 +305,17 @@ player.setVolume(100); // Volume level`}
 
 #### Media ping events
 
-Media ping events (not to be confused with page ping events, see below) are events sent in a regular interval while media tracking is active.
+Media ping events are events sent in a regular interval while media tracking is active.
 They inform about the current state of the media playback.
+
+<>{(props.tracker == 'js-browser' || props.tracker == 'js-tag') && (<>
+<Admonition type="info" title="Media pings vs page pings">
+  <p>
+    Media ping events are different events from the page ping events tracked by activity tracking in the tracker.
+    See the following section to read how page ping events are tracked during media playback.
+  </p>
+</Admonition>
+</>)}</>
 
 By default, ping events are sent every 30 seconds.
 This can be configured as follows:
@@ -683,12 +693,12 @@ The updated properties will apply for the current and all following events.
 {`import { trackMediaSeekEnd } from "@snowplow/browser-plugin-media";
 trackMediaSeekEnd({
     id,
-    media: { currentTime: 30.0 }
+    player: { currentTime: 30.0 }
 });`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
-{`mediaTracking.track(MediaSeekEndEvent(), media: MediaPlayerEntity().currentTime(30.0))`}
+{`mediaTracking.track(MediaSeekEndEvent(), player: MediaPlayerEntity().currentTime(30.0))`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">

--- a/docs/reusable/media/_index.md
+++ b/docs/reusable/media/_index.md
@@ -688,7 +688,7 @@ trackMediaSeekEnd({
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
-{`mediaTracking.track(MediaSeekEndEvent(), media: MediaPlayer().currentTime(30.0)`}
+{`mediaTracking.track(MediaSeekEndEvent(), media: MediaPlayer().currentTime(30.0))`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">

--- a/docs/reusable/media/_index.md
+++ b/docs/reusable/media/_index.md
@@ -249,7 +249,7 @@ startMediaTracking({
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
-{`let player = MediaPlayer()
+{`let player = MediaPlayerEntity()
     .currentTime(0) // The current playback time
     .duration(150.0) // A double-precision floating-point value indicating the duration of the media in seconds
     .ended(false) // If playback of the media has ended
@@ -643,7 +643,7 @@ updateMediaTracking({
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
-{`mediaTracking.update(player: MediaPlayer().currentTime(10.0))`}
+{`mediaTracking.update(player: MediaPlayerEntity().currentTime(10.0))`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
@@ -688,7 +688,7 @@ trackMediaSeekEnd({
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
-{`mediaTracking.track(MediaSeekEndEvent(), media: MediaPlayer().currentTime(30.0))`}
+{`mediaTracking.track(MediaSeekEndEvent(), media: MediaPlayerEntity().currentTime(30.0))`}
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'android-kotlin') && (<CodeBlock language="kotlin">
@@ -736,7 +736,7 @@ trackMediaAdStart({
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
-{`let ad = MediaAd(adId: "1234") // Unique identifier for the ad
+{`let ad = MediaAdEntity(adId: "1234") // Unique identifier for the ad
     .name("Podcast Ad") // Friendly name of the ad
     .creativeId("4321") // The ID of the ad creative
     .duration(15) // Length of the video ad in seconds
@@ -790,7 +790,7 @@ trackMediaAdBreakStart({
 </CodeBlock>)}</>
 
 <>{(props.tracker == 'ios') && (<CodeBlock language="swift">
-{`let adBreak = MediaAdBreak(breakId: "2345") // An identifier for the ad break
+{`let adBreak = MediaAdBreakEntity(breakId: "2345") // An identifier for the ad break
     .name("pre-roll") // Ad break name
     .podSize(2) // The number of ads to be played within the ad break
     .breakType(.linear) // Type of ads within the break

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -1,12 +1,12 @@
 export const versions = {
   // Trackers
-  androidTracker: '5.2.0',
+  androidTracker: '5.3.0',
   dotNetTracker: '1.2.1',
   cppTracker: '2.0.0',
   flutterTracker: '0.3.0',
   golangTracker: '3.0.0',
   googleAmpTracker: '1.1.0',
-  iosTracker: '5.2.0',
+  iosTracker: '5.3.0',
   javaTracker: '1.0.0',
   javaScriptTracker: '3.13.0',
   luaTracker: '0.2.0',


### PR DESCRIPTION
Adds code snippets to the media tracking documentation for iOS and Android. The same reusable component is used as for the JavaScript tracker docs.