### PR TITLE
Change code font size

### DIFF
--- a/src/components/SchemaProperties/index.js
+++ b/src/components/SchemaProperties/index.js
@@ -58,7 +58,7 @@ export default function SchemaProperties(props) {
           )}
 
           <details>
-            <summary className="cursor-pointer text-base font-semibold"><b>Schema</b></summary>
+            <summary className="cursor-pointer text-base font-semibold">Schema</summary>
             <div className="mt-2">
               <Tabs className="text-base not-prose" groupId="schema-view" queryString>
                 <TabItem value="table" label="Table">

--- a/src/components/SchemaProperties/index.js
+++ b/src/components/SchemaProperties/index.js
@@ -107,7 +107,7 @@ export default function SchemaProperties(props) {
 
           {(props.overview && props.overview.event) && (
             <details>
-              <summary className="cursor-pointer text-base font-semibold"><b>Warehouse query</b></summary>
+              <summary className="cursor-pointer text-base font-semibold">Warehouse query</summary>
               <div className="mt-2 text-base not-prose">
                 <EventQuery
                   vendor={props.schema.self.vendor}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -51,7 +51,7 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
       <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
-          <article className="overflow-x-auto max-w-fit leading-relaxed prose prose-headings:font-bold prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-base prose-img:mx-auto prose-img:block ">
+          <article className="overflow-x-auto max-w-fit leading-relaxed prose prose-headings:font-bold prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-sm prose-img:mx-auto prose-img:block ">
             <DocBreadcrumbs />
             <DocVersionBadge />
             {docTOC.mobile}

--- a/src/theme/MDXPage/index.js
+++ b/src/theme/MDXPage/index.js
@@ -28,7 +28,7 @@ export default function MDXPage(props) {
         <main className="container container--fluid margin-vert--lg">
           <div className={clsx('row', styles.mdxPageWrapper)}>
             <div className={clsx('col', !hideTableOfContents && 'col--7')}>
-              <article className="overflow-x-auto max-w-none leading-relaxed prose-headings:font-bold prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-base prose-img:mx-auto prose-img:block">
+              <article className="overflow-x-auto max-w-none leading-relaxed prose-headings:font-bold prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-sm prose-img:mx-auto prose-img:block">
                 <MDXContent>
                   <MDXPageContent />
                 </MDXContent>


### PR DESCRIPTION
Changes two things:

1. Changes all code-formatted font to 0.875 rem from 1 rem. Why? This is standard for basically every documentation site because monospace fonts appear larger than proportional fonts of the same size, so reducing the size a little gives it better visual balance.

2. Fixes a bug where the "Schema" and "Warehouse query" details in the Schema Component were inadvertently bolded
<img width="600" alt="CleanShot 2025-08-11 at 13 52 27@2x" src="https://github.com/user-attachments/assets/2def57f6-e22c-4642-a26f-3967cf350243" />
