### PR TITLE
Add transform function note for field value redaction.

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracking-events/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracking-events/index.md
@@ -1733,6 +1733,13 @@ enableFormTracking({
   </TabItem>
 </Tabs>
 
+:::caution
+
+It is recommended that the `transform` function does not return a falsy value but a string even when the intention is to redact a value from being tracked.
+E.g. Send `"null"` over `null`.
+
+:::
+
 **Context**
 
 Context entities can be sent with all form tracking events by supplying them in an array in the `context` argument.


### PR DESCRIPTION
On web trackers v3, it is not possible to send a value of `null` or `undefined` directly into form submission field values.
In cases the client wants to redact a field on the transform function, it is recommended they use a string over a falsy value.