### PR TITLE
Update variable name in docs for view user stitching

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-advanced-usage/dbt-user-mapping/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-advanced-usage/dbt-user-mapping/index.md
@@ -79,7 +79,7 @@ vars:
     snowplow__session_stitching: false
 ```
 
-In the unified package and also in the web package, since version 0.16.0, it is also possible to stitch onto the page views table by setting the value of `snowplow__page_view_stitching` to `true`. It may be enough to apply this with less frequency than on sessions to keep costs down, by only enabling this at runtime (on the command line) on only some of the runs.
+In the web and unified packages, since version 0.16.0, it is also possible to stitch onto the page views table by setting the value of `snowplow__page_view_stitching` (for web) or `snowplow__view_stitching` (for unified) to `true`. It may be enough to apply this with less frequency than on sessions to keep costs down, by only enabling this at runtime (on the command line) on only some of the runs.
 
 #### Cross platform stitching
 

--- a/src/components/JsonSchemaValidator/Schemas/dbtUnified_0.1.2.js
+++ b/src/components/JsonSchemaValidator/Schemas/dbtUnified_0.1.2.js
@@ -541,10 +541,10 @@ export const Schema = {
       },
       uniqueItems: true,
     },
-    snowplow__page_view_stitching: {
+    snowplow__view_stitching: {
       type: 'boolean',
-      title: 'Enable Page View Stitching',
-      longDescription: 'Determines whether to apply the user mapping to the page views table. Note this can be an expensive operation to do every run. One way to mitigate this is by running this update with less frequency than your usual run by enabling this variable only for that specific run. Please see the [User Mapping](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-advanced-usage/dbt-user-mapping/) section for more details.',
+      title: 'Enable View Stitching',
+      longDescription: 'Determines whether to apply the user mapping to the views table. Note this can be an expensive operation to do every run. One way to mitigate this is by running this update with less frequency than your usual run by enabling this variable only for that specific run. Please see the [User Mapping](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-advanced-usage/dbt-user-mapping/) section for more details.',
       packageDefault: 'false',
       group: 'Operation and Logic',
     },


### PR DESCRIPTION
This PR updates some references to the `snowplow__page_view_stitching` variable (web model variable name) in the unified docs to `snowplow__view_stitching` instead