### PR TITLE
Add docs for mobile trackers 6.2.0 update

### DIFF
--- a/docs/sources/trackers/mobile-trackers/installation-and-set-up/android-tracker/index.md
+++ b/docs/sources/trackers/mobile-trackers/installation-and-set-up/android-tracker/index.md
@@ -130,6 +130,7 @@ val sessionConfig = SessionConfiguration(
     TimeMeasure(30, TimeUnit.SECONDS),
     TimeMeasure(30, TimeUnit.SECONDS)
 )
+    .continueSessionOnRestart(false)
 createTracker(
     applicationContext,
     "appTracker",
@@ -162,7 +163,8 @@ TrackerConfiguration trackerConfig = new TrackerConfiguration("appId")
 SessionConfiguration sessionConfig = new SessionConfiguration(
     new TimeMeasure(30, TimeUnit.SECONDS),
     new TimeMeasure(30, TimeUnit.SECONDS)
-);
+)
+    .continueSessionOnRestart(false);
 Snowplow.createTracker(
     getApplicationContext(),
     "appTracker",

--- a/docs/sources/trackers/mobile-trackers/installation-and-set-up/ios-tracker/index.md
+++ b/docs/sources/trackers/mobile-trackers/installation-and-set-up/ios-tracker/index.md
@@ -88,6 +88,7 @@ Snowplow.createTracker(namespace: "appTracker", endpoint: "https://snowplow-coll
       foregroundTimeout: Measurement(value: 30, unit: .minutes),
       backgroundTimeout: Measurement(value: 30, unit: .minutes)
   )
+      .continueSessionOnRestart(false)
 }
 ```
 

--- a/docs/sources/trackers/mobile-trackers/tracking-events/session-tracking/index.md
+++ b/docs/sources/trackers/mobile-trackers/tracking-events/session-tracking/index.md
@@ -277,3 +277,42 @@ Uri decoratedLink = Snowplow.getDefaultTracker().decorateLink(link, new CrossDev
 
   </TabItem>
 </Tabs>
+
+## Session behavior on app restarts
+
+By default, each time the mobile app restarts (or when a new tracker instance is created), a new session is started regardless of whether the previous session timed out or not.
+
+Since version 6.2 of the iOS and Android trackers, there is an option to continue the previously persisted session when the app restarts.
+The previous session is only continued in case the app is restarted within the configured session timeout interval.
+The option can be configured using `SessionConfiguration`:
+
+<Tabs groupId="platform" queryString>
+  <TabItem value="ios" label="iOS" default>
+
+```swift
+let sessionConfig = SessionConfiguration()
+    .continueSessionOnRestart(true)
+```
+
+  </TabItem>
+  <TabItem value="android" label="Android (Kotlin)">
+
+```kotlin
+val sessionConfig = SessionConfiguration()
+    .continueSessionOnRestart(true)
+```
+
+  </TabItem>
+  <TabItem value="android-java" label="Android (Java)">
+
+```java
+SessionConfiguration trackerConfig = new SessionConfiguration()
+    .continueSessionOnRestart(true);
+```
+
+  </TabItem>
+</Tabs>
+
+With the option enabled, every session update is persisted to user defaults or shared preferences storage.
+In case it's disabled, only session changes are persisted to UserDefaults.
+This means that there is more overhead when the option is enabled.

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -1,12 +1,12 @@
 export const versions = {
   // Trackers
-  androidTracker: '6.1.0',
+  androidTracker: '6.2.0',
   dotNetTracker: '1.3.0',
   cppTracker: '2.0.0',
   flutterTracker: '0.7.1',
   golangTracker: '3.1.0',
   googleAmpTracker: '1.1.0',
-  iosTracker: '6.1.0',
+  iosTracker: '6.2.0',
   javaTracker: '2.1.0',
   javaScriptTracker: '4.3.0',
   luaTracker: '0.2.0',


### PR DESCRIPTION
Includes documentation for the new continue session on app restart option.