### PR TITLE
Update config generator package name from web to unified

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
@@ -48,7 +48,7 @@ export const printYamlVariables = (data) => {
   return(
     <>
       <h4>Project Variables:</h4>
-      <CodeBlock language="yaml">{dump({vars: {"snowplow_web": data}}, { flowLevel: 3 })}</CodeBlock>
+      <CodeBlock language="yaml">{dump({vars: {"snowplow_unified": data}}, { flowLevel: 3 })}</CodeBlock>
     </>
   )
 }


### PR DESCRIPTION
The config generator on the [unified](https://docs.snowplow.io/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/) page is set to web: this PR updates it to unified (I'm not certain this is the right way but the preview build looks correct)