### PR TITLE
Added note on the warning that also screen_view events are included in base_events_this_run

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/conversions/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/conversions/index.md
@@ -29,7 +29,7 @@ By configuring the conversion specifications through the `snowplow__conversion_e
 
 :::caution
 
-Because this is part of the sessions table within the Unified dbt package, we still expect your sessions to contain at least one `page_view` or `page_ping` event, and the events must all have a `session_identifier` to be included in the `base_events_this_run_table`. Without a `session_identifier` the event will not be visible to the model, and without a `page_view` or `page_ping` in the session there will be no session record for the model to attach the conversions to.
+Because this is part of the sessions table within the Unified dbt package, we still expect your sessions to contain at least one `page_view`, a `page_ping` or a `screen_view` event, and the events must all have a `session_identifier` to be included in the `base_events_this_run_table`. Without a `session_identifier` the event will not be visible to the model, and without a `page_view`, a `page_ping` or a `screen_view` in the session there will be no session record for the model to attach the conversions to.
 
 :::
 


### PR DESCRIPTION
The caution suggests that only `page_view` and `page_ping` events are supported within the Unified package. This isn't exactly right, as `screen_view` events on mobile are also included. 