### PR TITLE
Fix Iglu schema URI in the schema properties reusable block

### DIFF
--- a/docs/reusable/schema-properties/_index.md
+++ b/docs/reusable/schema-properties/_index.md
@@ -11,7 +11,7 @@ import EventQuery from "@site/docs/reusable/event-query/_index.md"
   <p>
     Schema URI:
     <code>
-      iglu://{props.schema.self.vendor}/{props.schema.self.name}/{props.schema.self.format}/{props.schema.self.version}
+      iglu:{props.schema.self.vendor}/{props.schema.self.name}/{props.schema.self.format}/{props.schema.self.version}
     </code>
   </p>
   {


### PR DESCRIPTION
Remove the `//` after `iglu:` from schema properties reusable block.