### PR TITLE
Note "Internal" behavior for referer-parser enrichment

### DIFF
--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -32,6 +32,13 @@ Snowplow has several subdomains like _community.snowplow.io_ and _docs.snowplow.
 
 Enabling this enrichment with the above configuration would fill the `refr_medium` column in our data warehouse with _“Internal”_ (rather then _"Unknown"_) when the referring URL to a page matches the subdomains above.
 
+:::note
+
+The enrichment will also classify `refr_medium` as `Internal` when an event's `page_urlhost` matches it's `refr_urlhost`, regardless of the configured `internalDomains`.
+This behavior is not configurable, and may require handling in data models or a [JavaScript enrichment](/docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/index.md) to change.
+
+:::
+
 ## Output
 
 This enrichment populates the following fields of the atomic event :


### PR DESCRIPTION
The refer-parser library [will always](https://github.com/snowplow-referer-parser/scala-referer-parser/blob/8b84cd3619087b0328b7f279ca0cfa41a8dbfa22/src/main/scala/com/snowplowanalytics/refererparser/Parser.scala#L102-L105) classify an event's `refr_medium` as `internal` if the `page_urlhost` and `refr_urlhost` are the same, even if the domains in question aren't configured as `internalDomains`.

This can be slightly surprising, so add a note that it may need to be handled in data models or over-ridden with a custom JS enrichment.

Thanks to @jkersu for mentioning!