### PR TITLE
Fix italics fonts

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -68,20 +68,20 @@
  * bundles Infima by default. Infima is a CSS framework designed to
  * work well for content-centric websites.
  */
- @font-face {
-  font-family: 'Inter18pt-Bold';
-  src: url('/fonts/Inter18pt-BoldItalic.woff2') format('woff2'),
-      url('/fonts/Inter18pt-BoldItalic.woff') format('woff');
-  font-weight: bold;
+@font-face {
+  font-family: 'Inter18pt-Regular';
+  src: url('/fonts/Inter18pt-Italic.woff2') format('woff2'),
+      url('/fonts/Inter18pt-Italic.woff') format('woff');
+  font-weight: normal;
   font-style: italic;
   font-display: swap;
 }
 
 @font-face {
-  font-family: 'Inter18pt-BoldItalic';
-  src: url('/fonts/Inter18pt-Italic.woff2') format('woff2'),
-      url('/fonts/Inter18pt-Italic.woff') format('woff');
-  font-weight: normal;
+  font-family: 'Inter18pt-Bold';
+  src: url('/fonts/Inter18pt-BoldItalic.woff2') format('woff2'),
+      url('/fonts/Inter18pt-BoldItalic.woff') format('woff');
+  font-weight: bold;
   font-style: italic;
   font-display: swap;
 }


### PR DESCRIPTION
Italic text wasn't rendering with true italics (i.e. built into the font file), but instead was using synthetic italics generated by the browser. Updated the `@font-face` declarations in `src/css/custom.css` to fix this