### PR TITLE
Include link to Console API docs in API Reference navigation

### DIFF
--- a/docs/api-reference/console-api.md
+++ b/docs/api-reference/console-api.md
@@ -1,0 +1,5 @@
+---
+type: link
+title: Console API
+href: https://console.snowplowanalytics.com/api/msc/v1/docs/
+---


### PR DESCRIPTION
It's currently linked on several pages, but not any that are in the actual API Reference section.