### PR TITLE
Remove pagination and add quick links at top of page

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.mdx
@@ -75,7 +75,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetter output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.mdx
@@ -81,4 +81,9 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
 <MyMdxComponent/>

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/fractribution/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/fractribution/index.mdx
@@ -51,7 +51,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetter output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/fractribution/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/fractribution/index.mdx
@@ -57,4 +57,9 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
 <MyMdxComponent/>

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/media-player/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/media-player/index.mdx
@@ -77,4 +77,9 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
 <MyMdxComponent/>

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/media-player/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/media-player/index.mdx
@@ -71,7 +71,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetter output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/mobile/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/mobile/index.mdx
@@ -80,4 +80,9 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
 <MyMdxComponent/>

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/mobile/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/mobile/index.mdx
@@ -74,7 +74,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetter output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/normalize/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/normalize/index.mdx
@@ -61,4 +61,9 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
 <MyMdxComponent/>

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/normalize/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/normalize/index.mdx
@@ -55,7 +55,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetter output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
@@ -75,7 +75,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetterWSeeds output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
@@ -81,4 +81,10 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
+
 <MyMdxComponent/>

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/utils/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/utils/index.mdx
@@ -58,4 +58,9 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
 <MyMdxComponent/>

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/utils/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/utils/index.mdx
@@ -52,7 +52,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetter output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/web/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/web/index.mdx
@@ -75,7 +75,7 @@ export const MyMdxComponent = () => {
             <p>You can use the below inputs to generate the code that you need to place into your <code>dbt_project.yml</code> file to configure the package as you require. Any values not specified will use their default values from the package.</p>
         </JsonSchemaGenerator>
         <DbtSchemas/>
-        <h2 id="schemas">Ouput Schemas</h2> 
+        <h2 id="schemas">Output Schemas</h2> 
         <SchemaSetterWSeeds output={printSchemaVariables} />
       </DbtCongfigurationPage>
     );

--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/web/index.mdx
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/web/index.mdx
@@ -81,4 +81,9 @@ export const MyMdxComponent = () => {
     );
   };
 
+<Admonition icon="" title = "Contents">
+  <a href="#Variables">Variables Definitions</a><br/>
+  <a href="#Generator">Config Generator</a><br/>
+  <a href="#schemas">Schema Generator</a>
+</Admonition>
 <MyMdxComponent/>

--- a/src/components/JsonSchemaValidator/index.js
+++ b/src/components/JsonSchemaValidator/index.js
@@ -203,7 +203,6 @@ export function JsonToTable({ children, versionedSchema }) {
               includeHeaders: true,
             }}
             getRowHeight={() => 'auto'}
-            pagination
             pageSizeOptions={[5, 10, 25, 50, 100]}
             rows={rows
               .filter(row => row.group === header) // Filter rows based on 'group' property


### PR DESCRIPTION
Using pagination means it can be hard to search for the variable you want on the page, especially as we split them into different tables. This ensures all variables are visible and loading on the page.

As this can lead to quite long pages, I had added quick links to the top of the page - note it is _technically_ possible to force a true sidebar table of contents on the page, I think these pages benefit from the extra width so took this approach.