### PR TITLE
Add GCP constraints to GCP setup

### DIFF
--- a/docs/getting-started-on-bdp/private-managed-cloud/setup-guide-gcp/index.md
+++ b/docs/getting-started-on-bdp/private-managed-cloud/setup-guide-gcp/index.md
@@ -37,3 +37,13 @@ The following roles are also required if using [RDB Loader](/docs/pipeline-compo
 ### Enable billing for the project
 
 Please enable billing on the project as failing to do so will prevent the pipeline from being installed. For details on enabling billing for your project, please refer to the GCP documentation for [APIs and billing](https://support.google.com/googleapi/answer/6158867).
+
+### Ensure that the following constraints are turned off
+
+The following is a list of Organizational Policy constraints that we require to be turned off, otherwise we are unable to deploy the pipeline.  For some, more specific configuration would enable the constraint to stay and the pipeline to deploy. This list will be updated as we discover more constraints that are not compatible with the pipeline deployment.
+
+- `constraints/compute.requireShieldedVm`
+- `constraints/gcp.resourceLocations`
+- `constraints/iam.disableServiceAccountCreation`
+- `constraints/iam.disableServiceAccountKeyCreation`
+- `constraints/sql.restrictPublicIp`


### PR DESCRIPTION
Add GCP Organizational Policy constraints that need removing to https://docs.snowplow.io/docs/getting-started-on-bdp/private-managed-cloud/setup-guide-gcp/