### PR TITLE
Add v4, remove v2 from third party CDN hosting

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracker-setup/hosting-the-javascript-tracker/third-party-cdn-hosting/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/web-tracker/tracker-setup/hosting-the-javascript-tracker/third-party-cdn-hosting/index.md
@@ -12,19 +12,12 @@ If you wish to follow our recommended best practices, please follow our [self ho
 
 ## jsDelivr CDN
 
-Snowplow JavaScript Tracker v2 and v3 assets are available via the [jsDelivr](http://jsdelivr.com) CDN. Click the links below to explore the available assets:
+Snowplow JavaScript Tracker v3 and v4 assets are available via the [jsDelivr](http://jsdelivr.com) CDN. Click the links below to explore the available assets:
 
-[JavaScript Tracker v3 on jsDelivr](https://www.jsdelivr.com/package/npm/@snowplow/javascript-tracker?path=dist)  
-[JavaScript Tracker v2 on jsDelivr](https://www.jsdelivr.com/package/gh/snowplow/sp-js-assets)
-
-## cdnjs CDN
-
-Snowplow JavaScript Tracker v2 is available via the [cdnjs](https://cdnjs.com/) CDN. v3 will be available soon. Click the link below to explore the available assets:
-
-[Snowplow JavaScript Tracker v2 on cdnjs](https://cdnjs.com/libraries/snowplow)
+[JavaScript Tracker v3 and v4 on jsDelivr](https://www.jsdelivr.com/package/npm/@snowplow/javascript-tracker?path=dist)  
 
 ## unpkg CDN
 
-Snowplow JavaScript Tracker v3 is available via the [unpkg](https://unpkg.com/) CDN. Click the link below to explore the available assets:
+Snowplow JavaScript Tracker v3 and v4 is available via the [unpkg](https://unpkg.com/) CDN. Click the link below to explore the available assets:
 
-[Snowplow JavaScript Tracker v3 on unpkg](https://unpkg.com/browse/@snowplow/javascript-tracker@latest/dist/)
+[Snowplow JavaScript Tracker v3 and v4 on unpkg](https://unpkg.com/browse/@snowplow/javascript-tracker@latest/dist/)


### PR DESCRIPTION
This PR removes mentions of JavaScript v2 from the third party CDN hosts, and adds in v4.