### PR TITLE
Tutorial layout enhacements

### DIFF
--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -50,12 +50,12 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
       <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
-          <article className="overflow-x-auto max-w-none leading-relaxed prose prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-base prose-img:mx-auto prose-img:block">
+          <article className="overflow-x-auto max-w-fit leading-relaxed prose prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-base prose-img:mx-auto prose-img:block ">
             <DocBreadcrumbs />
             <DocVersionBadge />
             {docTOC.mobile}
             {tutorial === TutorialKind.Tutorial ? (
-              <Paper sx={{ p: 4, pt: 3 }}>
+              <Paper sx={{ p: 2, pt: 2 }}>
                 <DocItemContent>{children}</DocItemContent>
               </Paper>
             ) : (

--- a/src/theme/DocPage/Layout/Main/Paginators.tsx
+++ b/src/theme/DocPage/Layout/Main/Paginators.tsx
@@ -9,9 +9,11 @@ export const Paginators: React.FC<{
   prev: Step | null
   setActiveStep: (step: Step) => void
   isMobile?: boolean
-}> = ({ next, prev, setActiveStep, isMobile = false }) => {
+  className?: string
+}> = ({ next, prev, setActiveStep, isMobile = false, className }) => {
   return (
     <Box
+      className={className}
       sx={{
         display: 'flex',
         width: '100%',
@@ -51,7 +53,7 @@ export const Paginators: React.FC<{
           </Grid>
         )}
       </Grid>
-      {!isMobile && <Box className="col col--3"></Box>}
+      
     </Box>
   )
 }

--- a/src/theme/DocPage/Layout/Main/index.tsx
+++ b/src/theme/DocPage/Layout/Main/index.tsx
@@ -218,11 +218,12 @@ const TutorialDocPageLayoutMobile: FC<{
 }> = ({ children, meta, steps, activeStep, setActiveStep, next, prev }) => {
   return (
     <Grid
-      sx={{ m: 2, mt: 0 }}
+      sx={{ m: 0, mt: 0 }}
       rowSpacing={2}
       container
       direction="column"
       wrap="nowrap"
+      className='p-4'
     >
       <Grid item>
         <Header title={meta?.title || ''} label={meta?.label || ''} />
@@ -235,8 +236,11 @@ const TutorialDocPageLayoutMobile: FC<{
           isMobile
         />
       </Grid>
-      <Grid item>{children}</Grid>
+      
+      <Grid item>{children}
       <Paginators next={next} prev={prev} setActiveStep={setActiveStep} />
+      </Grid>
+      
     </Grid>
   )
 }
@@ -251,7 +255,7 @@ const TutorialDocPageLayoutDesktop: FC<{
   prev: Step | null
 }> = ({ children, meta, steps, activeStep, setActiveStep, next, prev }) => {
   return (
-    <Grid container sx={{ m: 3, width: '100%' }} columnSpacing={1}>
+    <Grid container sx={{width: '100%' }} columnSpacing={1} className='px-4 py-8'>
       <Grid container item direction="column">
         <Grid item>
           <Header title={meta?.title || ''} label={meta?.label || ''} />
@@ -267,8 +271,9 @@ const TutorialDocPageLayoutDesktop: FC<{
           <Grid container item xs={9}>
             <Grid sx={{ width: '100%' }} item>
               {children}
+              <Paginators className="max-w-[75%]" next={next} prev={prev} setActiveStep={setActiveStep} />
             </Grid>
-            <Paginators next={next} prev={prev} setActiveStep={setActiveStep} />
+            
           </Grid>
         </Grid>
       </Grid>

--- a/src/theme/DocPage/Layout/Main/index.tsx
+++ b/src/theme/DocPage/Layout/Main/index.tsx
@@ -140,7 +140,7 @@ const TutorialDocPageLayout: FC<Props> = ({
   return (
     <main
       className={clsx(
-        'tutorial-doc-page',
+        'tutorial-doc-page', 'flex', 'w-full',
         styles.docMainContainer,
         (hiddenSidebarContainer || !sidebar) && styles.docMainContainerEnhanced
       )}
@@ -251,20 +251,20 @@ const TutorialDocPageLayoutDesktop: FC<{
   prev: Step | null
 }> = ({ children, meta, steps, activeStep, setActiveStep, next, prev }) => {
   return (
-    <Grid container sx={{ m: 3, width: '100%' }} columnSpacing={5}>
+    <Grid container sx={{ m: 3, width: '100%' }} columnSpacing={1}>
       <Grid container item direction="column">
         <Grid item>
           <Header title={meta?.title || ''} label={meta?.label || ''} />
         </Grid>
-        <Grid container item wrap="nowrap" columnGap={5}>
-          <Grid item xs={3} sx={{ minWidth: '250px' }}>
+        <Grid container item wrap="nowrap" columnGap={3}>
+          <Grid item xs={2} sx={{ minWidth: '240px' }}>
             <Steps
               steps={steps}
               activeStep={activeStep}
               setActiveStep={setActiveStep}
             />
           </Grid>
-          <Grid container item xs={8}>
+          <Grid container item xs={9}>
             <Grid sx={{ width: '100%' }} item>
               {children}
             </Grid>


### PR DESCRIPTION

### The Bug Noticed on the tutorial Page

-   the Tutorials layout looked a bit squished and the column spacing was inconsistent compared to the Docs layout.

-   You also encountered a bug where the  Paginators component was being passed a  className prop that it did not accept, resulting in a TypeScript error.

### How You Fixed It

1.  Paginators Component Update:

-   You updated the  Paginators component to accept an optional  className prop and applied it to the root Box element. This resolved the TypeScript error and allowed you to style the paginator as needed.

2.  Tutorial Layout Spacing Fixes:

-   In the mobile layout (TutorialDocPageLayoutMobile), you:

-   Changed the Grid container’s margin from  { m:  2, mt:  0 } to { m: 0, mt:  0 } and added a  className='p-4' for consistent padding.

-   In the desktop layout (TutorialDocPageLayoutDesktop), you:

-   Removed the outer margin (m:  3) from the main  Grid container and replaced it with  className='px-4 py-8' for more consistent and spacious padding.

-   Adjusted the  Paginators component’s width by changing its  className from  "max-w-60" to  "max-w-[75%]", making it less squished and more visually balanced.

----------

Result:

The Tutorials layout now has more consistent and spacious padding, and the column spacing matches the Docs layout better. The paginator is no longer squished, and the bug with the className prop is resolved. The overall user experience and visual consistency between Tutorials and Docs have improved.