### PR TITLE
Fix nav bar CollapseButton behavior

### DIFF
--- a/src/theme/DocSidebarItem/Category/index.js
+++ b/src/theme/DocSidebarItem/Category/index.js
@@ -57,7 +57,7 @@ function CollapseButton({ categoryLabel, href, collapsed, updateCollapsed }) {
   const handleClick = (e) => {
     e.preventDefault()
     e.stopPropagation()
-    
+
     // Only toggle the collapse state, don't navigate
     updateCollapsed(!collapsed)
   }
@@ -128,25 +128,6 @@ export default function DocSidebarItemCategory({
     }
   }, [collapsible, expandedItem, index, setCollapsed, autoCollapseCategories])
 
-  // Modified click handler for the title link
-  const handleTitleClick = (e) => {
-    onItemClick?.(item)
-
-    if (collapsible) {
-      if (isActive && !collapsed) {
-        // When expanded and selected, clicking title should collapse and navigate
-        updateCollapsed(true)
-      } else if (href) {
-        // For items with href, expand and let navigation happen
-        updateCollapsed(false)
-      } else {
-        // For items without href, just toggle
-        e.preventDefault()
-        updateCollapsed()
-      }
-    }
-  }
-
   return (
     <li
       className={clsx(
@@ -170,7 +151,6 @@ export default function DocSidebarItemCategory({
             'menu__link--sublist-caret': !href && collapsible,
             'menu__link--active': isActive,
           })}
-          onClick={handleTitleClick}
           aria-current={isCurrentPage ? 'page' : undefined}
           aria-expanded={collapsible ? !collapsed : undefined}
           href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}

--- a/src/theme/DocSidebarItem/Category/index.js
+++ b/src/theme/DocSidebarItem/Category/index.js
@@ -54,26 +54,12 @@ function useCategoryHrefWithSSRFallback(item) {
 }
 
 function CollapseButton({ categoryLabel, href, collapsed, updateCollapsed }) {
-  // Modified CollapseButton so that it has the same behavior as the title
   const handleClick = (e) => {
     e.preventDefault()
     e.stopPropagation()
-
-    if (!collapsed) {
-      // When expanded, simply collapse
-      updateCollapsed(true)
-    } else {
-      // When collapsed, expand AND navigate to the page
-      updateCollapsed(false)
-      if (href) {
-        const linkElement = e.target
-          .closest('.menu__list-item-collapsible')
-          .querySelector('.menu__link')
-        if (linkElement) {
-          linkElement.click()
-        }
-      }
-    }
+    
+    // Only toggle the collapse state, don't navigate
+    updateCollapsed(!collapsed)
   }
 
   return (


### PR DESCRIPTION
Fixes https://snplow.atlassian.net/browse/DOC-122.

 - **Problem**: The expand/collapse arrow was both expanding the sidebar
  section AND navigating to the category page
- **Root cause**: The CollapseButton component was
  programmatically clicking the link element after expanding
- **Solution**: Simplified the handleClick function to only toggle the
  collapse state (`updateCollapsed(!collapsed)`) without any navigation logic