### PR TITLE
docs: specify Include Original Self Describing Event

### DIFF
--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
@@ -58,14 +58,14 @@ Let's assume we have a self-describing event following the schema `iglu:com.acme
 
 In case the option to *Include Original Self Describing Event* is enabled, then the Snowplow client, if it finds the original event (see note below), will also include it in the common event, resulting in:
 
-```
-'x-sp-self_describing_event_com_acme_foobar_1': {
-    foo: 'bar'
+```json
+"x-sp-self_describing_event_com_acme_foobar_1": {
+    "foo": "bar"
 },
-'x-sp-self_describing_event': {
-    schema: 'iglu:com.acme/foobar/jsonschema/1-0-0',
-    data: {
-        foo: 'bar'
+"x-sp-self_describing_event": {
+    "schema": "iglu:com.acme/foobar/jsonschema/1-0-0",
+    "data": {
+        "foo": "bar"
     }
 }
 ```

--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
@@ -48,6 +48,30 @@ If using this Client to receive Snowplow Tracker events and then forward to a Sn
 
 By default, the self describing event will be "shredded" into a key using the schema name as the key, this is a "lossy" transformation, as the Minor and Patch parts of the jsonschema version will be dropped. This flag populates the original, lossless, Self Describing Event as `x-sp-self_describing_event`.
 
+Let's assume we have a self-describing event following the schema `iglu:com.acme/foobar/jsonschema/1-0-0`. By default, the option to *Include Original Self Describing Event* is disabled. So the Snowplow client by default will include it in the common event as:
+
+```
+'x-sp-self_describing_event_com_acme_foobar_1': {
+    foo: 'bar'
+}
+```
+
+In case the option to *Include Original Self Describing Event* is enabled, then the Snowplow client, if it finds the original event (see note below), will also include it in the common event, resulting in:
+
+```
+'x-sp-self_describing_event_com_acme_foobar_1': {
+    foo: 'bar'
+},
+'x-sp-self_describing_event': {
+    schema: 'iglu:com.acme/foobar/jsonschema/1-0-0',
+    data: {
+        foo: 'bar'
+    }
+}
+```
+
+Please note that this option only makes sense in using GTM as [**Server Side Tag Manager (pre-pipeline)**](https://docs.snowplow.io/docs/destinations/forwarding-events/google-tag-manager-server-side/#configuration-options) architecture because it only makes a difference when the input is a raw Snowplow event. In a [**Destinations Hub (post-pipeline)**](https://docs.snowplow.io/docs/destinations/forwarding-events/google-tag-manager-server-side/#configuration-options) architecture, this **option does not apply**. There — no matter how this option is configured — it is possible to access/filter data based only on self-describing data. In the above example, Destinations Hub would only contain 'x-sp-self_describing_event_com_acme_foobar_1', while the Server Side Tag Manager would include `x-sp-self_describing_event` in case the *Include Original Self Describing Event* is activated. 
+
 ### Include Original Contexts Array
 
 By default, the contexts will be "shredded" into separate keys using the context name as the key, this is a "lossy" transformation, as the Minor and Patch parts of the jsonschema version will be dropped. If you would like to keep the original "lossless" contexts array (as `x-sp-contexts`), enable this option.

--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
@@ -70,7 +70,13 @@ In case the option to *Include Original Self Describing Event* is enabled, then 
 }
 ```
 
-Please note that this option only makes sense in using GTM as [**Server Side Tag Manager (pre-pipeline)**](https://docs.snowplow.io/docs/destinations/forwarding-events/google-tag-manager-server-side/#configuration-options) architecture because it only makes a difference when the input is a raw Snowplow event. In a [**Destinations Hub (post-pipeline)**](https://docs.snowplow.io/docs/destinations/forwarding-events/google-tag-manager-server-side/#configuration-options) architecture, this **option does not apply**. There — no matter how this option is configured — it is possible to access/filter data based only on self-describing data. In the above example, Destinations Hub would only contain 'x-sp-self_describing_event_com_acme_foobar_1', while the Server Side Tag Manager would include `x-sp-self_describing_event` in case the *Include Original Self Describing Event* is activated. 
+:::note
+
+This option only makes sense when using GTM in a [**Server Side Tag Manager (pre-pipeline)**](/docs/destinations/forwarding-events/google-tag-manager-server-side/index.md#configuration-options) architecture, because it only makes a difference when the input is a _raw_ Snowplow event.
+
+In a [**Destinations Hub (post-pipeline)**](/docs/destinations/forwarding-events/google-tag-manager-server-side/index.md#configuration-options) architecture, this option **does not apply**. Effectively, it’s always disabled, regardless of the setting. In the example above, this would mean that the data will contain `x-sp-self_describing_event_com_acme_foobar_1`, but not`x-sp-self_describing_event`.
+
+:::
 
 ### Include Original Contexts Array
 

--- a/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
+++ b/docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
@@ -50,9 +50,9 @@ By default, the self describing event will be "shredded" into a key using the sc
 
 Let's assume we have a self-describing event following the schema `iglu:com.acme/foobar/jsonschema/1-0-0`. By default, the option to *Include Original Self Describing Event* is disabled. So the Snowplow client by default will include it in the common event as:
 
-```
-'x-sp-self_describing_event_com_acme_foobar_1': {
-    foo: 'bar'
+```json
+"x-sp-self_describing_event_com_acme_foobar_1": {
+    "foo": "bar"
 }
 ```
 


### PR DESCRIPTION
Edited @adatzer 's input from https://snplow.atlassian.net/browse/BCPF-657 as requested by me/client in [[com.vouchercodes] I would like to load my events to Google Tag Manager - Server-side #37763](https://snowplow.zendesk.com/agent/tickets/37763)