### PR TITLE
Fix/update view terminology

### DIFF
--- a/docs/signals/configuration/batch-calculations/index.md
+++ b/docs/signals/configuration/batch-calculations/index.md
@@ -15,11 +15,11 @@ Only Snowflake is supported currently.
 
 Signals is configured slightly differently depending if you're using existing tables or creating new ones.
 
-| Signals component | Required for existing attributes | Required for creating new attributes |
-| ----------------- | -------------------------------- | ------------------------------------ |
-| `BatchSource`     | ✅                                | ❌                                    |
-| `View`            | with `fields` ✅                  | with `attributes` ✅                  |
-| Batch engine      | ❌                                | ✅                                    |
+| Signals component   | Required for existing attributes | Required for creating new attributes |
+| -----------------   | -------------------------------- | ------------------------------------ |
+| `BatchSource`       | ✅                                | ❌                                   |
+| `BatchView`         | ❌                                | with `attributes` ✅                 |
+| `ExternalBatchView` | with `fields` ✅                  | ❌                                   |
 
 To create new attribute tables, the batch engine will help you set up the required dbt projects and models.
 
@@ -63,26 +63,20 @@ The `timestamp_field` is optional but recommended for incremental or snapshot-ba
 
 ### Defining a view with fields
 
-Pass your source to a new view.
+Pass your source to a new `ExternalBatchView` so that Signals does not materialize the attributes. This will be done later, once Signals has connected to the table.
 
 For stream or batch attributes that are calculated by Signals, a view contains references to your attribute definitions. In this case, the attributes are already defined elsewhere and pre-calculated in the warehouse. Instead of `attributes`, this view will have `fields`.
-
-To start with, create the view with `online=False` so that Signals does not materialize the attributes. This will be done later, once Signals has connected to the table.
 
 Specify the fields (columns) you want to use from the source table, using `Field`. Here's an example:
 
 ```python
 from snowplow_signals import View, domain_userid, Field
 
-view = View(
+view = ExternalBatchView(
     name="ecommerce_transaction_interactions_attributes",
     version=1,
     entity=domain_userid,
     owner="user@company.com",
-
-    offline=True, # Set this to True because this is a batch view
-    online=False, # Set this to False until the configuration is complete
-
     batch_source=data_source,
     fields=[
         Field(
@@ -143,14 +137,11 @@ The entity here is typically the user, which may be the `domain_userid` or other
 ```python
 from snowplow_signals import View, domain_userid
 
-view = View(
+view = BatchView(
     name="batch_ecommerce_attributes",
     version=1,
     entity=domain_userid,
     owner="user@company.com"
-
-    offline=True, # Set this to True because this is a batch view
-
     attributes=[
         products_added_to_cart_last_7_days,
         total_product_price_clv,
@@ -173,7 +164,7 @@ Check out the full instructions in [Creating new batch attributes](/docs/signals
 The materialization engine is a cron job that sends warehouse attributes to the Profiles Store.
 
 The engine will be enabled when you either:
-* Apply a view for an existing table, with `online=True`
+* Apply an `ExternalBatchView` for an existing table
 * Run the batch engine `materialize` command after creating new attribute tables
 
 Once enabled, syncs begin at a fixed interval. By default, this is every 5 minutes. Only the records that have changed since the last sync are sent to the Profiles Store.

--- a/docs/signals/configuration/batch-calculations/index.md
+++ b/docs/signals/configuration/batch-calculations/index.md
@@ -70,7 +70,7 @@ For stream or batch attributes that are calculated by Signals, a view contains r
 Specify the fields (columns) you want to use from the source table, using `Field`. Here's an example:
 
 ```python
-from snowplow_signals import View, domain_userid, Field
+from snowplow_signals import ExternalBatchView, domain_userid, Field
 
 view = ExternalBatchView(
     name="ecommerce_transaction_interactions_attributes",
@@ -135,7 +135,7 @@ The key difference between a standard stream [view](/docs/signals/configuration/
 The entity here is typically the user, which may be the `domain_userid` or other Snowplow identifier fields, such as the logged in `user_id`.
 
 ```python
-from snowplow_signals import View, domain_userid
+from snowplow_signals import BatchView, domain_userid
 
 view = BatchView(
     name="batch_ecommerce_attributes",

--- a/docs/signals/configuration/views-services/index.md
+++ b/docs/signals/configuration/views-services/index.md
@@ -24,7 +24,7 @@ There are 3 types of view, depending on how you want to calculate and materializ
 
 - `StreamView` - Processed in the streaming engine
 - `BatchView` - Processed using the batch engine
-- `ExternalBatchView` - Existing customer warehouse table that's materialized into Signals
+- `ExternalBatchView` - Existing warehouse table that's materialized into Signals
 
 When defining batch attributes, it's possible to apply configurations that just create a table without attributes, or calculate attributes in a table without materializing them to the Profiles Store. You can also define an `ExternalBatchView` with fields instead of attributes, for using pre-existing tables with pre-calculated attributes.
 
@@ -46,7 +46,7 @@ TODO
 
 ## StreamView
 
-Use a `StreamView` to calculate attributes in real time from event streams.
+Use a `StreamView` to calculate attributes from the real-time event stream. Read more about this in the [Stream calculations](/docs/signals/configuration/stream-calculations/index.md) section.
 
 ```python
 from snowplow_signals import StreamView, domain_sessionid
@@ -115,7 +115,6 @@ my_external_batch_view = ExternalBatchView   (
 )
 ```
 
-By default, views will calculate attributes from the real-time event stream. Read more about this in the [Stream calculations](/docs/signals/configuration/stream-calculations/index.md) section.
 
 
 ## View options

--- a/docs/signals/configuration/views-services/index.md
+++ b/docs/signals/configuration/views-services/index.md
@@ -26,8 +26,6 @@ There are 3 types of view, depending on how you want to calculate and materializ
 - `BatchView` - Processed using the batch engine
 - `ExternalBatchView` - Existing warehouse table that's materialized into Signals
 
-When defining batch attributes, it's possible to apply configurations that just create a table without attributes, or calculate attributes in a table without materializing them to the Profiles Store. You can also define an `ExternalBatchView` with fields instead of attributes, for using pre-existing tables with pre-calculated attributes.
-
 For stream attributes, you can choose to configure and apply views that don't calculate their attribute values.
 
 This means that configuration, calculation, materialization, and retrieval are fully decoupled.

--- a/docs/signals/configuration/views-services/index.md
+++ b/docs/signals/configuration/views-services/index.md
@@ -10,7 +10,7 @@ Signals has two attribute groupings:
 
 Each view is a versioned collection of attributes, and specific to one entity and one data source (stream or batch).
 
-Services are groups of views or attributes.
+Services are groups of views.
 
 ## Attribute management
 
@@ -20,32 +20,13 @@ Signals provides functionality for separating attribute definition from calculat
 
 To configure a table for batch attributes, you may choose to set up a view using that source without defining any attributes initially. This ensures that the table is ready and tested for adding and calculating attributes. Read more about configuring batch attributes and views in the [Batch calculations](/docs/signals/configuration/batch-calculations/index.md) section.
 
-Deciding when to calculate and materialize the attributes using the `online` and `offline` view configuration options:
+There are 3 types of view, depending on how you want to calculate and materialize the attributes:
 
-```mermaid
-flowchart TD
+- `StreamView` - Processed in the streaming engine
+- `BatchView` - Processed using the batch engine
+- `ExternalBatchView` - Existing customer warehouse table that's materialized into Signals
 
-    B{Is the view batch or stream?} -->|Default| C[Stream source]
-    B -->|Batch| D[Batch source]
-
-    C --> E{Do you want to calculate attributes now?}
-
-    E -->|Yes| F[Online = true, Offline = false<br/>Attributes calculated in stream]
-    E -->|No| G[Online = false, Offline = false<br/>Attributes are not calculated anywhere]
-
-    D --> H{Have you assigned attributes to this view?}
-
-    H -->|Yes| I{Do you want to send attributes to Signals?}
-    H -->|No| J{Do you want to materialize a new table into Signals?}
-
-    I -->|Yes| K[Online = true, Offline = true<br/>Attributes calculated using Batch Engine<br/>and materialized into Signals]
-    I -->|No| L[Online = false, Offline = true<br/>Attributes calculated using Batch Engine<br/>but not materialized]
-
-    J -->|Yes| M[Online = true, Offline = true<br/>Table materialized into Signals<br/>if it has a batch source configured]
-    J -->|No| N[Online = false, Offline = true<br/>Table pre-computed without Batch Engine<br/>and only in the warehouse]
-```
-
-When defining batch attributes, it's possible to apply configurations that just create a table without attributes, or calculate attributes in a table without materializing them to the Profiles Store. You could also define views with fields instead of attributes, for using pre-existing tables with pre-calculated attributes.
+When defining batch attributes, it's possible to apply configurations that just create a table without attributes, or calculate attributes in a table without materializing them to the Profiles Store. You can also define an `ExternalBatchView` with fields instead of attributes, for using pre-existing tables with pre-calculated attributes.
 
 For stream attributes, you can choose to configure and apply views that don't calculate their attribute values.
 
@@ -63,15 +44,15 @@ If Signals then processes a new event that calculates the attribute again, or ma
 
 TODO
 
-## Minimal stream view example
+## StreamView
 
-You can define a `View` by passing in a list of previously defined attributes. Here's a minimal example:
+Use a `StreamView` to calculate attributes in real time from event streams.
 
 ```python
-from snowplow_signals import View, domain_sessionid
+from snowplow_signals import StreamView, domain_sessionid
 
-my_attribute_view = View(
-    name="my_attribute_view",
+my_stream_view = StreamView(
+    name="my_stream_view",
     version=1,
     entity=domain_sessionid,
     owner="user@company.com",
@@ -83,53 +64,103 @@ my_attribute_view = View(
 )
 ```
 
+## BatchView
+
+Use a `BatchView` to calculate attributes from batch data sources (e.g., warehouse tables).
+
+```python
+from snowplow_signals import BatchView, domain_sessionid
+
+my_batch_view = BatchView   (
+    name="my_batch_view",
+    version=1,
+    entity=domain_sessionid,
+    owner="user@company.com",
+    attributes=[
+        # Previously defined attributes
+        page_view_count,
+        products_added_to_cart_feature,
+    ],
+)
+```
+
+## ExternalBatchView
+
+Use an `ExternalBatchView` to materialize attributes from an existing warehouse table.
+
+
+```python
+from snowplow_signals import ExternalBatchView, domain_sessionid
+
+my_external_batch_view = ExternalBatchView   (
+    name="my_external_batch_view",
+    version=1,
+    entity=domain_sessionid,
+    owner="user@company.com",
+    batch_source=data_source, # Assuming Data source previously configured
+    fields=[
+        Field(
+            name="TOTAL_TRANSACTIONS",
+            type="int32",
+        ),
+        Field(
+            name="TOTAL_REVENUE",
+            type="int32",
+        ),
+        Field(
+            name="AVG_TRANSACTION_REVENUE",
+            type="int32",
+        ),
+    ],
+)
+```
+
 By default, views will calculate attributes from the real-time event stream. Read more about this in the [Stream calculations](/docs/signals/configuration/stream-calculations/index.md) section.
+
 
 ## View options
 
-The table below lists all available arguments for a `View`:
+The table below lists all available arguments for all types of `View`:
 
-| Argument       | Description                                                                         | Type                | Default | Required? | For batch only? |
-| -------------- | ----------------------------------------------------------------------------------- | ------------------- | ------- | --------- | --------------- |
-| `name`         | The name of the view                                                                | `string`            |         | ✅         |                 |
-| `version`      | The version of the view                                                             | `int`               | 1       | ❌         |                 |
-| `entity`       | The entity associated with the view                                                 | `Entity`            |         | ✅         |                 |
-| `owner`        | The owner of the feature view, typically the email of the primary maintainer        | email `string`      |         | ✅         |                 |
-| `attributes`   | The list of attributes that will be calculated from events as part of this view     | list of `Attribute` |         | ❌         |                 |
-| `description`  | A description of the view                                                           | `string`            |         | ❌         |                 |
-| `ttl`          | The amount of time that this group of attributes will live for in the Profile Store | `timedelta`         |         | ❌         |                 |
-| `offline`      | Whether the view is calculated in the warehouse (`True`) or in real-time (`False`)  | `bool`              | `False` | ❌         |                 |
-| `online`       | Whether online retrieval is enabled (`True`) or not (`False`)                       | `bool`              | `True`  | ❌         |                 |
-| `batch_source` | The batch data source for the view                                                  | `BatchSource`       |         | ❌         | ✅               |
-| `fields`       | The list of table columns that are part of this view during materialization         | `Field`             |         | ❌         | ✅               |
-| `tags`         | String key-value pairs of arbitrary metadata                                        | `dict`              |         | ❌         |                 |
+Below is a summary of all options available for configuring Views in Signals. The "Applies to" column shows which view types each option is relevant for.
+
+| Argument       | Description                                                                         | Type                | Default | Required? | Applies to                |
+| -------------- | ----------------------------------------------------------------------------------- | ------------------- | ------- | --------- | ------------------------- |
+| `name`         | The name of the view                                                                | `string`            |         | ✅        | All                       |
+| `version`      | The version of the view                                                             | `int`               | 1       | ❌        | All                       |
+| `entity`       | The entity associated with the view                                                 | `Entity`            |         | ✅        | All                       |
+| `owner`        | The owner of the view                                                               | `Email`             |         | ✅        | All                       |
+| `description`  | A description of the view                                                           | `string`            |         | ❌        | All                       |
+| `ttl`          | Time-to-live for attributes in the Profile Store                                    | `timedelta`         |         | ❌        | All                       |
+| `tags`         | Metadata key-value pairs                                                            | `dict`              |         | ❌        | All                       |
+| `attributes`   | List of attributes to calculate                                                     | list of `Attribute` |         | ✅        | `StreamView`, `BatchView`     |
+| `batch_source` | The batch data source for the view                                                  | `BatchSource`       |         | ✅/❌     | `BatchView`/`ExternalBatchView` |
+| `fields`       | Table columns for materialization                                                   | `Field`             |         | ✅        | `ExternalBatchView`         |
+| `offline`      | Calculate in warehouse (`True`) or real-time (`False`)                              | `bool`              | varies  | ❌        | All                       |
+| `online`       | Enable online retrieval (`True`) or not (`False`)                                   | `bool`              | `True`  | ❌        | All                       |
+
 
 If no `ttl` is set, the entity's `ttl` will be used. If the entity also has no `ttl`, there will be no time limit for attributes.
 
 ## Extended stream view example
 
-This example shows all the available configuration options for a stream view. To find out how to configure a batch view, see the [Batch calculations](/docs/signals/configuration/batch-calculations/index.md) section.
+This example shows all the available configuration options for a stream view. To find out how to configure a batch view, see the [batch calculations](/docs/signals/configuration/batch-calculations/index.md) section.
 
 This view groups attributes for a user entity, to be calculated in real-time.
 
 ```python
 from snowplow_signals import View, user_id
 
-stream_view = View(
+stream_view = StreamView(
     name="comprehensive_stream_view",
     version=2,
     entity=user_id,
     owner="data-team@company.com",
-
     attributes=[
         page_view_count,
         session_duration,
         conversion_rate,
     ],
-
-    offline=False,  # Stream processing (default)
-    online=True,    # Calculate and serve attributes (default)
-
     description="User engagement attributes in real-time",
     ttl=timedelta(days=90),  # Attributes live in the Profiles Store for 90 days
     tags={

--- a/docs/signals/configuration/views-services/index.md
+++ b/docs/signals/configuration/views-services/index.md
@@ -149,7 +149,7 @@ This example shows all the available configuration options for a stream view. To
 This view groups attributes for a user entity, to be calculated in real-time.
 
 ```python
-from snowplow_signals import View, user_id
+from snowplow_signals import StreamView, user_id
 
 stream_view = StreamView(
     name="comprehensive_stream_view",

--- a/tutorials/signals-end-to-end/define-prospect-attributes.md
+++ b/tutorials/signals-end-to-end/define-prospect-attributes.md
@@ -39,7 +39,7 @@ We will reuse them multiple times, and this makes the code concise and clear.
 
 ```python
 # Imports
-from snowplow_signals import Attribute, Criteria, Criterion, Event, View, user_entity
+from snowplow_signals import Attribute, Criteria, Criterion, Event, StreamView, user_entity
 from datetime import datetime, timedelta
 
 # View name
@@ -83,11 +83,11 @@ first_mkt_medium_l30d = Attribute(name="first_mkt_medium_l30d", type="string", e
 num_engaged_campaigns_l30d = Attribute(name="num_engaged_campaigns_l30d", type="string_list", events=[sp_page_view], period=l30d, aggregation="unique_list", property="mkt_campaign")
 ```
 
-Third, let's wrap these all into a single View.
+Third, let's wrap these all into a single StreamView.
 
 ```python
 # Wrap attributes into a view
-user_attributes_view = View(
+user_attributes_view = StreamView(
     name=DEMO_VIEW_NAME,
     version=view_version,
     entity=user_entity,

--- a/tutorials/signals-quickstart/define-view.md
+++ b/tutorials/signals-quickstart/define-view.md
@@ -6,9 +6,9 @@ title: Create and deploy a view
 A `View` is a collection of attributes that share a common entity (e.g., session or user). Here's how to create a view with the attributes we defined earlier:
 
 ```python
-from snowplow_signals import View, domain_sessionid
+from snowplow_signals import StreamView, domain_sessionid
 
-my_attribute_view = View(
+my_attribute_view = StreamView(
     name="my_attribute_view",
     version=1,
     entity=domain_sessionid,

--- a/tutorials/snowplow-batch-engine/start.md
+++ b/tutorials/snowplow-batch-engine/start.md
@@ -29,11 +29,7 @@ Before starting, ensure you have:
   - API Key
   - API Key ID
   - Organization ID
-- Have View(s) already created
-
-:::info 
-Make sure you specified `offline = True` in your View definition.
-:::
+- Have BatchView/ExternalBatchView(s) already created
 
 
 ## Installation


### PR DESCRIPTION
This PR is linked to [PR75](https://github.com/snowplow-incubator/snowplow-signals-sdk/pull/75) in the SDK, and adds 3 new View subclasses to simplify attribute management. This allows us to remove some of the complexity around Online/Offline options in the docs as this was causing some confusion with the design partners.

- Notebooks [PR](https://github.com/snowplow-incubator/signals-notebooks/pull/17)