### PR TITLE
Missing comma on JSON example

### DIFF
--- a/docs/understanding-tracking-design/managing-your-data-structures/iglu/index.md
+++ b/docs/understanding-tracking-design/managing-your-data-structures/iglu/index.md
@@ -31,7 +31,7 @@ First, design the schema for your custom event (or entity). For example:
      "type": "object",
      "properties": {
          "id": {
-             "type": "string"
+             "type": "string",
              "minLength": 1
          },
          "target": {


### PR DESCRIPTION
JSON at https://docs.snowplow.io/docs/understanding-tracking-design/managing-your-data-structures/iglu/#creating-a-schema is missing a comma here.

When trying to upload the schema to Iglu, it fails with a basic JSON structure error.

<img width="359" alt="image" src="https://github.com/snowplow/documentation/assets/3116331/fb85aa2f-7ce4-4d40-9365-717fd8628f1b">
