### PR TITLE
Fix sidebar menu border overlap issue

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -411,6 +411,7 @@ aside.theme-doc-sidebar-container {
         background-color: hsla(261.56, 53.33%, 47.06%, 0.12);
         border-radius: 0px var(--radius) var(--radius)  0px;
         border-left: 1px solid hsl(var(--primary));
+        margin-left: -1px;
 }
 
 
@@ -433,7 +434,8 @@ aside.theme-doc-sidebar-container {
 .menu__link:hover, .menu__caret:hover {
     background: var(--ifm-menu-color-background-hover);
     border-radius: 0px var(--radius) var(--radius)  0px;
-     border-left: 1px solid hsl(var(--foreground));
+    border-left: 1px solid hsl(var(--foreground));
+    margin-left: -1px;
   }
 
 .menu__link {
@@ -472,17 +474,20 @@ aside.theme-doc-sidebar-container {
         color: var(--ifm-menu-color-active);
         border-radius: 0px var(--radius) var(--radius)  0px;
         border-left: 1px solid hsl(var(--primary));
+        margin-left: -1px;
 }
 .menu__list-item-collapsible .menu__link:hover, .menu__list-item-collapsible .menu__link--active{
   color: var(--ifm-menu-color-active);
         border-radius: 0px var(--radius) var(--radius)  0px;
         border-left: 1px solid hsl(var(--primary));
+        margin-left: -1px;
 }
 
 .menu__link--active:not(.menu__link--sublist) {
         background-color: hsla(261.56, 53.33%, 47.06%, 0.12);
         border-radius: 0px var(--radius) var(--radius)  0px;
         border-left: 1px solid hsl(var(--primary));
+        margin-left: -1px;
       }
 
 .menu__caret {


### PR DESCRIPTION
Fixes the issue I found [here](https://github.com/snowplow/documentation/pull/1346#issuecomment-3155659631)

- Add margin-left: -1px to active/hover menu item states to prevent double borders
- Purple border now properly overlaps grey list border instead of adding adjacent border
- Eliminates text shifting when menu items become active or are hovered
- Applied to all menu border selectors for consistent behavior

🤖 Generated with [Claude Code](https://claude.ai/code)