### PR TITLE
Add accelerators link to header

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -115,7 +115,6 @@ module.exports = {
             label: 'GitHub',
             position: 'left',
           },
-
           {
             to: 'https://try.snowplowanalytics.com/?utm_content=hero-cta&utm_campaign=snowplow-docs',
             label: 'Try Snowplow for free',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,13 +94,6 @@ module.exports = {
         },
         items: [
           {
-            type: 'doc',
-            docId: 'introduction',
-            position: 'left',
-            className: 'nav-link__first',
-            label: 'Docs',
-          },
-          {
             href: 'https://snowplow.io/data-product-accelerators/',
             label: 'Accelerators',
             position: 'left',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,6 +101,11 @@ module.exports = {
             label: 'Docs',
           },
           {
+            href: 'https://snowplow.io/data-product-accelerators/',
+            label: 'Accelerators',
+            position: 'left',
+          },
+          {
             href: 'https://discourse.snowplow.io',
             label: 'Discourse',
             position: 'left',
@@ -110,6 +115,7 @@ module.exports = {
             label: 'GitHub',
             position: 'left',
           },
+
           {
             to: 'https://try.snowplowanalytics.com/?utm_content=hero-cta&utm_campaign=snowplow-docs',
             label: 'Try Snowplow for free',

--- a/src/theme/NavbarItem/styles.module.css
+++ b/src/theme/NavbarItem/styles.module.css
@@ -17,7 +17,7 @@
   margin-right: 16px;
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 1131px) {
   :global(.navbar__inner) .customized {
     display: none !important;
   }

--- a/src/theme/NavbarItem/styles.module.css
+++ b/src/theme/NavbarItem/styles.module.css
@@ -17,8 +17,12 @@
   margin-right: 16px;
 }
 
-@media screen and (max-width: 1131px) {
+@media screen and (max-width: 1070px) {
   :global(.navbar__inner) .customized {
     display: none !important;
+  }
+
+  :global(.navbar__items .navbar__toggle) {
+    display: block !important;
   }
 }


### PR DESCRIPTION
This PR adds a link to the accelerators on the page header. 

Q: Do we need this link to the docs in the header? 

![image](https://github.com/snowplow/documentation/assets/87364579/fa2ce5a6-7ffa-4638-899c-9c8aa92c15e3)