### PR TITLE
Add newSession call to the JS tracker docs

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracker-setup/additional-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracker-setup/additional-options/index.md
@@ -368,3 +368,26 @@ setReferrerUrl(document.referrer);
   </TabItem>
 </Tabs>
 
+## Starting a new session
+
+The tracker automatically tracks session information and implements session timeouts after which the session is reset.
+However, in case you want to trigger a new session manually (e.g., after logging out a user), you can use the `newSession` call to do that.
+This will expire the current session and start a new session.
+
+<Tabs groupId="platform" queryString>
+  <TabItem value="js" label="JavaScript (tag)" default>
+
+```javascript
+snowplow('newSession');
+```
+
+  </TabItem>
+  <TabItem value="browser" label="Browser (npm)">
+
+```javascript
+import { newSession } from '@snowplow/browser-tracker';
+
+newSession();
+```
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
Add docs for the `newSession` call in the JS tracker.