### PR TITLE
Lake Loader 0.3.0

### DIFF
--- a/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_biglake_config.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_biglake_config.md
@@ -1,32 +1,36 @@
 <tr>
+    <td><code>output.good.type</code></td>
+    <td>Required, set this to <code>Iceberg</code>.</td>
+</tr>
+<tr>
+    <td><code>output.good.catalog.type</code></td>
+    <td>Required, set this to <code>BigLake</code></td>
+</tr>
+<tr>
     <td><code>output.good.location</code></td>
     <td>Required, e.g. <code>gs://mybucket/</code>.  URI of the bucket location to which to write Snowplow enriched events in Iceberg format.  The URI should start with <code>gs://</code>.</td>
 </tr>
 <tr>
-    <td><code>output.good.project</code></td>
-    <td>Required. The GCP project hosting BigLake</td>
-</tr>
-<tr>
-    <td><code>output.good.catalog</code></td>
-    <td>Required. The name of the BigLake catalog</td>
-</tr>
-<tr>
     <td><code>output.good.database</code></td>
-    <td>Required. The name of the database in the BigLake catalog</td>
+    <td>Required. Name of the database in the BigLake catalog</td>
 </tr>
 <tr>
     <td><code>output.good.table</code></td>
     <td>Required. The name of the table in the BigLake database</td>
 </tr>
 <tr>
-    <td><code>output.good.connection</code></td>
-    <td>Required. The name of the BigQuery connection which has permissions to access the lake</td>
+    <td><code>output.good.catalog.project</code></td>
+    <td>Required. The GCP project owning the BigLake catalog</td>
 </tr>
 <tr>
-    <td><code>output.good.bqDataset</code></td>
-    <td>Required. The name of the BigQuery dataset to contain the Iceberg BigLake table</td>
+    <td><code>output.good.catalog.name</code></td>
+    <td>Required. The name of the BigLake catalog</td>
 </tr>
 <tr>
-    <td><code>output.good.region</code></td>
-    <td>Required. GCP region of the BigLake</td>
+    <td><code>output.good.catalog.region</code></td>
+    <td>Required. GCP region of the BigLake catalog</td>
+</tr>
+<tr>
+    <td><code>output.good.catalog.options.*</code></td>
+    <td>Optional. A map of key/value strings which are passed to the catalog configuration.</td>
 </tr>

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_glue_config.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_glue_config.md
@@ -1,0 +1,27 @@
+<tr>
+    <td><code>output.good.type</code></td>
+    <td>Required, set this to <code>Iceberg</code></td>
+</tr>
+<tr>
+    <td><code>output.good.catalog.type</code></td>
+    <td>Required, set this to <code>Glue</code></td>
+</tr>
+<tr>
+    <td><code>output.good.location</code></td>
+    <td>Required, e.g. <code>s3a://mybucket/events</code>.  URI of the bucket location to which to write Snowplow enriched events in Iceberg format.  The URI should start with <code>s3a://</code></td>
+</tr>
+<tr>
+    <td><code>output.good.database</code></td>
+    <td>Required. Name of the database in the Glue catalog</td>
+</tr>
+<tr>
+    <td><code>output.good.table</code></td>
+    <td>Required. The name of the table in the Glue database</td>
+</tr>
+<tr>
+    <td><code>output.good.catalog.options.*</code></td>
+    <td>
+    Optional. A map of key/value strings which are passed to the catalog configuration.
+    These can be anything <a href="https://iceberg.apache.org/docs/latest/aws/" target="_blank">from the Iceberg catalog documentation</a> e.g. <code>"glue.id": "1234567"</code>
+    </td>
+</tr>

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_glue_config.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_glue_config.md
@@ -1,3 +1,7 @@
+```mdx-code-block
+import Link from '@docusaurus/Link';
+```
+
 <tr>
     <td><code>output.good.type</code></td>
     <td>Required, set this to <code>Iceberg</code></td>
@@ -22,6 +26,6 @@
     <td><code>output.good.catalog.options.*</code></td>
     <td>
     Optional. A map of key/value strings which are passed to the catalog configuration.
-    These can be anything <a href="https://iceberg.apache.org/docs/latest/aws/" target="_blank">from the Iceberg catalog documentation</a> e.g. <code>"glue.id": "1234567"</code>
+    These can be anything <Link to="https://iceberg.apache.org/docs/latest/aws/">from the Iceberg catalog documentation</Link> e.g. <code>"glue.id": "1234567"</code>
     </td>
 </tr>

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/index.md
@@ -11,6 +11,7 @@ import TabItem from '@theme/TabItem';
 import DeltaConfig from '@site/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_delta_config.md';
 import HudiConfig from '@site/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_hudi_config.md';
 import IcebergBigLakeConfig from '@site/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_biglake_config.md';
+import IcebergGlueConfig from '@site/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_iceberg_glue_config.md';
 import PubsubConfig from '@site/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_pubsub_config.md';
 import KinesisConfig from '@site/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_kinesis_config.md';
 import KafkaConfig from '@site/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/configuration-reference/_kafka_config.md';
@@ -37,6 +38,37 @@ import Admonition from '@theme/Admonition';
     </table>
   </TabItem>
 
+  <TabItem value="iceberg-glue" label="Iceberg / Glue">
+    <table>
+        <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+          <IcebergGlueConfig/>
+        </tbody>
+    </table>
+  </TabItem>
+
+  <TabItem value="iceberg-biglake" label="Iceberg / BigLake">
+    <Admonition type="note" title="Alternative Docker image">
+    To use the Lake Loader with BigLake support, pull the <code>snowplow/lake-loader-gcp:{`${versions.lakeLoader}`}-biglake</code> image from Docker Hub.
+    </Admonition>
+    <table>
+        <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+          <IcebergBigLakeConfig/>
+        </tbody>
+    </table>
+  </TabItem>
+
   <TabItem value="hudi" label="Hudi">
     <Admonition type="note" title="Alternative Docker image">
     To use the Lake Loader with Hudi support, pull the appropriate alternative image from Docker Hub:
@@ -59,42 +91,6 @@ import Admonition from '@theme/Admonition';
     </table>
   </TabItem>
 
-  <TabItem value="iceberg-biglake" label="Iceberg / BigLake">
-    <Admonition type="note" title="Alternative Docker image">
-    To use the Lake Loader with BigLake support, pull the <code>snowplow/lake-loader-gcp:{`${versions.lakeLoader}`}-biglake</code> image from Docker Hub.
-    </Admonition>
-    <table>
-        <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Description</th>
-            </tr>
-        </thead>
-        <tbody>
-          <IcebergBigLakeConfig/>
-        </tbody>
-    </table>
-  </TabItem>
-
-  <TabItem value="iceberg-glue" label="Iceberg / Glue">
-
-:::note Coming soon
-
-A future release of Lake Loader will add support for [AWS Glue as an Iceberg catalog](https://docs.aws.amazon.com/glue/).
-
-:::
-
-  </TabItem>
-
-  <TabItem value="iceberg-snowflake" label="Iceberg / Snowflake">
-
-:::note Coming soon
-
-A future release of Lake Loader will add support for [Snowflake as an Iceberg catalog](https://docs.snowflake.com/en/user-guide/tables-iceberg).
-
-:::
-
-  </TabItem>
 </Tabs>
 
 ### Streams configuration

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/lake-loader/index.md
@@ -19,7 +19,7 @@ The Lake Loader is an application that loads Snowplow events to a cloud storage 
 
 The Lake Loader supports the three major Open Table Formats: [Delta](https://delta.io/), [Iceberg](https://iceberg.apache.org/) and [Hudi](https://hudi.apache.org/).
 
-Currently, for Iceberg tables, the loader supports [BigLake](https://cloud.google.com/bigquery/docs/iceberg-tables) as a catalog.  Future releases will add support for [AWS Glue](https://docs.aws.amazon.com/glue/) and [Snowflake](https://docs.snowflake.com/en/user-guide/tables-iceberg) as an Iceberg catalog.
+For Iceberg tables, the loader supports [AWS Glue](https://docs.aws.amazon.com/glue/) and [GCP BigLake](https://cloud.google.com/bigquery/docs/iceberg-tables) as Iceberg catalogs.
 
 :::
 

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -36,7 +36,7 @@ export const versions = {
   rdbLoader: '5.8.2',
   s3Loader: '2.2.8',
   s3Loader22x: '2.2.8',
-  lakeLoader: '0.2.0',
+  lakeLoader: '0.3.0',
   snowflakeStreamingLoader: '0.2.1',
 
   // Data Modelling


### PR DESCRIPTION
This adds the minimum documentation required for Lake Loader 0.3.0. It does not yet promote Iceberg/Glue to explain how awesome it is or why users might want to use it.