### PR TITLE
Remove users config

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.md
@@ -135,10 +135,6 @@ export const printSchemaVariables = (manifestSchema, scratchSchema, derivedSchem
       +schema: ${derivedSchema}
       scratch:
         +schema: ${scratchSchema}
-    users:
-      +schema: ${derivedSchema}
-      scratch:
-        +schema: ${scratchSchema}`}
         </CodeBlock>
     </>
   )


### PR DESCRIPTION
Config generator exposes a user schema which doesn't exist in Snowplow eCommerce models.