### PR TITLE
Update datamodel-name to correct format

### DIFF
--- a/docs/modeling-your-data/running-data-models-via-snowplow-bdp/dbt/index.md
+++ b/docs/modeling-your-data/running-data-models-via-snowplow-bdp/dbt/index.md
@@ -18,7 +18,7 @@ As an initial overview, in your snowplow-pipeline repository, your data models r
 ```text
 .
 ├── datamodeling
-|   ├── datamodel_name
+|   ├── datamodel-name
 |       └── dbt
 |           ├── analyses
 |           ├── logs


### PR DESCRIPTION
Updated the datamodel-name example to follow the correct naming conventions later in the article.