### PR TITLE
change browser context autotracked to false

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/ootb-data/device-and-browser/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/ootb-data/device-and-browser/index.md
@@ -22,7 +22,7 @@ The following context entities are attached at the tracker based on information 
 This is an optional feature on the JavaScript tracker that adds browser information that is normally tracked in the atomic event properties (see above) plus some extra information (such as the tab ID) as a context entity.
 
 <SchemaProperties
-  overview={{event: false, web: true, mobile: false, automatic: true}}
+  overview={{event: false, web: true, mobile: false, automatic: false}}
   example={{
     viewport: null,
     documentSize: null,


### PR DESCRIPTION
95% sure browser context is not tracked by default. Reference this docs page: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracker-setup/initialization-options/ 

Should confirm, but if correct this should be changed