### PR TITLE
Mobile trackers v6 migration guide

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
@@ -15,7 +15,7 @@ These changes probably won't break your app code, but they will affect the event
 
 Affects: iOS ✅ Android ✅
 
-Lifecycle autotracking ADD LINK is now on by default, for both trackers. This is because it's a prerequisite for the new screen engagement ADD LINK tracking, which is also on by default.
+[Lifecycle autotracking](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/lifecycle-tracking/index.md) is now on by default, for both trackers. This is because it's a prerequisite for the new [screen engagement tracking](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/screen-tracking/index.md#screen-engagement-tracking), which is also on by default.
 
 ### Removed properties from platform context entity
 
@@ -23,13 +23,13 @@ Affects: iOS ✅ Android ❌
 
 To comply with Apple's Privacy Manifest rules, we have removed the automatic tracking of `totalStorage` and `availableStorage` metrics from the [platform context entity](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/platform-and-application-context/index.md). We've also added a Privacy Manifest for the SDK.
 
-To track `totalStorage` or `availableStorage`, use the new `PlatformContextRetriever` callbacks class (see below).
+To track `totalStorage` or `availableStorage`, use the new `PlatformContextRetriever` callbacks class to configure the platform context entity.
 
 ### Preventing unnecessary ScreenView event
 
 Affects: iOS ❌ Android ✅
 
-Previously a screen view event was tracked again by the screen view autotracking ADD LINK feature when the app moved to foreground. This is not expected because the screen doesn't change when the app is in background, and it is not consistent with how the screen view autotracking works on iOS. The extra event will no longer be tracked.
+Previously a screen view event was tracked again by the [screen view autotracking](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/screen-tracking/index.md) feature when the app moved to foreground. This is not expected because the screen doesn't change when the app is in background, and it is not consistent with how the screen view autotracking works on iOS. The extra event will no longer be tracked.
 
 ### Event entities API
 
@@ -43,7 +43,7 @@ There's no change to the behaviour of the variable `entities`, so you could stil
 
 Affects: iOS ✅ Android ✅
 
-In both trackers, we have changed how the `EmitterConfiguration` options `bufferOption` and `emitRange` are used, as well as changing the defaults. Read more about that here ADD LINK. The `BufferOption.defaultGroup` has been renamed to `BufferOption.SmallGroup`. 
+In both trackers, we have changed how the `EmitterConfiguration` options `bufferOption` and `emitRange` are used, as well as changing the defaults. Read more about that [here](docs/collecting-data/collecting-from-own-applications/mobile-trackers/configuring-how-events-are-sent/index.md#configuring-how-many-events-to-send-in-one-request). The `BufferOption.defaultGroup` has been renamed to `BufferOption.SmallGroup`.
 
 Network requests are now made serially. If you are using a custom `EmitterConfiguration.emitRange`, you may wish to set it to a lower value. The new default `emitRange` is 25 (down from 150).
 
@@ -75,11 +75,11 @@ See the full changelog on Github, for iOS ADD LINK and Android ADD LINK.
 
 ### New events
 
-The screen engagement ADD LINK feature adds new events for both iOS and Android. For iOS only, there are new events (and a new demo app) for visionOS ADD LINK. For Android, the `PageView` event has been restored, after accidental deprecation in v5.
+The [screen engagement](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/screen-tracking/index.md#screen-engagement-tracking) feature adds new events for both iOS and Android. For iOS only, there are new events (and a new demo app) for [visionOS](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/visionos/index.md). For Android, the `PageView` event has been restored, after accidental deprecation in v5.
 
 ### Cross-navigation tracking
 
-Decorate URIs with user and session information in both trackers using the new `CrossDeviceParameterConfiguration`. ADD LINK This is the equivalent of cross-domain tracking for web.
+Decorate URIs with [user and session information](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/session-tracking/index.md#decorating-outgoing-links-using-cross-navigation-tracking) in both trackers using the new `CrossDeviceParameterConfiguration`. This is the equivalent of cross-domain tracking for web.
 
 ### Access to `EventStore` in iOS tracker
 
@@ -91,11 +91,11 @@ The custom event and entity classes `SelfDescribing` and `SelfDescribingJson` no
 
 ### Provide custom values to platform context entity
 
-As mentioned above, the new `PlatformContextRetriever` callbacks class allows you to override any platform entity properties. The `PlatformContextRetriever` is available for both iOS and Android. ADD LINK
+As mentioned above, the new `PlatformContextRetriever` callbacks class allows you to override any [platform entity](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/platform-and-application-context/index.md#overriding-platform-context-properties) properties. The `PlatformContextRetriever` is available for both iOS and Android.
 
 ### Emitter and network connection behaviour
 
-The Android tracker default emit timeout has been increased to 30 seconds, from 5 seconds. This setting is configured ADD LINK using the `NetworkConfiguration`. The `timeout` option has been added to the iOS tracker.
+The Android tracker default emit timeout has been increased to 30 seconds, from 5 seconds. This setting is configured using `NetworkConfiguration`. The `timeout` configuration option has been added to the iOS tracker.
 
 In both trackers, the internal `Emitter` constructor has been updated. The change moves the namespace and event store into the constructor, enabling removing some optionals, and makes the properties immutable and safer.
 

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
@@ -71,7 +71,7 @@ For the Android tracker, we have updated the `EventStore` interface to remove th
 
 ## Other changes
 
-See the full changelog on Github, for iOS ADD LINK and Android ADD LINK.
+See the full changelog on Github, for [iOS](https://github.com/snowplow/snowplow-ios-tracker/releases/tag/6.0.0) and [Android](https://github.com/snowplow/snowplow-android-tracker/releases/tag/6.0.0).
 
 ### New events
 

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
@@ -1,0 +1,67 @@
+---
+title: "From version 5.x to 6.0"
+sidebar_position: -7
+---
+
+# Migration guide from version 5.x to 6.0
+
+There were a few breaking changes within the new features and updates in v6, for both iOS and Android.
+
+## Changes to events
+
+These changes probably won't affect your app code, but they will affect the events generated.
+
+### Lifecycle autotracking
+
+Lifecycle autotracking is now on by default, for both trackers. This is because it's a prerequisite for the new screen engagement tracking, which is also on by default.
+
+### Platform context entity (iOS only)
+
+To comply with 
+
+
+
+TODO
+
+Although the trackers underwent a huge internal rewrite (from Objective-C to Swift and from Java to Kotlin), we tried to keep the API with as little breaking changes as possible.
+
+## iOS tracker
+
+The supported platforms have changed on the iOS tracker:
+
+* Minimum iOS deployment target changed from 9.0 to 11.0.
+* On macOS, from 10.10 to 10.13.
+* On tvOS, from 9.0 to 12.0.
+* On watchOS, from 2.0 to 6.0.
+
+Additionally, there is a new way to enable tracking the IDFA identifier – instead of adding the `SNOWPLOW_IDFA_ENABLED` compiler flag, one now needs to implement a callback (`TrackerConfiguration.advertisingIdentifierRetriever`) that retrieves the value. See the [documentation for more information](../../tracking-events/platform-and-application-context/index.md#identifier-for-advertisers-idfaaaid).
+
+If using `EmitterConfiguration` when creating a new tracker, the default buffer option configuration changed from `single` (max 1 event per batch) to `default` (max 10 events per batch). If not using an `EmitterConfiguration`, the buffer option was set to `default` also in tracker v4.
+
+## Android tracker
+
+We adopted using Kotlin properties instead of Java fields for public properties of the event classes. This doesn't change the API in Kotlin. On the other hand, in Java, the properties are now accessible through getter and setter methods instead of directly as Java fields.
+
+For example, to set the true timestamp of events in Java the API changes as follows:
+
+```java
+// v4 API:
+event.trueTimestamp = 123456789L; // doesn't work anymore
+// v5 API:
+event.setTrueTimestamp(123456789L);
+```
+
+However, the API hasn't changed if you use the builder methods to set the properties. For example, this approach works in both the v4 and v5 tracker:
+
+```java
+// works both in v4 and v5 API:
+event.trueTimestamp(123456789L);
+```
+
+If using `EmitterConfiguration` when creating a new tracker, the default buffer option configuration changed from `single` (max 1 event per batch) to `default` (max 10 events per batch). If not using an `EmitterConfiguration`, the buffer option was set to `default` also in tracker v4.
+
+## Renaming contexts to entities
+
+The `contexts` property in events used to assign custom context entities to events has been renamed to `entities`. The previous naming is still available but it is deprecated.
+
+In the Android tracker, the `customContexts` property in events has been deprecated in favor of the `entities` property.

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
@@ -5,7 +5,7 @@ sidebar_position: -7
 
 # Migration guide from version 5.x to 6.0
 
-There were a few breaking changes within v6, for both iOS and Android. These are described here, with a quick summary of the non-breaking changes at the end.
+There were a few breaking changes within v6, for both iOS and Android. These are described here, with a quick summary of the rest of the changelog at the end.
 
 ## Changes to events
 
@@ -13,61 +13,73 @@ These changes probably won't break your app code, but they will affect the event
 
 ### Lifecycle autotracking
 
+Affects: iOS ✅ Android ✅
+
 Lifecycle autotracking ADD LINK is now on by default, for both trackers. This is because it's a prerequisite for the new screen engagement ADD LINK tracking, which is also on by default.
 
-### Platform context entity (iOS only)
+### Removed properties from platform context entity
+
+Affects: iOS ✅ Android ❌
 
 To comply with Apple's Privacy Manifest rules, we have removed the automatic tracking of `totalStorage` and `availableStorage` metrics from the [platform context entity](docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/platform-and-application-context/index.md). We've also added a Privacy Manifest for the SDK.
 
-To track `totalStorage` or `availableStorage`, use the new `PlatformContextRetriever` callbacks class. The `PlatformContextRetriever` is available for both iOS and Android. It allows you to override any platform entity properties.
+To track `totalStorage` or `availableStorage`, use the new `PlatformContextRetriever` callbacks class (see below).
 
-### Preventing unnecessary ScreenView event for Android
+### Preventing unnecessary ScreenView event
+
+Affects: iOS ❌ Android ✅
 
 Previously a screen view event was tracked again by the screen view autotracking ADD LINK feature when the app moved to foreground. This is not expected because the screen doesn't change when the app is in background, and it is not consistent with how the screen view autotracking works on iOS. The extra event will no longer be tracked.
 
-### Event entities API for iOS
+### Event entities API
+
+Affects: iOS ✅ Android ❌
 
 To standardise the behaviour between trackers, we've changed how the `entities()` method of all events works on iOS. Previously, calling `event.entities(newListEntities)` replaced all the context entities currently attached to the event. Now, the new entities are appended instead.
 
 There's no change to the behaviour of the variable `entities`, so you could still replace them all using `event.entities = newListEntities`.
 
-## Non-optional tracker on iOS
+## Event batching
+
+Affects: iOS ✅ Android ✅
+
+In both trackers, we have changed how the `EmitterConfiguration` options `bufferOption` and `emitRange` are used, as well as changing the defaults. Read more about that here ADD LINK. The `BufferOption.defaultGroup` has been renamed to `BufferOption.SmallGroup`. 
+
+Network requests are now made serially. If you are using a custom `EmitterConfiguration.emitRange`, you may wish to set it to a lower value. The new default `emitRange` is 25 (down from 150).
+
+## Non-optional tracker
+
+Affects: iOS ✅ Android ❌
 
 In the v5.x of the iOS tracker, `createTracker` returned an optional `TrackerController?`. This was an oversight. In v6, the iOS tracker again returns a non-optional `TrackerController`.
 
-## Concurrency on iOS
+## `Tracker.track()` return type
 
-The return type of the `Tracker.track()` method has changed from `UUID?` to `UUID`. Previously, `nil` could be returned if the tracker was paused, or if the event was filtered out and not actually tracked. From v6 onwards it will always return a UUID. If the event is tracked, this will be the `eventId`.
+Affects: iOS ✅ Android ❌
+
+The return type of the `Tracker.track()` method has changed from `UUID?` to `UUID` on iOS. Previously, `nil` could be returned if the tracker was paused, or if the event was filtered out and not actually tracked. From v6 onwards it will always return a UUID. If the event is tracked, this will be the `eventId`.
 
 This change was necessary as part of the comprehensive refactoring of the tracker thread model. The iOS tracker now uses a global dispatch queue. This single queue makes the tracker much safer. Almost all actions are now performed concurrently. Network requests in Emitter are still asynchronous.
 
 ## Changes to the `EventStore` interface
 
+Affects: iOS ✅ Android ✅
+
 A new method, `removeOldEvents()` has been added to the `EventStore` protocol on both trackers. This method is used in the new feature that deletes events from storage if they get too old (by default, 30 days). Also, if too many events collect in the `EventStore`, the older ones will be deleted (default 1000 events).
 
 For the Android tracker, we have updated the `EventStore` interface to remove the optional types.
 
-## Non-breaking changes and bug fixes
+## Other changes
+
+See the full changelog on Github, for iOS ADD LINK and Android ADD LINK.
 
 ### New events
 
 The screen engagement ADD LINK feature adds new events for both iOS and Android. For iOS only, there are new events (and a new demo app) for visionOS ADD LINK. For Android, the `PageView` event has been restored, after accidental deprecation in v5.
 
-### Cross-device tracking
+### Cross-navigation tracking
 
-Decorate URIs in both trackers using the new `CrossDeviceParameterConfiguration`. ADD LINK 
-
-### Emitter and network connection behaviour
-
-The Android tracker default emit timeout has been increased to 30 seconds, from 5 seconds. This setting is configured ADD LINK using the `NetworkConfiguration`. The `timeout` option has been added to the iOS tracker.
-
-In both trackers, we have officially set the default batch size to 1 (`BufferOption.Single`), i.e. the events are sent as soon as they are tracked. This is consistent with the web tracker, and is a good default to use in client side apps to prevent some events hanging in the event store when the app is quit/uninstalled earlier than the event store is cleared. In theory, the previous behaviour was to send batches of 10 (`BufferOption.SmallGroup`), but due to a bug, they were always sent individually. We've also fixed a bug in which the `bufferOption` in `EmitterConfiguration` was not being used correctly, making it impossible to batch events. This is now possible.
-
-For Android, we've increased the number of threads in the `Executor` thread pool. The thread count is now properly configurable.
-
-For both trackers, network requests are now made serially. The new behaviour updates how the `EmitterConfiguration.emitRange` configuration is used – it now tells how many events should be added to one request. The new default `emitRange` is 25.
-
-In both trackers, the internal `Emitter` constructor has been updated. The change moves the namespace and event store into the constructor, enabling removing some optionals, and makes the properties immutable and safer.
+Decorate URIs with user and session information in both trackers using the new `CrossDeviceParameterConfiguration`. ADD LINK This is the equivalent of cross-domain tracking for web.
 
 ### Access to `EventStore` in iOS tracker
 
@@ -76,6 +88,16 @@ The `EventStore` is now exposed as part of the `EmitterController`, allowing acc
 ### Codable structs in the iOS tracker
 
 The custom event and entity classes `SelfDescribing` and `SelfDescribingJson` now accept data represented using `Encodable` structs. This alllows you to define the data using typed structs, and track that directly instead of using untyped dictionaries.
+
+### Provide custom values to platform context entity
+
+As mentioned above, the new `PlatformContextRetriever` callbacks class allows you to override any platform entity properties. The `PlatformContextRetriever` is available for both iOS and Android. ADD LINK
+
+### Emitter and network connection behaviour
+
+The Android tracker default emit timeout has been increased to 30 seconds, from 5 seconds. This setting is configured ADD LINK using the `NetworkConfiguration`. The `timeout` option has been added to the iOS tracker.
+
+In both trackers, the internal `Emitter` constructor has been updated. The change moves the namespace and event store into the constructor, enabling removing some optionals, and makes the properties immutable and safer.
 
 ### Removed FMDB dependency for iOS
 

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/lifecycle-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/lifecycle-tracking/index.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 The tracker can capture application lifecycle state changes. In particular, when the app changes state from foreground to background and vice versa.
 
-The lifecycle tracking is disabled by default. It can be enabled in `TrackerConfiguration` like in the example below:
+The lifecycle tracking is enabled by default (since v6.0.0). It can be configured in `TrackerConfiguration` like in the example below:
 
 <Tabs groupId="platform" queryString>
   <TabItem value="ios" label="iOS" default>

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/screen-tracking/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/screen-tracking/index.md
@@ -132,7 +132,7 @@ The `Screen` entity is conditioned by the internal state of the tracker only. To
 
 Indeed, disabling the `screenViewAutotracking` only, the tracker can still attach `Screen` entities automatically based only to the manual tracking of `ScreenView` events, and vice versa.
 
-## Screen engagemement tracking
+## Screen engagement tracking
 
 :::note Available since version 6
 This feature has been added in the version 6.0.0 of the iOS and Android trackers.


### PR DESCRIPTION
There are some placeholders for links needed to other parts of the docs. Once the other v6 features have been merged into this base branch I'll rebase and add all the links.