### PR TITLE
Fix typo under tracking design on index.md

### DIFF
--- a/docs/managing-data-quality/testing-and-qa-workflows/set-up-automated-testing-with-snowplow-micro/index.md
+++ b/docs/managing-data-quality/testing-and-qa-workflows/set-up-automated-testing-with-snowplow-micro/index.md
@@ -99,7 +99,7 @@ If you wanted to use `docker run` instead of `docker-compose`, the same step 
 
 ## Tracking design
 
-Our demo web app uses Snowplow to track user activity. Then, using Snowplow Micro we will be testing that tracking is properly configured on our site using, as examples, two populat web test tools, Nightwatch and Cypress.
+Our demo web app uses Snowplow to track user activity. Then, using Snowplow Micro we will be testing that tracking is properly configured on our site using, as examples, two popular web test tools, Nightwatch and Cypress.
 
 ### Overview of the demo app
 


### PR DESCRIPTION
There was a small **typo populat instead of popular**, I just updated that for the page under heading tracking design: https://docs.snowplow.io/docs/managing-data-quality/testing-and-qa-workflows/set-up-automated-testing-with-snowplow-micro/#organisation-of-tests