### PR TITLE
Snowbridge 3.3.0

### DIFF
--- a/docs/destinations/forwarding-events/snowbridge/configuration/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/index.md
@@ -4,6 +4,11 @@ date: "2022-10-20"
 sidebar_position: 300
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # Configuration Overview
 
 Snowbridge is configured using [HCL](https://github.com/hashicorp/hcl). To configure Snowbridge, create your configuration in a file with `.hcl` extension, and set the `SNOWBRIDGE_CONFIG_FILE` environment variable to the path to your file. By default, the Snowbridge docker image uses `/tmp/config.hcl` as the config path - when using the docker images you can either mount your config file to `/tmp/config.hcl`, or mount it to a different path, and set the `SNOWBRIDGE_CONFIG_FILE` environment variable in your docker container to that path.
@@ -23,7 +28,7 @@ If you do not provide a configuration, or provide an empty one, the application 
 * no transformations;
 * `stdout` target;
 * `stdout` failure target.
-There’ll be no external statistics reporting or sentry error reporting.
+There'll be no external statistics reporting or sentry error reporting.
 
 ## License
 
@@ -43,6 +48,6 @@ The below example is a complete configuration, which specifies a kinesis source,
 
 In layman's terms, this configuration will read data from a kinesis stream, filter out any data whose `event_name` field is not `page_view`, run a custom Javascript script upon the data to change the `app_id` to `"1"`, and send the transformed page view data to pubsub. It will also send statistics about what it's doing to a statsD endpoint, and will send information about errors to a sentry endpoint.
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/overview-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/overview-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/monitoring/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/monitoring/index.md
@@ -4,39 +4,44 @@ date: "2022-10-20"
 sidebar_position: 400
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # Monitoring Configuration
 
 ## Stats and metrics
 
-Snowbridge comes with configurable logging, [pprof](https://github.com/google/pprof) profiling, [statsD](https://www.datadoghq.com/statsd-monitoring) statistics and [Sentry](https://sentry.io/welcome/) integrations to ensure that you know what’s going on.
+Snowbridge comes with configurable logging, [pprof](https://github.com/google/pprof) profiling, [statsD](https://www.datadoghq.com/statsd-monitoring) statistics and [Sentry](https://sentry.io/welcome/) integrations to ensure that you know what's going on.
 
 ### Logging
 
 Use the log_level parameter to specify the log level.
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/monitoring/log-level-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/monitoring/log-level-example.hcl
+`}</CodeBlock>
 
 ### Sentry Configuration
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/monitoring/sentry-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/monitoring/sentry-example.hcl
+`}</CodeBlock>
 
 ### StatsD stats receiver configuration
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/monitoring/statsd-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/monitoring/statsd-example.hcl
+`}</CodeBlock>
 
 ### End-to-end latency configuration
 
 Snowplow Enriched data only:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/metrics/e2e-latency-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/metrics/e2e-latency-example.hcl
+`}</CodeBlock>
 
 Snowbridge sends the following metrics to statsd:
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/retries/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/retries/index.md
@@ -3,6 +3,11 @@ title: "Retry behavior (beta)"
 description: "Configure retry behaviour."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 :::note
 This feature was added in version 3.0.0
 
@@ -21,6 +26,6 @@ Retries will be attempted with an exponential backoff. In other words, on each s
 
 ## Configuration options
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/retry-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/retry-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/index.md
@@ -4,6 +4,11 @@ date: "2022-10-20"
 sidebar_position: 100
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 **Stdin source** is the default. We also support Kafka, Kinesis, PubSub, and SQS sources.
 
 Stdin source simply treats stdin as the input. It has one optional configuration to set the concurrency.
@@ -12,12 +17,12 @@ Stdin source simply treats stdin as the input. It has one optional configuration
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/stdin-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/stdin-minimal-example.hcl
+`}</CodeBlock>
 
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/stdin-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/stdin-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/kafka.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/kafka.md
@@ -3,6 +3,11 @@ title: "Kafka"
 description: "Read data from a Kafka topic."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Authentication
 
 Authentication is done by providing valid credentials in the configuration.
@@ -11,12 +16,12 @@ Authentication is done by providing valid credentials in the configuration.
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/kafka-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kafka-minimal-example.hcl
+`}</CodeBlock>
 
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/kafka-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kafka-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/kinesis.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/kinesis.md
@@ -3,6 +3,11 @@ title: "Kinesis"
 description: "Read data from a Kinesis stream."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 :::note
 
 To use this source, you need the AWS-specific version of Snowbridge that can only be run on AWS. See [the page on Snowbridge distributions](/docs/destinations/forwarding-events/snowbridge/getting-started/index.md) for more information.
@@ -34,12 +39,12 @@ Assuming your AWS credentials have sufficient permission for Kinesis and DynamoD
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/kinesis-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kinesis-minimal-example.hcl
+`}</CodeBlock>
 
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/kinesis-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kinesis-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/pubsub.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/pubsub.md
@@ -3,6 +3,11 @@ title: "PubSub"
 description: "Read data from a PubSub topic."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Authentication
 
 Authentication is done using a [GCP Service Account](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa). Create a service account credentials file, and provide the path to it via the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
@@ -13,12 +18,12 @@ Snowbridge connects to PubSub using [Google's Go Pubsub sdk](https://cloud.googl
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/pubsub-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/pubsub-minimal-example.hcl
+`}</CodeBlock>
 
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/pubsub-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/pubsub-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/sqs.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/sqs.md
@@ -3,6 +3,11 @@ title: "SQS"
 description: "Read data from an SQS queue."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # SQS Source
 
 Read data from an SQS queue.
@@ -15,12 +20,12 @@ Authentication is done via the [AWS authentication environment variables](https:
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/sqs-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/sqs-minimal-example.hcl
+`}</CodeBlock>
 
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/sources/sqs-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/sqs-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/eventhub.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/eventhub.md
@@ -3,6 +3,11 @@ title: "EventHub"
 description: "Write data to an EventHub."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Authentication
 
 Authentication for the EventHub target is done by configuring any valid combination of the environment variables [listed in the Azure Event Hubs Client documentation](https://pkg.go.dev/github.com/Azure/azure-event-hubs-go#NewHubWithNamespaceNameAndEnvironment).
@@ -11,15 +16,15 @@ Authentication for the EventHub target is done by configuring any valid combinat
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/eventhub-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/eventhub-minimal-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/eventhub-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/eventhub-full-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md
@@ -3,6 +3,11 @@ title: "HTTP"
 description: "Send data over HTTP."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 :::note
 Version 3.0.0 makes breaking changes to the HTTP target. Details on migrating can be found [in the migration guide](/docs/destinations/forwarding-events/snowbridge/3-X-X-upgrade-guide/index.md)
 :::
@@ -49,13 +54,13 @@ In addition to all base functions available in the Go text/template package, the
 
 `env` - Allows you to set and refer to an env var in your template. Use it when your request body must contain sensitive data, for example an API key.
 
-### Template example
+### Template example
 
 The following example provides an API key via environment variable, and iterates the batch to provide JSON-formatted data one by one into a new key, inserting a comma before all but the first event.
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/http-template-full-example.file
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/http-template-full-example.file
+`}</CodeBlock>
 
 ## Response rules (beta)
 
@@ -83,15 +88,15 @@ Data that matches a setup response rule is handled by a retry as determined in t
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/http-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/http-minimal-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/http-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/http-full-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/index.md
@@ -4,6 +4,11 @@ date: "2022-10-20"
 sidebar_position: 300
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 **Stdout target** is the default. We also support EventHub, HTTP, Kafka, Kinese, PubSub, and SQS targets.
 
 Stdout target doesn't have any configurable options - when configured it simply outputs the messages to stdout.
@@ -12,8 +17,8 @@ Stdout target doesn't have any configurable options - when configured it simply 
 
 Here is an example of the configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/stdout-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/stdout-full-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use `failure_target` instead of `target`.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/kafka.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/kafka.md
@@ -3,6 +3,11 @@ title: "Kafka"
 description: "Write data to a Kafka topic."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Authentication
 
 Where SASL is used, it may be enabled via the `enable_sasl`, `sasl_username`, and `sasl_password` and `sasl_algorithm` options.
@@ -16,16 +21,16 @@ TLS may be configured by providing the `key_file`, `cert_file` and `ca_file` opt
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/kafka-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kafka-minimal-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/kafka-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kafka-full-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/kinesis.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/kinesis.md
@@ -3,6 +3,11 @@ title: "Kinesis"
 description: "Write data to a Kinesis stream."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Authentication
 
 Authentication is done via the [AWS authentication environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). Optionally, you can use the `role_arn` option to specify an ARN to use on the stream.
@@ -15,15 +20,15 @@ As of 2.4.2, the kinesis target handles kinesis write throughput exceptions sepa
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/kinesis-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kinesis-minimal-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/kinesis-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kinesis-full-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/pubsub.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/pubsub.md
@@ -3,6 +3,11 @@ title: "PubSub"
 description: "Write data to a Pubsub topic."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Authentication
 
 Authentication is done using a [GCP Service Account](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa). Create a service account credentials file, and provide the path to it via the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
@@ -13,8 +18,8 @@ Snowbridge connects to PubSub using [Google's Go Pubsub sdk](https://cloud.googl
 
 The PubSub Target has only two required options, and no optional ones.
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/pubsub-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/pubsub-full-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/sqs.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/sqs.md
@@ -3,6 +3,11 @@ title: "SQS"
 description: "Write data to an SQS queue."
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Authentication
 
 Authentication is done via the [AWS authentication environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). Optionally, you can use the `role_arn` option to specify an ARN to use on the queue.
@@ -12,16 +17,16 @@ Authentication is done via the [AWS authentication environment variables](https:
 
 Here is an example of the minimum required configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/sqs-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/sqs-minimal-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 
 Here is an example of every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/targets/sqs-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/sqs-full-example.hcl
+`}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # base64Decode
 
 Introduced in version 2.1.0
@@ -10,6 +15,6 @@ This transformation base64 decodes the message's data from a base64 byte array, 
 
 ## Configuration options
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/builtin/base64Decode-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/base64Decode-minimal-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
@@ -1,9 +1,12 @@
+---
+title: "base64Decode"
+description: "Base64 decodes the message's data."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# base64Decode
 
 Introduced in version 2.1.0
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
@@ -1,9 +1,12 @@
+---
+title: "base64Encode"
+description: "Base64 encodes the message's data."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# base64Encode
 
 Introduced in version 2.1.0
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # base64Encode
 
 Introduced in version 2.1.0
@@ -10,6 +15,6 @@ This transformation base64 encodes the message's data to a base 64 byte array.
 
 ## Configuration options
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/builtin/base64Encode-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/base64Encode-minimal-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
@@ -1,9 +1,12 @@
+---
+title: "jq"
+description: "Runs a jq command on the message data and outputs the result."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# jq
 
 :::note
 This transformation was added in version 3.0.0.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # jq
 
 :::note
@@ -22,15 +27,15 @@ The jq transformation will remove any keys with null values from the data.
 
 Minimal configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/builtin/jq-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jq-minimal-example.hcl
+`}</CodeBlock>
 
 Every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/builtin/jq-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jq-full-example.hcl
+`}</CodeBlock>
 
 ## Helper functions
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
@@ -1,9 +1,12 @@
+---
+title: "jqFilter"
+description: "Filters messages based on the output of a jq command."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# jqFilter
 
 :::note
 This transformation was added in version 3.0.0.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # jqFilter
 
 :::note
@@ -20,15 +25,15 @@ This example filters out all data that doesn't have an `app_id` key.
 
 Minimal configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/builtin/jqFilter-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jqFilter-minimal-example.hcl
+`}</CodeBlock>
 
 Every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/builtin/jqFilter-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jqFilter-full-example.hcl
+`}</CodeBlock>
 
 ## Helper Functions
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/reusable/_jqHelpers.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/reusable/_jqHelpers.md
@@ -11,3 +11,14 @@ In addition to the native functions available in the jq language, the following 
 ```
 { foo: .collector_tstamp | epochMillis }
 ```
+
+* `hash(algorithm, salt)` hashes the input value. To use unsalted hash, pass an empty string for salt. Salt may be provided as an environment variable using hcl syntax.
+
+The following hash algorithms are supported:
+- `sha1` - SHA-1 hash (160 bits)
+- `sha256` - SHA-256 hash (256 bits)
+- `md5` - MD5 hash (128 bits) 
+
+```
+{ foo: .user_id |  hash("sha1"; "${env.SHA1_SALT}") }
+```

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
@@ -1,9 +1,12 @@
+---
+title: "spEnrichedFilter"
+description: "Filters messages based on a regex match against an atomic field."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# spEnrichedFilter
 
 `spEnrichedFilter`: Specific to Snowplow data. Filters messages based on a regex match against an atomic field.
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # spEnrichedFilter
 
 `spEnrichedFilter`: Specific to Snowplow data. Filters messages based on a regex match against an atomic field.
@@ -12,12 +17,12 @@ This example filters out all data whose `platform` value does not match either `
 
 Minimal configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-minimal-example.hcl
+`}</CodeBlock>
 
 Every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # spEnrichedFilterContext
 
 `spEnrichedFilterContext`: Specific to Snowplow data. Filters messages based on a regex match against a field in an entity.
@@ -18,12 +23,12 @@ The below example keeps messages which contain `prod` in the `environment` field
 
 Minimal configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-minimal-example.hcl
+`}</CodeBlock>
 
 Every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
@@ -1,9 +1,12 @@
+---
+title: "spEnrichedFilterContext"
+description: "Filters messages based on a regex match against a field in an entity."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# spEnrichedFilterContext
 
 `spEnrichedFilterContext`: Specific to Snowplow data. Filters messages based on a regex match against a field in an entity.
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # spEnrichedFilterUnstructEvent
 
 `spEnrichedFilterUnstructEvent`: Specific to Snowplow data.  Filters messages based on a regex match against a field in a custom event.
@@ -18,12 +23,12 @@ This example keeps all events whose `add_to_cart` event data at the `sku` field 
 
 Minimal configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-minimal-example.hcl
+`}</CodeBlock>
 
 Every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
@@ -1,9 +1,12 @@
+---
+title: "spEnrichedFilterUnstructEvent"
+description: "Filters messages based on a regex match against a field in a custom event."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# spEnrichedFilterUnstructEvent
 
 `spEnrichedFilterUnstructEvent`: Specific to Snowplow data.  Filters messages based on a regex match against a field in a custom event.
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
@@ -1,9 +1,12 @@
+---
+title: "spEnrichedSetPk"
+description: "Sets the message's destination partition key to an atomic field."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# spEnrichedSetPk
 
 `spEnrichedSetPk`: Specific to Snowplow data. Sets the message's destination partition key to an atomic field from a Snowplow Enriched tsv string.  The input data must be a valid Snowplow enriched TSV.
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # spEnrichedSetPk
 
 `spEnrichedSetPk`: Specific to Snowplow data. Sets the message's destination partition key to an atomic field from a Snowplow Enriched tsv string.  The input data must be a valid Snowplow enriched TSV.
@@ -7,8 +12,8 @@
 
 `SpEnrichedSetPk` only takes one option — the field to use for the partition key.
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-minimal-example.hcl
+`}</CodeBlock>
 
 Note: currently, setting partition key to fields in custom events and contexts is unsupported.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
@@ -1,9 +1,12 @@
+---
+title: "spEnrichedToJson"
+description: "Transforms a message's data from Snowplow Enriched tsv string format to a JSON object."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# SpEnrichedToJson
 
 `spEnrichedToJson`: Specific to Snowplow data. Transforms a message's data from Snowplow Enriched tsv string format to a JSON object. The input data must be a valid Snowplow enriched TSV.
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # SpEnrichedToJson
 
 `spEnrichedToJson`: Specific to Snowplow data. Transforms a message's data from Snowplow Enriched tsv string format to a JSON object. The input data must be a valid Snowplow enriched TSV.
@@ -6,14 +11,14 @@
 
 ## Configuration options
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-minimal-example.hcl
+`}</CodeBlock>
 
 The transformation to JSON is done via the [analytics SDK](/docs/api-reference/analytics-sdk/index.md) logic, specifically in this case the [Golang analytics SDK](/docs/api-reference/analytics-sdk/analytics-sdk-go/index.md).
 
 In brief, the relevant logic here is that:
 
-*   If a field is not populated in the original event, it won’t have a key in the resulting JSON
+*   If a field is not populated in the original event, it won't have a key in the resulting JSON
 
-*   In the TSV, there’s a separate field for `contexts` (sent via tracker), and `derived_contexts` (attached during enrichment). In the analytics SDK, there is one key per context, regardless of which type. (Technically, it’s one key per major version of a context. So if you had a 1.0.0 and a 2.0.0 of the same one, you’d have two keys).
+*   In the TSV, there's a separate field for `contexts` (sent via tracker), and `derived_contexts` (attached during enrichment). In the analytics SDK, there is one key per context, regardless of which type. (Technically, it's one key per major version of a context. So if you had a 1.0.0 and a 2.0.0 of the same one, you'd have two keys).

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
@@ -1,9 +1,12 @@
+---
+title: "spGtmssPreview"
+description: "Extracts a value from the x-gtm-server-preview field and attaches it as the GTM SS preview mode header."
+---
+
 ```mdx-code-block
 import {versions} from '@site/src/componentVersions';
 import CodeBlock from '@theme/CodeBlock';
 ```
-
-# spGtmssPreview
 
 :::note
 This transformation was added in version 2.3.0

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
@@ -1,3 +1,8 @@
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 # spGtmssPreview
 
 :::note
@@ -18,10 +23,10 @@ First, we validate to ensure that the value is a valid base64 string. Second, we
 
 ## Configuration options
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-minimal-example.hcl
+`}</CodeBlock>
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/examples/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/examples/index.md
@@ -4,6 +4,11 @@ date: "2022-10-20"
 sidebar_position: 900
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 Examples showing the transformation of Snowplow or non-Snowplow data.
 
 ## Non-Snowplow data
@@ -20,15 +25,15 @@ For this example, the input data is a json string which looks like this:
 
 The script filters out any data with a `batmobileCount` less than 1, otherwise it updates the Data's `name` field to "Bruce Wayne", and sets the PartitionKey to the value of `id`:
 
-```js reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-script-example.js
-```
+<CodeBlock language="js" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-script-example.js
+`}</CodeBlock>
 
 The configuration for this script is:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-config-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-config-example.hcl
+`}</CodeBlock>
 
 ## Snowplow data
 
@@ -38,12 +43,12 @@ The script below filters out non-web data, based on the `platform` value, otherw
 
 It also sets the partitionKey to `app_id`.
 
-```js reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-script-example.js
-```
+<CodeBlock language="js" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-script-example.js
+`}</CodeBlock>
 
 The configuration for this script is:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-config-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-config-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
@@ -127,6 +127,20 @@ https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/tra
 
 The headers will only be included if the target has the [`dynamic_headers = true` setting](/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md#configuration-options) configured.
 
+
+## Helper functions
+
+* `hash(input, algorithm)` hashes the input value. Salt is configured using the `hash_salt_secret` parameter in the hcl configuration. If no value is provided, this function will perform an unsalted hash
+
+The following hash algorithms are supported:
+- `sha1` - SHA-1 hash (160 bits)
+- `sha256` - SHA-256 hash (256 bits)
+- `md5` - MD5 hash (128 bits) 
+
+```
+hash(input.Data["app_id"], "sha1")
+```
+
 ## Configuration
 
 Once your script is ready, you can configure it in the app by following the [Javascript](/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/javascript-configuration/index.md) configuration page.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
@@ -4,6 +4,11 @@ date: "2022-10-20"
 sidebar_position: 100
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 Custom transformation scripts may be defined in Javascript and provided to Snowbridge.
 
 ## The scripting interface
@@ -91,39 +96,39 @@ For all the below examples, the input is a string representation of the below JS
 
 To modify the message data, return an object which conforms to EngineProtocol, with the `Data` field set to the modified data. The `Data` field may be returned as either a string, or an object.
 
-```js reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.js
-```
+<CodeBlock language="js" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.js
+`}</CodeBlock>
 
 ## Filtering
 
 If the `FilterOut` field of the output is returned as `true`, the message will be acknowledged immediately and won't be sent to the target. This will be the behavior regardless of what is returned to the other fields in the protocol.
 
-```js reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.js
-```
+<CodeBlock language="js" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.js
+`}</CodeBlock>
 
 ## Setting the Partition Key
 
 To set the Partition Key in the message, you can simply set the input's PartitionKey field, and return it:
 
-```js reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.js
-```
+<CodeBlock language="js" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.js
+`}</CodeBlock>
 
 Or, if modifying the data as well, return the modified data and PartitionKey field:
 
-```js reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.js
-```
+<CodeBlock language="js" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.js
+`}</CodeBlock>
 
 ## Setting an HTTP header
 
 For the `http` target only, you can specify a set of HTTP headers, which will be appended to the configured headers for the `http` target. Do so by providing an object in the `HTTPHeaders` field:
 
-```js reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/create-a-script-header-example.js
-```
+<CodeBlock language="js" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-header-example.js
+`}</CodeBlock>
 
 The headers will only be included if the target has the [`dynamic_headers = true` setting](/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md#configuration-options) configured.
 

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/javascript-configuration/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/javascript-configuration/index.md
@@ -4,6 +4,11 @@ date: "2022-10-20"
 sidebar_position: 200
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 This section details how to configure the transformation, once a script is written.
 
 You can also find some complete example use cases in [the examples section](../examples/index.md).
@@ -18,12 +23,12 @@ Scripts must be available to the runtime of the application at the path provided
 
 Minimal configuration:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/js-configuration-minimal-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/js-configuration-minimal-example.hcl
+`}</CodeBlock>
 
 Every configuration option:
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/custom-scripts/js-configuration-full-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/js-configuration-full-example.hcl
+`}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/index.md
@@ -4,6 +4,11 @@ date: "2022-10-20"
 sidebar_position: 200
 ---
 
+```mdx-code-block
+import {versions} from '@site/src/componentVersions';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 You can configure any number of transformations to run on the data one after another - transformations will run in the order provided. (You can repeatedly specify the same transformation more than once, if needed.) All transformations operate on a single message basis.
 
 If you're filtering the data, it's best to provide the filter first, for efficiency.
@@ -26,6 +31,6 @@ Example:
 
 The below first filters out any `event_name` which does not match the regex `^page_view$`, then runs a custom javascript script to change the app_id value to `"1"`
 
-```hcl reference
-https://github.com/snowplow/snowbridge/blob/master/assets/docs/configuration/transformations/transformations-overview-example.hcl
-```
+<CodeBlock language="hcl" reference>{`
+https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/transformations-overview-example.hcl
+`}</CodeBlock>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -183,7 +183,6 @@ module.exports = {
           'bash',
           'diff',
           'json',
-          'hcl',
         ],
       },
       algolia: {

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -26,7 +26,7 @@ export const versions = {
   enrich: '5.4.0',
   sqs2kinesis: '1.0.4',
   dataflowRunner: '0.7.5',
-  snowbridge: '3.2.3',
+  snowbridge: '3.3.0',
 
   // Loaders
   bqLoader: '2.0.1',


### PR DESCRIPTION
This PR:

- Adds documentation of new features for Snowbridge 3.3.0 release (in rollout now), and updates the componentVersion.
- Updates all 'reference' type codeblocks to use a reference to the version specified, instead of master (our code examples were out of sync with the documented version before this)
- Fixes an issue where some files then had duplicated headers for some reason
- Removes a duplicate reference to `hcl` in the languages array.

That last change is an attempt to get codeblock formatting to work for hcl, but it appears still not to work. @mscwilson would you have any ideas on that?

It works for js reference code blocks, and it doesn't work for hcl reference or non-reference blocks. I've tried to find why but I'm lost.

(note: not all the features in 3.3.0 are documented here, because those are mostly for our internal under-the-hood use in event streaming, not really relevant for typical customers or community users)