### PR TITLE
Fix transactionError example missing total_quantity attribute

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/plugins/snowplow-ecommerce/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/plugins/snowplow-ecommerce/index.md
@@ -335,7 +335,8 @@ trackTransactionError({
     revenue: 45,
     currency: "EUR",
     transaction_id: "T12345",
-    payment_method: "card" 
+    payment_method: "card",
+    total_quantity: 1
   }
 });
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/plugins/snowplow-ecommerce/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/plugins/snowplow-ecommerce/index.md
@@ -314,7 +314,8 @@ window.snowplow("trackTransactionError:{trackerName}", {
     revenue: 45,
     currency: "EUR",
     transaction_id: "T12345",
-    payment_method: "card" 
+    payment_method: "card",
+    total_quantity: 1
   }
 });
 ```


### PR DESCRIPTION
Added the required `total_quantity` attribute on the `transactionError` example.
Fix #512 