### PR TITLE
Small fixes for PHP tracker docs

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/emitters/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/emitters/index.md
@@ -4,11 +4,14 @@ date: "2020-02-26"
 sidebar_position: 40
 ---
 
-We now support four different emitters: sync, socket, curl and an out-of-band file emitter. The most basic emitter only requires you to specify the type of emitter to be used and the collectors URI as parameters.
+We currently support four different emitters: sync, socket, curl and an out-of-band file emitter. The most basic emitter only requires you to select the type of emitter to be used and specify the collector's hostname as parameters.
 
-All emitters support both `GET` and `POST` as methods for sending events to Snowplow collectors. For the sake of speed, we recommend using `POST` as the tracker can then bundle many events together into a single request.
+All emitters support both `GET` and `POST` as methods for sending events to Snowplow collectors.
 
-It is recommended that after you have finished logging all of your events to run the following command:
+For the sake of performance, we recommend using `POST` as the tracker can then batch many events together into a single request.
+Note that depending on your pipeline architecture, your collector may have limits on the maximum request size it will accept that could be exceeded by large batch sizes.
+
+It is recommended that after you have finished logging all of your events to call the following method:
 
 ```php
 $tracker->flushEmitters();
@@ -23,7 +26,7 @@ The Sync emitter is a very basic synchronous emitter which supports both `GET`�
 By default, this emitter uses the Request type POST, HTTP and a buffer size of 50.
 
 As of version 0.7.0, the emitter has the capability to retry failed requests.
-In case connection to the collector can't be estabilished or the request fails with a 4xx (except for 400, 401, 403, 410, 422) or 5xx status code, the same request is retried.
+In case connection to the collector can't be established or the request fails with a 4xx (except for 400, 401, 403, 410, 422) or 5xx status code, the same request is retried.
 The number of times a request should be retried is configurable but defaults to 1.
 There is a back-off period between subsequent retries, which starts with 100ms (configurable) and increases exponentially.
 
@@ -45,7 +48,7 @@ Arguments:
 
 | **Argument** | **Description** | **Required?** | **Validation** |
 | --- | --- | --- | --- |
-| `$uri` | Collector URI | Yes | Non-empty string |
+| `$uri` | Collector hostname | Yes | Non-empty string |
 | `$protocol` | Collector Protocol (HTTP or HTTPS) | No | String |
 | `$type` | Request Type (POST or GET) | No | String |
 | `$buffer_size` | Amount of events to store before flush | No | Int |
@@ -58,7 +61,7 @@ Arguments:
 The Socket emitter allows for the much faster transmission of Requests to the collector by allowing us to write data directly to the HTTP socket. However, this solution is still, in essence, a synchronous process and will block the execution of the main script.
 
 As of version 0.7.0, the emitter has the capability to retry failed requests.
-In case connection to the collector can't be estabilished or the request fails with a 4xx (except for 400, 401, 403, 410, 422) or 5xx status code, the same request is retried.
+In case connection to the collector can't be established or the request fails with a 4xx (except for 400, 401, 403, 410, 422) or 5xx status code, the same request is retried.
 The number of times a request should be retried is configurable but defaults to 1.
 There is a back-off period between subsequent retries, which starts with 100ms (configurable) and increases exponentially.
 
@@ -80,7 +83,7 @@ Arguments:
 
 | **Argument** | **Description** | **Required?** | **Validation** |
 | --- | --- | --- | --- |
-| `$uri` | Collector URI | Yes | Non-empty string |
+| `$uri` | Collector hostname | Yes | Non-empty string |
 | `$ssl` | Whether to use SSL encryption | No | Boolean |
 | `$type` | Request Type (POST or GET) | No | String |
 | `$timeout` | Socket Timeout Limit | No | Int or Float |
@@ -117,7 +120,7 @@ Arguments:
 
 | **Argument**    | **Description**                                         | **Required?** | **Validation**   |
 |-----------------|---------------------------------------------------------|---------------|------------------|
-| `$uri`          | Collector URI                                           | Yes           | Non-empty string |
+| `$uri`          | Collector hostname                                      | Yes           | Non-empty string |
 | `$protocol`     | Collector Protocol (HTTP or HTTPS)                      | No            | String           |
 | `$type`         | Request Type (POST or GET)                              | No            | String           |
 | `$buffer_size`  | Amount of events to store before flush                  | No            | Int              |
@@ -173,7 +176,7 @@ Arguments:
 
 | **Argument** | **Description** | **Required?** | **Validation** |
 | --- | --- | --- | --- |
-| `$uri` | Collector URI | Yes | Non-empty string |
+| `$uri` | Collector hostname | Yes | Non-empty string |
 | `$protocol` | Collector Protocol (HTTP or HTTPS) | No | String |
 | `$type` | Request Type (POST or GET) | No | String |
 | `$workers` | Amount of background workers | No | Int |

--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/initialization/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/initialization/index.md
@@ -18,7 +18,7 @@ We can now create our Emitter, Subject and Tracker objects.
 
 ### Creating a Tracker
 
-The most basic Tracker instance will only require you to provide the type of Emitter and the URI of the collector to which the Tracker will log events.
+The most basic Tracker instance will only require you to provide an [Emitter](/docs/collecting-data/collecting-from-own-applications/php-tracker/emitters/index.md) and the data [Subject](/docs/collecting-data/collecting-from-own-applications/php-tracker/subjects/index.md) for which the Tracker will log events.
 
 ```php
 $emitter = new SyncEmitter($collector_uri, "http", "POST", 10, false);
@@ -54,8 +54,8 @@ $emitter_array = array($emitter1, $emitter2);
 
 // Tracker Init
 $subject = new Subject();
-$tracker1 = ($emitter1, $subject); # Single Emitter
-$tracker2 = ($emitter_array, $subject); # Array of Emitters
+$tracker1 = new Tracker($emitter1, $subject); # Single Emitter
+$tracker2 = new Tracker($emitter_array, $subject); # Array of Emitters
 ```
 
 #### `subject`

--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/setup/index.md
@@ -15,9 +15,17 @@ Currently the only supported method of installation is through Composer. For a t
 
 ### Composer
 
-Using Composer to manage your dependencies, simply add the Snowplow PHP Tracker to your project by including it in your composer.json file as a dependency.
+Using Composer to manage your dependencies, simply add the Snowplow PHP Tracker to your project by running:
 
-<CodeBlock language="json">{
+```bash
+composer require snowplow/snowplow-tracker
+```
+
+to include it in your `composer.json` file as a dependency.
+
+You can also add it manually:
+
+<CodeBlock language="json" title="composer.json">{
 `{
     "require": {
         "snowplow/snowplow-tracker": "${versions.phpTracker}"
@@ -27,16 +35,15 @@ Using Composer to manage your dependencies, simply add the Snowplow PHP Tracker 
 
 Assuming you have Composer setup correctly in the root of your project. Type the following command line argument:
 
-```javascript
-composer install # If composer has not been run yet
-composer update # If composer dependencies are already installed
+```bash
+composer update # Will update lockfile and install dependencies
 ```
 
 This will install the Snowplow Tracker and allow you to initialize a Tracker object:
 
 ```php
 // Bare minimum Tracker initialization.
- 
+
 use Snowplow\Tracker\Tracker;
 use Snowplow\Tracker\Subject;
 use Snowplow\Tracker\Emitters\SyncEmitter;

--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/setup/index.md
@@ -15,7 +15,7 @@ Currently the only supported method of installation is through Composer. For a t
 
 ### Composer
 
-Using Composer to manage your dependencies, simply add the Snowplow PHP Tracker to your project by running:
+If using Composer to manage your dependencies, simply add the Snowplow PHP Tracker to your project by running:
 
 ```bash
 composer require snowplow/snowplow-tracker

--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/subjects/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/subjects/index.md
@@ -12,7 +12,7 @@ To create a new subject:
 $subject = new Subject();
 ```
 
-By default the subject has one piece information in it already, the [platform](/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/going-deeper/event-parameters/index.md#application-parameters) `["p" => "srv"]`.
+By default the subject has one piece of information in it already, the [platform](/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/going-deeper/event-parameters/index.md#application-parameters) `["p" => "srv"]`.
 
 The Subject class contains a variety of 'set' methods to attach extra data to your event.
 

--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/subjects/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/subjects/index.md
@@ -4,7 +4,7 @@ date: "2020-02-26"
 sidebar_position: 30
 ---
 
-The Subject object lets you send any additional information about your application's environment, current user etc to Snowplow.
+The Subject object lets you send any additional information about your application's environment, current user, etc to Snowplow.
 
 To create a new subject:
 
@@ -12,22 +12,25 @@ To create a new subject:
 $subject = new Subject();
 ```
 
-By default the subject has one piece information in it already, the platform ["p" => "srv"].
+By default the subject has one piece information in it already, the [platform](/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/going-deeper/event-parameters/index.md#application-parameters) `["p" => "srv"]`.
 
 The Subject class contains a variety of 'set' methods to attach extra data to your event.
 
-- [`setPlatform`](#set-platform)
-- [`setUserId`](#set-user-id)
-- [`setScreenRes`](#set-screen-res)
-- [`setViewport`](#set-viewport)
-- [`setColorDepth`](#set-color-depth)
-- [`setTimezone`](#set-timezone)
-- `[setLanguage](#set-lang)`
-- [`setIpAddress`](#set-ip-address)
-- [`setUseragent`](#set-useragent)
-- [`setNetworkUserId`](#set-network-user-id)
-- [`setSessionId`](#set-session-id)
-- [`setSessionIndex`](#set-session-index)
+- [`setPlatform`](#setplatform)
+- [`setUserId`](#setuserid)
+- [`setScreenResolution`](#setscreenresolution)
+- [`setViewPort`](#setviewport)
+- [`setColorDepth`](#setcolordepth)
+- [`setTimezone`](#settimezone)
+- [`setLanguage`](#setlanguage)
+- [`setIpAddress`](#setipaddress)
+- [`setUseragent`](#setuseragent)
+- [`setNetworkUserId`](#setnetworkuserid)
+- [`setDomainUserId`](#setdomainuserid)
+- [`setSessionId`](#setsessionid)
+- [`setSessionIndex`](#setsessionindex)
+- [`setRefr`](#setrefr)
+- [`setPageUrl`](#setpageurl)
 
 These set methods can be called either directly onto a subject object:
 
@@ -40,6 +43,13 @@ Or they can be called through the tracker object:
 
 ```php
 $tracker->returnSubject()->setPlatform("tv");
+```
+
+You can also change the active Subject a Tracker is operating with:
+
+```php
+$subject2 = new Subject();
+$tracker->updateSubject($subject2);
 ```
 
 ### `setPlatform`
@@ -56,7 +66,7 @@ For example:
 $subject->setPlatform("tv") # Running on a Connected TV
 ```
 
-For a full list of supported platforms, please see the [Snowplow Tracker Protocol](/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/index.md).
+For a full list of supported platforms, please see the [Event Parameters reference](/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/going-deeper/event-parameters/index.md#application-parameters).
 
 ### `setUserId`
 
@@ -86,18 +96,18 @@ Both numbers should be positive integers; note the order is width followed by he
 $subject->setScreenResolution(1366, 768);
 ```
 
-### `setViewport`
+### `setViewPort`
 
 If your PHP code has access to the viewport dimensions, then you can pass this in to Snowplow too:
 
 ```php
-$subject->setViewport($width, $height);
+$subject->setViewPort($width, $height);
 ```
 
 Both numbers should be positive integers; note the order is width followed by height. Example:
 
 ```php
-$subject->setViewport(300, 200);
+$subject->setViewPort(300, 200);
 ```
 
 ### `setColorDepth`
@@ -224,4 +234,20 @@ The session index should be a number:
 
 ```php
 $subject->setSessionIndex(1);
+```
+
+### `setRefr`
+
+This method lets you set the referrer URL to a full URI:
+
+```php
+$subject->setRefr("https://example.com/previous-page");
+```
+
+### `setPageUrl`
+
+This method lets you set the page URL to a full URI string:
+
+```php
+$subject->setPageUrl("https://example.com/current-page");
 ```

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -10,7 +10,7 @@ export const versions = {
   javaTracker: '2.1.0',
   javaScriptTracker: '3.24.0',
   luaTracker: '0.2.0',
-  phpTracker: '0.7.0',
+  phpTracker: '0.7.1',
   pixelTracker: '0.3.0',
   pythonTracker: '1.0.2',
   reactNativeTracker: '2.1.0',


### PR DESCRIPTION
- Update PHP tracker version reference
- Mention batch size collector limits (the default 50 events with a 4KB event size is close to the 192KB surge protection limit, for instance)
- Typos/speling
- Reference collector `hostname` rather than `URI` (we seem to pretty blindly [prepend the scheme ourselves](https://github.com/snowplow/snowplow-php-tracker/blob/master/src/Emitter.php#L175) so asking for a URI is confusing/misleading)
- Fix some ToC anchor IDs
- Fix typo in [case of `setViewPort`](https://github.com/snowplow/snowplow-php-tracker/blob/5ffab25d160c397477ab52730a5674db3f969b72/src/Subject.php#L83)
- Adjust links to valid `platform` values that are no longer at the Tracker Protocol location
- Slightly modernise `composer` usage instructions
- Add some public APIs that are not documented (`Tracker.updateSubject`, `Subject.setRefr`, `Subject.setPageUrl`)