### PR TITLE
Rename "ID Service" to "Cookie Extension Service" in GTM 

### DIFF
--- a/docs/sources/trackers/google-tag-manager/settings-template/index.md
+++ b/docs/sources/trackers/google-tag-manager/settings-template/index.md
@@ -86,9 +86,9 @@ This setting disables client-side user identifiers but tracks session informatio
 
 See [here](/docs/resources/recipes-tutorials/recipe-anonymous-tracking/index.md) for more information on anonymous tracking.
 
-#### ID Service
+#### Cookie Extension Service
 
-This allows you to set the endpoint for the [ID service](/docs/sources/trackers/javascript-trackers/web-tracker/browsers/index.md#what-is-a-cookie-extension-service-).
+This allows you to set the endpoint for the [Cookie Extension Service](/docs/sources/trackers/javascript-trackers/web-tracker/browsers/index.md#what-is-a-cookie-extension-service-).
 
 ## Cookie Settings
 


### PR DESCRIPTION
Documentation update for https://github.com/snowplow/snowplow-gtm-variable-template-v4/pull/11