### PR TITLE
Add action to prep a dbt release given package and version

### DIFF
--- a/.github/scripts/copy_schema.sh
+++ b/.github/scripts/copy_schema.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+package_name="${1}"
+version="${2}"
+
+file_to_copy=$(find src/components/JsonSchemaValidator/Schemas -type f -name "dbt${package_name}*" | sort -V | tail -n 1)
+new_file_name=$(echo "${file_to_copy}" | sed "s/\(dbt${package_name}\).*\(\..*\)$/\1${version}\2/")
+cp "${file_to_copy}" "${new_file_name}"

--- a/.github/scripts/update_versions.sh
+++ b/.github/scripts/update_versions.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+package_name="${1}"
+version="${2}"
+
+sed -i "s/dbtSnowplow${package_name}:[[:space:]]*'[^']*'/dbtSnowplow${package_name}: '${version}'/" src/componentVersions.js

--- a/.github/workflows/release-dbt-update.yml
+++ b/.github/workflows/release-dbt-update.yml
@@ -1,0 +1,60 @@
+name: Release dbt Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: 'Select package name'
+        type: choice
+        required: true
+        options:
+          - Attribution
+          - Unified
+          - Media
+          - Ecommerce
+          - Normalize
+          - Web
+          - Mobile
+          - Fractribution
+          # Add more package names as needed
+      version:
+        description: 'Enter version'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+
+
+    - name: Copy Schema File
+      run: |
+        bash .github/scripts/copy_schema.sh ${{ github.event.inputs.package_name }} ${{ github.event.inputs.version }}
+
+    - name: Update Component Versions
+      run: |
+        bash .github/scripts/update_versions.sh ${{ github.event.inputs.package_name }} ${{ github.event.inputs.version }}
+
+    - name: Get Users Username
+      id: get_username
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { data } = await github.users.getByUsername({
+            username: '${{ github.actor }}'
+          });
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: Release/${{ github.event.inputs.package_name }}/${{ github.event.inputs.version }}
+        base: main
+        title: "Release ${{ github.event.inputs.package_name }} version ${{ github.event.inputs.version }}"
+        body: |
+          This pull request is automatically generated to release version ${{ github.event.inputs.version }} of package ${{ github.event.inputs.package_name }}.
+        reviewers: ${{ steps.get_username.outputs.result }}

--- a/.github/workflows/release-dbt-update.yml
+++ b/.github/workflows/release-dbt-update.yml
@@ -10,7 +10,7 @@ on:
         options:
           - Attribution
           - Unified
-          - Media
+          - MediaPlayer
           - Ecommerce
           - Normalize
           - Web


### PR DESCRIPTION
https://snplow.atlassian.net/browse/PE-6303

This adds an action we can manually trigger to prepare for a dbt version update - it copies the schema and converts it to the new version, and also updates the version in the components list. This means for releases with no other changes (e.g. bug fixes) we can just click this and then it's good to go.

Note it assigns the person who ran the action as a reviewer, but someone else should still be asked to review anyway.