### PR TITLE
Update default value for the enable_mobile variable in unified

### DIFF
--- a/src/components/JsonSchemaValidator/Schemas/dbtUnified_0.1.2.js
+++ b/src/components/JsonSchemaValidator/Schemas/dbtUnified_0.1.2.js
@@ -594,7 +594,7 @@ export const Schema = {
       type: 'boolean',
       title: 'Enable Mobile Data',
       longDescription: 'Flag to process mobile events throughout the package.',
-      packageDefault: 'false',
+      packageDefault: 'true',
       group: 'Warehouse and Tracker',
     },
     snowplow__enable_web: {


### PR DESCRIPTION
This PR updates the default value in the documentation, which is incorrect - the mobile data is enabled by default