### PR TITLE
Document React Native getSessionState method

### DIFF
--- a/docs/sources/trackers/react-native-tracker/tracking-events/session-tracking/index.md
+++ b/docs/sources/trackers/react-native-tracker/tracking-events/session-tracking/index.md
@@ -116,3 +116,11 @@ This method returns a promise to resolve to the number of foreground transitions
 ```javascript
 const fgIndex = await tracker.getForegroundIndex();
 ```
+
+### getSessionState
+
+This method returns a promise to resolve to the object containing the full state used to build the `client_session` entity in a single call, rather than the individual fields returned by the other methods.
+
+```javascript
+const sessionState = await tracker.getSessionState();
+```


### PR DESCRIPTION
As pointed out by @jonathanmalloy120, the RN `getSessionState()` method is undocumented.