### PR TITLE
Clarify the vm sku command for Azure

### DIFF
--- a/docs/get-started/snowplow-bdp/private-managed-cloud/setup-guide-azure/index.md
+++ b/docs/get-started/snowplow-bdp/private-managed-cloud/setup-guide-azure/index.md
@@ -83,13 +83,18 @@ You must check that the following infrastructure is available in the subscriptio
 
 Snowplow requires the below instances and databases. We have provided the Azure CLI commands that can be used to check their availability. Please note that they are required in all availability zones in the region for redundancy.
 
-Instances DSv5 (preferred), DSv4 and DSv3 series:
+Instances D4s_v5 (preferred), or D4s_v4 series:
 
-`az vm list-skus --location <REGION> --size Standard_D4s --all --output table`
+```bash
+az vm list-skus --location <REGION> --size Standard_D4s_v5 --all --output table
+az vm list-skus --location <REGION> --size Standard_D4s_v4 --all --output table
+```
 
 Database B_Standard_B2s:
 
-`az vm list-skus --location <REGION> --size Standard_B2s --all --output table`
+```bash
+az vm list-skus --location <REGION> --size Standard_B2s --all --output table
+```
 
 Please note that the above is for a minimal deployment. If you will be sending over one billion events per month through the pipeline, please speak to us for advice on what instance sizes are recommended. 
 


### PR DESCRIPTION
Clarify the VM list-sku commands based on customer feedback.

Explicitly specify the commands and remove the D4S_v3 which would get rejected at deployment.

Updated docs/get-started/snowplow-bdp/private-managed-cloud/setup-guide-azure/

<img width="947" alt="image" src="https://github.com/user-attachments/assets/c8aa1c61-2e36-4882-b3bf-4169d62b1b62" />
