### PR TITLE
Add mui key

### DIFF
--- a/src/components/JsonSchemaValidator/index.js
+++ b/src/components/JsonSchemaValidator/index.js
@@ -50,11 +50,9 @@ export const ObjectFieldTemplateGroupsGenerator2 = () => (props) => {
           // filter to just the relevant props
           const childProps = getPropsForGroup2(groupNames[group], props)
           return (
-            <>
-              <Details summary={group}>
-                <ObjectFieldTemplates key={group} {...childProps} />
-              </Details>
-            </>
+            <Details key={group} summary={group}>
+              <ObjectFieldTemplates key={group} {...childProps} />
+            </Details>
           )
         })}
       </>

--- a/src/components/JsonSchemaValidator/index.js
+++ b/src/components/JsonSchemaValidator/index.js
@@ -12,9 +12,6 @@ import ReactMarkdown from 'react-markdown';
 
 import { DataGridPremium, GridToolbar, useGridApiRef, useKeepGroupedColumnsHidden, gridClasses, } from '@mui/x-data-grid-premium';
 
-import { LicenseInfo } from '@mui/x-license-pro';
-
-LicenseInfo.setLicenseKey('TODO: add the key here somehow');
 
 
 // Import all the schemas 

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -2,8 +2,10 @@ import React from 'react'
 import { getInitColorSchemeScript } from '@mui/material/styles'
 import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles'
 import theme from '@site/src/components/MuiTheme'
+import { LicenseInfo } from '@mui/x-license-pro';
 
 export default function Root({ children }) {
+  LicenseInfo.setLicenseKey("a3d6a1e3cdca760ace01b65d01608642Tz03MTE1NixFPTE3MjE1NDQ2NzEwMDAsUz1wcmVtaXVtLExNPXN1YnNjcmlwdGlvbixLVj0y");
   return (
     <>
       {getInitColorSchemeScript()}


### PR DESCRIPTION
This PR adds the MUI license to the root of the docs application. After a few attempts of setting the key from process.env I noticed that the key doesn't need to be kept secret (see [here](https://mui.com/x/introduction/licensing/#license-key-security)) which I think means this will suffice

_"The license key is checked without making any network requests—it's designed to be public. It's expected that the license key will be exposed in a JavaScript bundle; we simply ask licensed users not to actively publicize their license key."_

I also added a key to one of the components, think there's a few more that will need a similar change to suppress the errors!