### PR TITLE
Removed docs that dictate that Iglu Server is required by some components

### DIFF
--- a/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md
+++ b/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md
@@ -4,11 +4,10 @@ date: "2021-03-26"
 sidebar_position: 50
 ---
 
-This guide is designed for Iglu users wanting to create a public mirror or private clone of [Iglu Central](/docs/pipeline-components-and-applications/iglu/iglu-repositories/iglu-central/index.md). There are a couple of reasons you may want to do this:
+This guide is designed for Iglu users wanting to create a public mirror or private clone of [Iglu Central](/docs/pipeline-components-and-applications/iglu/iglu-repositories/iglu-central/index.md). There are a couple of reasons you may want to do this:
 
-1. Some Snowplow components require a Iglu Server, so the static Iglu Central repository will not work.
-2. You may want to access Iglu Central from a software system that cannot access the open internet.
-3. You may want a mirror of Iglu Central which has lower latency to your software system.
+1. You may want to access Iglu Central from a software system that cannot access the open internet.
+2. You may want a mirror of Iglu Central which has lower latency to your software system.
 
 This guide is divided into two sections:
 
@@ -19,7 +18,7 @@ This guide is divided into two sections:
 
 ### Hosting an Iglu Server based mirror
 
-Some components of Snowplow require an Iglu Server, and a static repo will not work. This means you'll want to host a mirror of Iglu Central. You can mirror Iglu Central using `[igluctl](/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md)`:
+You can mirror Iglu Central using `[igluctl](/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md)`:
 
 ```bash
 git clone https://github.com/snowplow/iglu-central
@@ -27,17 +26,17 @@ cd iglu-central
 igluctl static push --public schemas/ http://MY-IGLU-URL 00000000-0000-0000-0000-000000000000
 ```
 
-For further information on Iglu Central, consult the [Iglu Central setup guide](/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md).
+For further information on Iglu Central, consult the [Iglu Central setup guide](/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md).
 
 ### Hosting a Static Repository based mirror
 
-Iglu Central is built on top of the Iglu static repo server, so the first step is to [setup a static repo](/docs/pipeline-components-and-applications/iglu/iglu-repositories/static-repo/index.md). You can give your copy of Iglu Central a name like:
+Iglu Central is built on top of the Iglu static repo server, so the first step is to [setup a static repo](/docs/pipeline-components-and-applications/iglu/iglu-repositories/static-repo/index.md). You can give your copy of Iglu Central a name like:
 
 ```text
 http://iglucentral.acme.com
 ```
 
-Once you have completed this static repo setup, then copy into your `/schemas` sub-folder **all** of the schemas that you can find [in the Iglu Central GitHub Repo](https://github.com/snowplow/iglu-central/tree/master/schemas)
+Once you have completed this static repo setup, then copy into your `/schemas` sub-folder **all** of the schemas that you can find [in the Iglu Central GitHub Repo](https://github.com/snowplow/iglu-central/tree/master/schemas)
 
 Once you have done this, check that your schemas are publically accessible, for example:
 

--- a/docs/pipeline-components-and-applications/iglu/iglu-repositories/iglu-central/index.md
+++ b/docs/pipeline-components-and-applications/iglu/iglu-repositories/iglu-central/index.md
@@ -4,27 +4,25 @@ date: "2021-03-26"
 sidebar_position: 1000
 ---
 
-[Iglu Central](http://iglucentral.com/) is a public repository of JSON Schemas hosted by Snowplow Analytics.
+[Iglu Central](http://iglucentral.com/) is a public repository of JSON Schemas hosted by Snowplow Analytics.
 
-As far as we know, Iglu Central is the first public **machine-readable** schema repository - all prior efforts we have seen are human-browsable directories of articles about schemas (e.g. [schema.org](http://schema.org/)).
+As far as we know, Iglu Central is the first public **machine-readable** schema repository - all prior efforts we have seen are human-browsable directories of articles about schemas (e.g. [schema.org](http://schema.org/)).
 
-Think of Iglu Central as like [RubyGems.org](http://rubygems.org/) or [Maven Central](http://central.maven.org/) but for storing publically-available JSON Schemas.
+Think of Iglu Central as like [RubyGems.org](http://rubygems.org/) or [Maven Central](http://central.maven.org/) but for storing publically-available JSON Schemas.
 
 ## Technical architecture
 
-Under the hood, Iglu Central is built and run as a static Iglu repository, which is simply an Iglu repository server structured as a static website serving its whole content over http, and is hosted on Amazon S3.
+Under the hood, Iglu Central is built and run as a static Iglu repository, which is simply an Iglu repository server structured as a static website serving its whole content over http, and is hosted on Amazon S3.
 
 ![iglu-central-img](images/iglu-central.png)
 
-The [deployment process](/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md) for Iglu Central is documented on this wiki in case a user wants to setup a public mirror or private instance of Iglu Central.
+The [deployment process](/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md) for Iglu Central is documented on this wiki in case a user wants to setup a public mirror or private instance of Iglu Central.
 
-Iglu Central is available for view at [http://iglucentral.com](http://iglucentral.com/). Although Iglu Central is primarily designed to be consumed by [Iglu clients](/docs/pipeline-components-and-applications/iglu/iglu-clients/index.md), the root index page for Iglu Central links to all schemas currently hosted on Iglu Central.
+Iglu Central is available for view at [http://iglucentral.com](http://iglucentral.com/). Although Iglu Central is primarily designed to be consumed by [Iglu clients](/docs/pipeline-components-and-applications/iglu/iglu-clients/index.md), the root index page for Iglu Central links to all schemas currently hosted on Iglu Central.
 
 ## Self Hosting Iglu Central schemas
 
-The schemas for Iglu Central are stored in GitHub, in [snowplow/iglu-central](https://github.com/snowplow/iglu-central).
-
-Some components of Snowplow require an Iglu Server, and a static repo will not work. This means you'll want to host a mirror of Iglu Central. You can mirror Iglu Central using `[igluctl](/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md)`:
+The schemas for Iglu Central are stored in GitHub, in [snowplow/iglu-central](https://github.com/snowplow/iglu-central). You can mirror Iglu Central using `[igluctl](/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md)`:
 
 ```bash
 git clone https://github.com/snowplow/iglu-central
@@ -32,4 +30,4 @@ cd iglu-central
 igluctl static push --public schemas/ http://CHANGE-TO-MY-IGLU-URL.elb.amazonaws.com 00000000-0000-0000-0000-000000000000
 ```
 
-For further information on Iglu Central, consult the [Iglu Central setup guide](/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md).
+For further information on Iglu Central, consult the [Iglu Central setup guide](/docs/pipeline-components-and-applications/iglu/iglu-central-setup/index.md).

--- a/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md
+++ b/docs/pipeline-components-and-applications/iglu/igluctl-2/index.md
@@ -16,19 +16,19 @@ Iglu is a schema repository for JSON Schema. A schema repository (sometimes call
 
 Iglu provides a CLI application, called igluctl which allows you to perform most common tasks on Iglu registry. So far, the overall structure of igluctl commands looks like the following:
 
-- `lint` - validate set of JSON Schemas for syntax and consistency of their properties
-- `static` - work with static Iglu registry
-    - `generate` - verify that schema is evolved correctly within the same major version (e.g. from `1-a-b` to `1-c-d`) for Redshift and Postgres warehouses. Generate DDLs and migrations from set of JSON Schemas. If the schema is not evolved correctly and backward incompatible data is sent within transformer's aggregation window, loading would fail for all events.
-    - `push` - push set of JSON Schemas from static registry to full-featured (Scala Registry for example) one
-    - `pull` - pull set of JSON Schemas from registry to local folder
-    - `deploy` - run entire schema workflow using a config file. This could be used to chain multiple commands, i.e. `lint` followed by `push` and `s3cp`.
-    - `s3cp` - copy JSONPaths or schemas to S3 bucket
-- `server` - work with an Iglu server
-    - `keygen` - generate read and write API keys on Iglu Server
-- `table-check` - will check a given Redshift or Postgres tables against iglu server.
+- `lint` - validate set of JSON Schemas for syntax and consistency of their properties
+- `static` - work with static Iglu registry
+    - `generate` - verify that schema is evolved correctly within the same major version (e.g. from `1-a-b` to `1-c-d`) for Redshift and Postgres warehouses. Generate DDLs and migrations from set of JSON Schemas. If the schema is not evolved correctly and backward incompatible data is sent within transformer's aggregation window, loading would fail for all events.
+    - `push` - push set of JSON Schemas from static registry to full-featured (Scala Registry for example) one
+    - `pull` - pull set of JSON Schemas from registry to local folder
+    - `deploy` - run entire schema workflow using a config file. This could be used to chain multiple commands, i.e. `lint` followed by `push` and `s3cp`.
+    - `s3cp` - copy JSONPaths or schemas to S3 bucket
+- `server` - work with an Iglu server
+    - `keygen` - generate read and write API keys on Iglu Server
+- `table-check` - will check a given Redshift or Postgres tables against iglu server.
 - `verify` (since 0.13.0) - work with schemas to check their evolution
-    - `redshift` - verify that schema is evolved correctly within the same major version (e.g. from `1-a-b` to `1-c-d`) for loading into Redshift. It reports the major schema versions within which schema evolution rules were broken.
-    - `parquet` - verify that schema is evolved correctly within the same major version (e.g. from `1-a-b` to `1-c-d`) for parquet transformation (for loading into Databricks). It reports the breaking schema versions.
+    - `redshift` - verify that schema is evolved correctly within the same major version (e.g. from `1-a-b` to `1-c-d`) for loading into Redshift. It reports the major schema versions within which schema evolution rules were broken.
+    - `parquet` - verify that schema is evolved correctly within the same major version (e.g. from `1-a-b` to `1-c-d`) for parquet transformation (for loading into Databricks). It reports the breaking schema versions.
 
 ## Downloading and running Igluctl 
 
@@ -55,7 +55,7 @@ Note that Igluctl expects [JRE 8](http://www.oracle.com/technetwork/java/javase/
 
 ## lint
 
-`igluctl lint` validates JSON Schemas.
+`igluctl lint` validates JSON Schemas.
 
 It is designed to be run against file-based schema registries with the standard Iglu folder structure:
 
@@ -68,7 +68,7 @@ schemas
             └── 1-0-1
 ```
 
-You can validate _all_ the schemas in the registry:
+You can validate _all_ the schemas in the registry:
 
 ```bash
 $ /path/to/igluctl lint /path/to/schema/registry/schemas
@@ -83,22 +83,22 @@ $ /path/to/igluctl lint /path/to/schema/registry/schemas/com.example_company/exa
 Examples of errors that are identified:
 
 - JSON Schema has inconsistent self-describing information and path on filesystem
-- JSON Schema has invalid `$schema` keyword. It should be always set to [iglu-specific](http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#), while users tend to set it to Draft v4 or even to self-referencing Iglu URI
-- JSON Schema is invalid against its standard (empty `required`, string `maximum` and similar)
-- JSON Schema contains properties which contradict each other, like `{"type": "integer", "maxLength": 0}` or `{"maximum": 0, "minimum": 10'}`. These schemas are inherently useless as for some valiators there is no JSON instance they can validate
+- JSON Schema has invalid `$schema` keyword. It should be always set to [iglu-specific](http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#), while users tend to set it to Draft v4 or even to self-referencing Iglu URI
+- JSON Schema is invalid against its standard (empty `required`, string `maximum` and similar)
+- JSON Schema contains properties which contradict each other, like `{"type": "integer", "maxLength": 0}` or `{"maximum": 0, "minimum": 10'}`. These schemas are inherently useless as for some valiators there is no JSON instance they can validate
 
 The above cases can very hard to spot without a specialized tool as they are still valid JSONs and in last case it is even valid JSON Schemas - so will validate against a standard JSON schema validator.
 
-`lint` has two options:
+`lint` has two options:
 
-- `--skip-checks` which will lint without specified linters, given comma separated. To see available linters and their explanations, `$ /path/to/igluctl --help`
-- `--skip-schemas` which will lint all the schemas except the schemas passed to this option as a comma separated list. For example running:  
+- `--skip-checks` which will lint without specified linters, given comma separated. To see available linters and their explanations, `$ /path/to/igluctl --help`
+- `--skip-schemas` which will lint all the schemas except the schemas passed to this option as a comma separated list. For example running:  
     `/path/to/igluctl lint /path/to/schema/registry/schemas --skip-schemas iglu:com.acme/click/jsonschema/1-0-1,iglu:com.acme/scroll/jsonschema/1-0-1`  
     will lint all schemas in `/path/to/schema/registry/schemas` except the two schemas passed via `--skip-schemas`.
 
-Note: `--severityLevel` option is deprecated and removed as of version 0.4.0.
+Note: `--severityLevel` option is deprecated and removed as of version 0.4.0.
 
-Below are two groups of linters; allowed to be skipped and not allowed to be skipped. By default, all of them are enabled but igluctl users can skip any combination of `rootObject`, `unknownFormats`, `numericMinMax`, `stringLength`, `optionalNull`, `description` through `--skip-checks`.
+Below are two groups of linters; allowed to be skipped and not allowed to be skipped. By default, all of them are enabled but igluctl users can skip any combination of `rootObject`, `unknownFormats`, `numericMinMax`, `stringLength`, `optionalNull`, `description` through `--skip-checks`.
 
 Igluctl let you skip below checks:
 
@@ -119,13 +119,13 @@ $ ./igluctl lint --skip-checks description,rootObject /path/to/schema/registry/s
 
 Note that linter names are case sensitive
 
-Igluctl also includes many checks proving that schemas doesn’t have conflicting expectations (such as `minimum` value bigger than `maximum`). Schemas with such expectations are valid according to specification, but do not make any sense in real-world use cases. These checks are mandatory and cannot be disabled.
+Igluctl also includes many checks proving that schemas doesn’t have conflicting expectations (such as `minimum` value bigger than `maximum`). Schemas with such expectations are valid according to specification, but do not make any sense in real-world use cases. These checks are mandatory and cannot be disabled.
 
-`igluctl lint` will exit with status code 1 if encounter at least one error.
+`igluctl lint` will exit with status code 1 if encounter at least one error.
 
 ## static generate
 
-`igluctl static generate` generates corresponding [Redshift](http://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html) DDL files (`CREATE TABLE` statements) and migration scripts (`ALTER TABLE` statements).
+`igluctl static generate` generates corresponding [Redshift](http://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html) DDL files (`CREATE TABLE` statements) and migration scripts (`ALTER TABLE` statements).
 
 As of version 0.11.0 this command will also validate the compatibility of schema family and display warnings if there is an incompatible evolution.
 
@@ -155,15 +155,15 @@ Igluctl will generate the following migration scripts:
 - sql/com.acme/click_event/1-0-0/1-0-2 to alter table from 1-0-0 to 1-0-2
 - sql/com.acme/click_event/1-0-1/1-0-2 to alter table from 1-0-1 to 1-0-2
 
-This migrations (and all subsequent table definitions) are aware of column order and will ensure that new columns are added at the end of the table definition. This means that the tables can be updated in-place with single `ALTER TABLE` statements.
+This migrations (and all subsequent table definitions) are aware of column order and will ensure that new columns are added at the end of the table definition. This means that the tables can be updated in-place with single `ALTER TABLE` statements.
 
 ### Handling union types
 
-One of the more problematic scenarios to handle when generating Redshift table definitions is handling `UNION` field types e.g. `["integer", "string"]`. Union types will be transformed as most general. In the above example (union of an integer and string type) the corresponding Redshift column will be a `VARCHAR(4096)`.
+One of the more problematic scenarios to handle when generating Redshift table definitions is handling `UNION` field types e.g. `["integer", "string"]`. Union types will be transformed as most general. In the above example (union of an integer and string type) the corresponding Redshift column will be a `VARCHAR(4096)`.
 
 ### Missing schema versions
 
-`static generate` command will check versions of schemas inside `input` as following:
+`static generate` command will check versions of schemas inside `input` as following:
 
 - If user specified folder and one of schemas has no 1-0-0 or misses any other schemas in between (like it has 1-0-0 and 1-0-2) - refuse to do anything (but proceed with –force option)
 - If user specified full path to file with schema and this file is not 1-0-0 - just print a warning
@@ -172,15 +172,15 @@ One of the more problematic scenarios to handle when generating Redshift table d
 
 ## static push
 
-`igluctl static push` publishes schemas stored locally to a remote [Iglu Server](https://github.com/snowplow/iglu-server).
+`igluctl static push` publishes schemas stored locally to a remote [Iglu Server](https://github.com/snowplow/iglu-server).
 
 It accepts three required arguments:
 
-- `host` - Iglu Server host name or IP address with optional port and endpoint. It should conform to the pattern `host:port/path` (or just `host`) **without** http:// prefix.
-- `apikey` - master API key, used to create temporary write and read keys
-- `path` - path to your static registry (local folder containing schemas)
+- `host` - Iglu Server host name or IP address with optional port and endpoint. It should conform to the pattern `host:port/path` (or just `host`) **without** http:// prefix.
+- `apikey` - master API key, used to create temporary write and read keys
+- `path` - path to your static registry (local folder containing schemas)
 
-Also it accepts optional `--public` argument which makes schemas available without `apikey` header.
+Also it accepts optional `--public` argument which makes schemas available without `apikey` header.
 
 ```bash
 $ ./igluctl static push /path/to/static/registry iglu.acme.com:80/iglu-server f81d4fae-7dec-11d0-a765-00a0c91e6bf6
@@ -188,13 +188,13 @@ $ ./igluctl static push /path/to/static/registry iglu.acme.com:80/iglu-server f8
 
 ## static pull
 
-`igluctl static pull` downloads schemas stored on a remote [](https://github.com/snowplow/iglu/tree/master/2-repositories/iglu-server)[Iglu Server](https://github.com/snowplow/iglu-server) to a local folder.
+`igluctl static pull` downloads schemas stored on a remote [](https://github.com/snowplow/iglu/tree/master/2-repositories/iglu-server)[Iglu Server](https://github.com/snowplow/iglu-server) to a local folder.
 
 It accepts three required arguments:
 
-- `host` - Scala Iglu Registry host name or IP address with optional port and endpoint. It should conform to the pattern `host:port/path` (or just `host`) **without** http:// prefix.
-- `apikey` - master API key, used to create temporary write and read keys
-- `path` - path to your static registry (local folder to download to)
+- `host` - Scala Iglu Registry host name or IP address with optional port and endpoint. It should conform to the pattern `host:port/path` (or just `host`) **without** http:// prefix.
+- `apikey` - master API key, used to create temporary write and read keys
+- `path` - path to your static registry (local folder to download to)
 
 ```bash
 $ ./igluctl static pull /path/to/static/registry iglu.acme.com:80/iglu-server f81d4fae-7dec-11d0-a765-00a0c91e6bf6
@@ -202,28 +202,28 @@ $ ./igluctl static pull /path/to/static/registry iglu.acme.com:80/iglu-server f8
 
 ## static s3cp
 
-`igluctl static s3cp` enables you to upload JSON Schemas to chosen S3 bucket. This is helpful for generating a remote iglu registry which can be served from S3 over http(s).
+`igluctl static s3cp` enables you to upload JSON Schemas to chosen S3 bucket. This is helpful for generating a remote iglu registry which can be served from S3 over http(s).
 
-`igluctl static s3cp` accepts two required arguments and several options:
+`igluctl static s3cp` accepts two required arguments and several options:
 
-- `input` - path to your files. Required.
-- `bucket` - S3 bucket name. Required.
-- `s3path` - optional S3 path to prepend your input root. Usually you don’t need it.
-- `accessKeyId` - your AWS Access Key Id. This may or or may not be required, depending on your preferred authentication option.
-- `secretAccessKey` - your AWS Secret Access Key. This may or or may not be required, depending on your preferred authentication option.
-- `profile` - your AWS profile name. This may or or may not be required, depending on your preferred authentication option.
-- `region` - AWS S3 region. Default: `us-west-2`
-- `skip-schema-lists` - Do not generate and upload schema list objects.
+- `input` - path to your files. Required.
+- `bucket` - S3 bucket name. Required.
+- `s3path` - optional S3 path to prepend your input root. Usually you don’t need it.
+- `accessKeyId` - your AWS Access Key Id. This may or or may not be required, depending on your preferred authentication option.
+- `secretAccessKey` - your AWS Secret Access Key. This may or or may not be required, depending on your preferred authentication option.
+- `profile` - your AWS profile name. This may or or may not be required, depending on your preferred authentication option.
+- `region` - AWS S3 region. Default: `us-west-2`
+- `skip-schema-lists` - Do not generate and upload schema list objects. If using a static registry for all Snowplow applications, don’t enable this setting as some components still require lists to function correctly.
 
-`igluctl static s3cp` tries to closely follow AWS CLI authentication process. First it checks if profile name or `accessKeyId`/`secretAccessKey` pair provided and uses it. If neither of above provided - it looks into `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` environment variables. If above aren’t available as well - it `~/.aws/config` file. If all above failed - it exits with error.
+`igluctl static s3cp` tries to closely follow AWS CLI authentication process. First it checks if profile name or `accessKeyId`/`secretAccessKey` pair provided and uses it. If neither of above provided - it looks into `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` environment variables. If above aren’t available as well - it `~/.aws/config` file. If all above failed - it exits with error.
 
 ## static deploy
 
-`igluctl static deploy` performs whole schema workflow at once.
+`igluctl static deploy` performs whole schema workflow at once.
 
 It accepts one required arguments:
 
-- `config` - Path to configuration file
+- `config` - Path to configuration file
 
 ```bash
 $ ./igluctl static deploy /path/to/config/file
@@ -278,8 +278,8 @@ Example:
 
 It accepts two required arguments:
 
-- `host` - Scala Iglu Registry host name or IP address with optional port and endpoint. It should conform pattern `host:port/path` (or just `host`) **without** http:// prefix.
-- `apikey` - master API key, used to create temporary write and read keys
+- `host` - Scala Iglu Registry host name or IP address with optional port and endpoint. It should conform pattern `host:port/path` (or just `host`) **without** http:// prefix.
+- `apikey` - master API key, used to create temporary write and read keys
 
 Also it accepts `--vendor-prefix` argument which will be associated with generated key.
 
@@ -338,7 +338,7 @@ $ ./igluctl table-check --server <uri> ...connection params
 
 It accepts one required arguments:
 
-- `input` - path to your schema files.
+- `input` - path to your schema files.
 
 Example command:
 
@@ -361,8 +361,8 @@ Breaking change introduced by 'com.acme/item/jsonschema/1-1-0'. Changes: Incompa
 
 It accepts two required and one optional arguments:
 
-- `server` - Iglu Server URL.
-- `apikey` - Iglu Server Read ApiKey
+- `server` - Iglu Server URL.
+- `apikey` - Iglu Server Read ApiKey
 - `--verbose/-v` - emit detailed report or not (disabled by default)
 
 Example command:


### PR DESCRIPTION
Also removed some weird characters `<0xa0>` from the docs and replaced them with normal whitespace.

---

Ultimately doesn't change the quickstart flow stating that users should setup an Iglu Server but also isn't misleading that its required (as it isn't).

Made a note that if using the static registry for everything that you shouldn't skip schema lists as well given some apps do require that still.