### PR TITLE
Document disableActivityTracking and disableActivityTrackingCallback

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracking-events/index.md
@@ -273,6 +273,38 @@ On the next interval after this call, a ping will be generated even if the user 
 
 This is particularly useful when a user is passively engaging with your content, e.g. watching a video.
 
+#### `disableActivityTracking`
+
+:::note
+Available since version 3.14 of the tracker.
+:::
+
+To disable activity tracking, you can use the `disableActivityTracking` method.
+
+```javascript
+import { disableActivityTracking } from '@snowplow/browser-tracker';
+
+disableActivityTracking();
+```
+
+Disabling activity tracking will stop page activity intervals and will not send additional activity tracking events.
+
+#### `disableActivityTrackingCallback`
+
+:::note
+Available since version 3.14 of the tracker.
+:::
+
+To disable the activity tracking callback, you can use the `disableActivityTrackingCallback` method.
+
+```javascript
+import { disableActivityTrackingCallback } from '@snowplow/browser-tracker';
+
+disableActivityTrackingCallback();
+```
+
+This will stop any further activity tracking callback from being executed.
+
 ### Tracking custom self-describing events
 
 ```mdx-code-block

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracking-events/index.md
@@ -255,6 +255,34 @@ On the next interval after this call, a ping will be generated even if the user 
 
 This is particularly useful when a user is passively engaging with your content, e.g. watching a video.
 
+#### `disableActivityTracking`
+
+:::note
+Available since version 3.14 of the tracker.
+:::
+
+To disable activity tracking, you can use the `disableActivityTracking` method.
+
+```javascript
+snowplow('disableActivityTracking');
+```
+
+Disabling activity tracking will stop page activity intervals and will not send additional activity tracking events.
+
+#### `disableActivityTrackingCallback`
+
+:::note
+Available since version 3.14 of the tracker.
+:::
+
+To disable the activity tracking callback, you can use the `disableActivityTrackingCallback` method.
+
+```javascript
+snowplow('disableActivityTracking');
+```
+
+This will stop any further activity tracking callback from being executed.
+
 ### Tracking custom self-describing events
 
 ```mdx-code-block


### PR DESCRIPTION
Document the new `disableActivityTracking` and `disableActivityTrackingCallback` [JS methods](https://github.com/snowplow/snowplow-javascript-tracker/pull/1224) to be released in JS tracker 3.14.