### PR TITLE
Update instructions for using React Native tracker both in React Native and native code

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/advanced-usage/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/advanced-usage/index.md
@@ -45,7 +45,7 @@ As an example, we have implemented this setup in a simple demo app [available he
 
 1. Adds a dependency for the React Native tracker [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/package.json#L3).
 2. Creates a tracker instance in the React Native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L5).
-3. Tracks a screen view event in the React Native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L90).
+3. Tracks a screen view event in the React Native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L9).
 4. Adds the Android tracker as a dependency in the Android app [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/build.gradle#L182-L183).
 5. Periodically tracks an event from the Android native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/src/main/java/com/snowplowanalytics/reactnativedemohybrid/MainActivity.java#L29-L37).
 6. Periodically tracks an event from the iOS native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/ios/snowplowreactnativedemohybrid/main.m#L9-L15).

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/advanced-usage/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/advanced-usage/index.md
@@ -34,11 +34,27 @@ removeAllTrackers();
 
 ## Accessing the tracker from native code
 
-Since the Snowplow React Native Tracker is a wrapper around the native trackers for iOS and Android, it is possible to access the underlying iOS and Android trackers in native iOS and Android code. For instance, you can instantiate a new tracker in React Native and track a new event in your Swift code within the same app.
+Since the Snowplow React Native Tracker is a wrapper around the native trackers for iOS and Android, it is possible to access the underlying iOS and Android trackers in native iOS and Android code. This allows you to:
+
+1. Instantiate a new tracker instance either in React Native or iOS/Android native code.
+2. Track events using the same tracker instance from both React Native code as well as iOS/Android native code.
+
+This is a better approach than creating a separate tracker instance for React Native and for native code because it enables all the events to share the same user and session identifiers.
+
+As an example, we have implemented this setup in a simple demo app [available here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid). The app does the following:
+
+1. Adds a dependency for the React Native tracker [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/package.json#L3).
+2. Creates a tracker instance in the React Native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L5).
+3. Tracks a screen view event in the React Native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L90).
+4. Adds the Android tracker as a dependency in the Android app [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/build.gradle#L182-L183).
+5. Periodically tracks an event from the Android native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/src/main/java/com/snowplowanalytics/reactnativedemohybrid/MainActivity.java#L29-L37).
+6. Periodically tracks an event from the iOS native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/ios/snowplowreactnativedemohybrid/main.m#L9-L15).
 
 When accessing the native tracker APIs in Swift, Objective-C, Java, or Kotlin, refer to the documentation for the [mobile trackers](/docs/collecting-data/collecting-from-own-applications/mobile-trackers/index.md).
 
+:::note
 Please note that in Android, you will need to add a dependency for the Android tracker to your `build.gradle` inside the Android codebase within your React Native app. Follow the instructions in the [mobile tracker documentation](/docs/collecting-data/collecting-from-own-applications/mobile-trackers/index.md). Make sure that you include the same version of the Android tracker as used by the React Native tracker.
+:::
 
 ### Example usage in the demo app
 

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/advanced-usage/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/advanced-usage/index.md
@@ -41,14 +41,14 @@ Since the Snowplow React Native Tracker is a wrapper around the native trackers 
 
 This is a better approach than creating a separate tracker instance for React Native and for native code because it enables all the events to share the same user and session identifiers.
 
-As an example, we have implemented this setup in a simple demo app [available here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid). The app does the following:
+As an example, we have implemented this setup in [a simple demo app](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid). The app does the following:
 
-1. Adds a dependency for the React Native tracker [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/package.json#L3).
-2. Creates a tracker instance in the React Native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L5).
-3. Tracks a screen view event in the React Native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L9).
-4. Adds the Android tracker as a dependency in the Android app [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/build.gradle#L182-L183).
-5. Periodically tracks an event from the Android native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/src/main/java/com/snowplowanalytics/reactnativedemohybrid/MainActivity.java#L29-L37).
-6. Periodically tracks an event from the iOS native code [here](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/ios/snowplowreactnativedemohybrid/main.m#L9-L15).
+1. [Adds a dependency](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/package.json#L3) for the React Native tracker.
+2. [Creates a tracker instance](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L5) in the React Native code.
+3. [Tracks a screen view event](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/App.tsx#L9) in the React Native code.
+4. [Adds the Android tracker as a dependency](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/build.gradle#L182-L183) in the Android app.
+5. [Periodically tracks an event](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/android/app/src/main/java/com/snowplowanalytics/reactnativedemohybrid/MainActivity.java#L29-L37) from the Android native code.
+6. [Periodically tracks an event](https://github.com/snowplow-incubator/snowplow-react-native-demo-hybrid/blob/main/ios/snowplowreactnativedemohybrid/main.m#L9-L15) from the iOS native code.
 
 When accessing the native tracker APIs in Swift, Objective-C, Java, or Kotlin, refer to the documentation for the [mobile trackers](/docs/collecting-data/collecting-from-own-applications/mobile-trackers/index.md).
 


### PR DESCRIPTION
Updates a section in React Native tracker docs for accessing the tracker from native code.