### PR TITLE
Update Tutorials CSS

### DIFF
--- a/src/components/tutorials/Header.tsx
+++ b/src/components/tutorials/Header.tsx
@@ -11,8 +11,15 @@ export function Header({ title, label }: { title: string; label: string }) {
   return (
     <Grid container direction="column" rowSpacing={0}>
       <Grid item>
-        <Link to="/tutorials">
-          <ChevronLeftIcon /> Back to Tutorials
+        <Link
+          to="/tutorials"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+          }}
+        >
+          <ChevronLeftIcon />
+          Back to Tutorials
         </Link>
       </Grid>
       <Grid item container alignItems="center" columnSpacing={2} sx={{ mb: 3 }}>

--- a/src/components/tutorials/Header.tsx
+++ b/src/components/tutorials/Header.tsx
@@ -19,7 +19,7 @@ export function Header({ title, label }: { title: string; label: string }) {
           }}
         >
           <ChevronLeftIcon />
-          Back to Tutorials
+          Tutorials
         </Link>
       </Grid>
       <Grid item container alignItems="center" columnSpacing={2} sx={{ mb: 3 }}>

--- a/src/components/tutorials/Header.tsx
+++ b/src/components/tutorials/Header.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 
 import { Link } from 'react-router-dom'
 
-import { Breadcrumbs, Grid, Typography } from '@mui/material'
+import { Grid } from '@mui/material'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 
 import { Topic, TutorialTitle } from './TutorialList/styledComponents'
 
@@ -10,10 +11,9 @@ export function Header({ title, label }: { title: string; label: string }) {
   return (
     <Grid container direction="column" rowSpacing={0}>
       <Grid item>
-        <Breadcrumbs>
-          <Link to="/tutorials">Tutorials & Guides</Link>
-          <Typography>{title}</Typography>
-        </Breadcrumbs>
+        <Link to="/tutorials">
+          <ChevronLeftIcon /> Back to Tutorials
+        </Link>
       </Grid>
       <Grid item container alignItems="center" columnSpacing={2} sx={{ mb: 3 }}>
         <Grid item>

--- a/src/components/tutorials/Header.tsx
+++ b/src/components/tutorials/Header.tsx
@@ -17,7 +17,9 @@ export function Header({ title, label }: { title: string; label: string }) {
       </Grid>
       <Grid item container alignItems="center" columnSpacing={2} sx={{ mb: 3 }}>
         <Grid item>
-          <TutorialTitle variant="h4">{title}</TutorialTitle>
+          <TutorialTitle className="tutorial-title" variant="h4">
+            {title}
+          </TutorialTitle>
         </Grid>
         <Grid item>
           <Topic label={label} />

--- a/src/components/tutorials/TutorialList/index.tsx
+++ b/src/components/tutorials/TutorialList/index.tsx
@@ -25,6 +25,8 @@ import {
 import { Meta, Topic as TopicType, Tutorial } from '../models'
 import { Card, Description, StartButton, Topic } from './styledComponents'
 
+import Head from '@docusaurus/Head'
+
 function getFirstStepPath(meta: Meta): string | null {
   const steps = getSteps(meta.id)
   if (steps.length === 0) {
@@ -144,22 +146,29 @@ const TutorialList: FC = () => {
     [search, topic, parsedTutorials]
   )
 
-  return isMobile ? (
-    <MobileTutorialList
-      search={search}
-      setSearch={setSearch}
-      topic={topic}
-      setTopic={setTopic}
-      tutorials={tutorials}
-    />
-  ) : (
-    <DesktopTutorialList
-      search={search}
-      setSearch={setSearch}
-      topic={topic}
-      setTopic={setTopic}
-      tutorials={tutorials}
-    />
+  return (
+    <>
+      <Head>
+        <title>Tutorials | Snowplow Documentation</title>
+      </Head>{' '}
+      {isMobile ? (
+        <MobileTutorialList
+          search={search}
+          setSearch={setSearch}
+          topic={topic}
+          setTopic={setTopic}
+          tutorials={tutorials}
+        />
+      ) : (
+        <DesktopTutorialList
+          search={search}
+          setSearch={setSearch}
+          topic={topic}
+          setTopic={setTopic}
+          tutorials={tutorials}
+        />
+      )}
+    </>
   )
 }
 

--- a/src/components/tutorials/TutorialList/index.tsx
+++ b/src/components/tutorials/TutorialList/index.tsx
@@ -2,10 +2,9 @@ import React, { FC, useEffect, useMemo, useState } from 'react'
 
 import Link from '@docusaurus/Link'
 import { useHistory } from '@docusaurus/router'
-import { ChevronRight, Search } from '@mui/icons-material'
+import { ChevronRight } from '@mui/icons-material'
 import {
   Box,
-  FormControl,
   Grid,
   InputAdornment,
   MenuItem,

--- a/src/components/tutorials/TutorialList/index.tsx
+++ b/src/components/tutorials/TutorialList/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react'
+import React, { FC, useMemo, useState } from 'react'
 
 import Link from '@docusaurus/Link'
 import { useHistory } from '@docusaurus/router'
@@ -202,7 +202,7 @@ const DesktopTutorialList: FC<{
   topic: TopicDropdown
   setTopic: React.Dispatch<React.SetStateAction<TopicDropdown>>
   tutorials: Tutorial[]
-}> = ({ search, setSearch, topic, setTopic, tutorials }) => {
+}> = ({ setSearch, topic, setTopic, tutorials }) => {
   return (
     <Box marginX={8} marginY={3} sx={{ minWidth: '90vw', mr: 0 }}>
       <Grid container columnSpacing={2}>

--- a/src/components/tutorials/TutorialList/index.tsx
+++ b/src/components/tutorials/TutorialList/index.tsx
@@ -38,7 +38,7 @@ const TutorialCard: FC<{ tutorial: Tutorial }> = ({ tutorial }) => {
   const firstStep = getFirstStepPath(tutorial.meta)
 
   return (
-    <Card>
+    <Card sx={{ height: '100%' }}>
       <Grid
         container
         direction="column"

--- a/src/components/tutorials/TutorialList/index.tsx
+++ b/src/components/tutorials/TutorialList/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo, useState } from 'react'
 
 import Link from '@docusaurus/Link'
+import Head from '@docusaurus/Head'
 import { useHistory } from '@docusaurus/router'
 import { ChevronRight } from '@mui/icons-material'
 import {
@@ -24,8 +25,6 @@ import {
 } from './styledComponents'
 import { Meta, Topic as TopicType, Tutorial } from '../models'
 import { Card, Description, StartButton, Topic } from './styledComponents'
-
-import Head from '@docusaurus/Head'
 
 function getFirstStepPath(meta: Meta): string | null {
   const steps = getSteps(meta.id)
@@ -153,7 +152,6 @@ const TutorialList: FC = () => {
       </Head>{' '}
       {isMobile ? (
         <MobileTutorialList
-          search={search}
           setSearch={setSearch}
           topic={topic}
           setTopic={setTopic}
@@ -161,7 +159,6 @@ const TutorialList: FC = () => {
         />
       ) : (
         <DesktopTutorialList
-          search={search}
           setSearch={setSearch}
           topic={topic}
           setTopic={setTopic}
@@ -183,12 +180,11 @@ function filterTutorials(
 }
 
 const MobileTutorialList: FC<{
-  search: string
   setSearch: React.Dispatch<React.SetStateAction<string>>
   topic: TopicDropdown
   setTopic: React.Dispatch<React.SetStateAction<TopicDropdown>>
   tutorials: Tutorial[]
-}> = ({ search, setSearch, topic, setTopic, tutorials }) => {
+}> = ({ setSearch, topic, setTopic, tutorials }) => {
   return (
     <Box sx={{ mt: 1 }}>
       <Grid container direction="column" rowSpacing={2}>
@@ -206,7 +202,6 @@ const MobileTutorialList: FC<{
 }
 
 const DesktopTutorialList: FC<{
-  search: string
   setSearch: React.Dispatch<React.SetStateAction<string>>
   topic: TopicDropdown
   setTopic: React.Dispatch<React.SetStateAction<TopicDropdown>>

--- a/src/components/tutorials/TutorialTabs.tsx
+++ b/src/components/tutorials/TutorialTabs.tsx
@@ -51,7 +51,7 @@ export const DocsTutorialsTabsMobile: React.FC = () => {
       <Tab value={DocsTab.Docs} label="Docs" sx={{ textTransform: 'none' }} />
       <Tab
         value={DocsTab.Tutorials}
-        label="Tutorials & Guides"
+        label="Tutorials"
         sx={{ textTransform: 'none' }}
       />
     </Tabs>
@@ -91,12 +91,14 @@ export const DocsTutorialsTabsDesktop: React.FC = () => {
         value={DocsTab.Docs}
         label="Docs"
         sx={{ textTransform: 'none' }}
+        href={DocsTab.Docs}
       />
       <Tab
         onClick={() => changeTab(DocsTab.Tutorials)}
         value={DocsTab.Tutorials}
-        label="Tutorials & Guides"
+        label="Tutorials"
         sx={{ textTransform: 'none' }}
+        href={DocsTab.Tutorials}
       />
     </Tabs>
   )


### PR DESCRIPTION
* make the cards all the same height
* add a selector for titles
* take out repetitive breadcrumbs
* change the name of the tab to Tutorials, not Tutorials & Guides
* make the docs/tutorials tabs right-clickable
* gives the tutorial cards page a proper title not "index | Snowplow Documentation"