### PR TITLE
Fix syntax error in demo code

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/new-derived-model/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/new-derived-model/index.md
@@ -47,7 +47,7 @@ Then it is simply a case of writing the actual model content itself, which in th
   )
 }}
 
-select *
+select
     session_identifier,
     min(derived_tstamp) as start_tstamp,
     event_name,


### PR DESCRIPTION
The example code to build a custom model has a syntax error due to a SELECT * that has no comma after it