### PR TITLE
Add missing column rename step

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/web/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/web/index.md
@@ -14,10 +14,11 @@ Note the minimum `dbt-core` version now required is 1.5.0
 Most upgrades and new features should be available automatically after the first run of the new version of the package, however there are a few breaking changes to manage before this first run. To enable any other new optional features or make use of the new configuration options, please see the [configuration](/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/web/index.mdx) page.
 
 1. The seed files have been prefixed with `snowplow_web_` so you will need to re-run `dbt seed` if this is not part of your standard workflow (note this will not drop the existing tables)
-2. Both the quarantined sessions and the sessions lifecycle table have has a column renamed, please run the below statements to rename this column in your warehouse if not doing a full-refresh of the package.
+2. Both the quarantined sessions and the sessions lifecycle table have has column(s) renamed, please run the below statements to rename this column in your warehouse if not doing a full-refresh of the package.
     ```sql
     alter table <your_schema>_snowplow_manifest.snowplow_web_base_sessions_lifecycle_manifest rename column session_id to session_identifier;
     alter table <your_schema>_snowplow_manifest.snowplow_web_base_quarantined_sessions rename column session_id to session_identifier;
+    alter table <your_schema>_snowplow_manifest.snowplow_web_base_sessions_lifecycle_manifest rename column domain_userid to user_identifier;
     ```
 3. For Redshift/Postgres users, the context variables are now just the table name, no need for the complicated `source` function if you had overwritten these previously.
 


### PR DESCRIPTION
Seems like we missed one step when writing the migration guide to 0.16.0 in the web package.