### PR TITLE
Fix dead link to JS tracker plugins and add a listing of plugins on the plugins page

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/plugins/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/plugins/index.md
@@ -13,3 +13,9 @@ import ReleaseBadge from '@site/docs/reusable/javascript-tracker-release-badge-v
 The Browser Tracker is based around a plugin architecture which allows new functionality to be added to the tracker. These plugins can be installed from npm or you can write your own in your codebase and then they are passed into the tracker.
 
 There are a number of Snowplow maintained plugins, however you are also free to build your own or leverage community plugins too.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracker-setup/initialization-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracker-setup/initialization-options/index.md
@@ -383,7 +383,7 @@ If you’re planning on leveraging the context’s variation names, you’ll hav
 
 ### Other contexts
 
-There are many other context entities which can be added to your tracking, which are available as [plugins](https://github.com/snowplow/snowplow-javascript-tracker/tree/release/3.0.0/plugins).
+There are many other context entities which can be added to your tracking, which are available as [plugins](/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/plugins/index.md).
 
 ## JavaScript tracker-specific contexts
 


### PR DESCRIPTION
* Fixes a dead link to JS tracker plugins in the JS tracker initialization docs
* Adds a listing of plugins using doc cards on the plugins page