### PR TITLE
Consistent-ify bigquery/lake/snowflake loaders config references for common-streams

### DIFF
--- a/docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/_kafka_config.md
+++ b/docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/_kafka_config.md
@@ -1,3 +1,7 @@
+```mdx-code-block
+import Link from '@docusaurus/Link';
+```
+
 <tr>
     <td><code>input.topicName</code></td>
     <td>Required.  Name of the Kafka topic for the source of enriched events.</td>
@@ -20,9 +24,9 @@
 </tr>
 <tr>
     <td><code>output.bad.producerConf.*</code></td>
-    <td>Optional. A map of key/value pairs for <a href="https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html" target="_blank">any standard Kafka producer configuration option</a>.</td>
+    <td>Optional. A map of key/value pairs for <Link to="https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html">any standard Kafka producer configuration option</Link>.</td>
 </tr>
 <tr>
-    <td><code>output.bad.maxRecordSize.*</code></td>
+    <td><code>output.bad.maxRecordSize</code></td>
     <td>Optional.  Default value 1000000.  Any single failed event sent to Kafka should not exceed this size in bytes</td>
 </tr>

--- a/docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/_kinesis_config.md
+++ b/docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/_kinesis_config.md
@@ -7,7 +7,7 @@
     <td>Optional, default <code>snowplow-bigquery-loader</code>. Name to use for the dynamodb table, used by the underlying Kinesis Consumer Library for managing leases.</td>
 </tr>
 <tr>
-    <td><code>input.initialPosition</code></td>
+    <td><code>input.initialPosition.type</code></td>
     <td>Optional, default <code>LATEST</code>. Allowed values are <code>LATEST</code>, <code>TRIM_HORIZON</code>, <code>AT_TIMESTAMP</code>. When the loader is deployed for the first time, this controls from where in the kinesis stream it should start consuming events.  On all subsequent deployments of the loader, the loader will resume from the offsets stored in the DynamoDB table.</td>
 </tr>
 <tr>
@@ -63,6 +63,6 @@
     <td>Optional.  Default value 5242880.  The maximum number of bytes we are allowed to send to Kinesis in 1 PutRecords request.</td>
 </tr>
 <tr>
-    <td><code>output.bad.maxRecordSize.*</code></td>
+    <td><code>output.bad.maxRecordSize</code></td>
     <td>Optional.  Default value 1000000.  Any single event failed event sent to Kinesis should not exceed this size in bytes</td>
 </tr>

--- a/docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/_pubsub_config.md
+++ b/docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/_pubsub_config.md
@@ -8,12 +8,12 @@
 </tr>
 <tr>
     <td><code>input.durationPerAckExtension</code></td>
-    <td>Optional. Default value <code>60 seconds</code>. Pubsub ack deadlines are extended for this duration when needed.</td>
+    <td>Optional. Default value <code>60 seconds</code>. Pub/Sub ack deadlines are extended for this duration when needed.</td>
 </tr>
 <tr>
     <td><code>input.minRemainingAckDeadline</code></td>
     <td>
-      Optional. Default value 0.1.
+      Optional. Default value <code>0.1</code>.
       Controls when ack deadlines are re-extended, for a message that is close to exceeding its ack deadline.
       For example, if <code>durationPerAckExtension</code> is <code>60 seconds</code> and <code>minRemainingAckDeadline</code> is <code>0.1</code> then the loader
       will wait until there is <code>6 seconds</code> left of the remining deadline, before re-extending the message deadline.

--- a/docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/_kafka_config.md
+++ b/docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/_kafka_config.md
@@ -26,3 +26,7 @@ import Link from '@docusaurus/Link';
     <td><code>output.bad.producerConf.*</code></td>
     <td>Optional. A map of key/value pairs for <Link to="https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html">any standard Kafka producer configuration option</Link>.</td>
 </tr>
+<tr>
+    <td><code>output.bad.maxRecordSize</code></td>
+    <td>Optional.  Default value 1000000.  Any single failed event sent to Kafka should not exceed this size in bytes</td>
+</tr>

--- a/docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/_kinesis_config.md
+++ b/docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/_kinesis_config.md
@@ -7,7 +7,7 @@
     <td>Optional, default <code>snowplow-lake-loader</code>. Name to use for the dynamodb table, used by the underlying Kinesis Consumer Library for managing leases.</td>
 </tr>
 <tr>
-    <td><code>input.initialPosition</code></td>
+    <td><code>input.initialPosition.type</code></td>
     <td>Optional, default <code>LATEST</code>. Allowed values are <code>LATEST</code>, <code>TRIM_HORIZON</code>, <code>AT_TIMESTAMP</code>. When the loader is deployed for the first time, this controls from where in the kinesis stream it should start consuming events.  On all subsequent deployments of the loader, the loader will resume from the offsets stored in the DynamoDB table.</td>
 </tr>
 <tr>
@@ -61,4 +61,8 @@
 <tr>
     <td><code>output.bad.byteLimit</code></td>
     <td>Optional.  Default value 5242880.  The maximum number of bytes we are allowed to send to Kinesis in 1 PutRecords request.</td>
+</tr>
+<tr>
+    <td><code>output.bad.maxRecordSize</code></td>
+    <td>Optional.  Default value 1000000.  Any single event failed event sent to Kinesis should not exceed this size in bytes</td>
 </tr>

--- a/docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/_pubsub_config.md
+++ b/docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/_pubsub_config.md
@@ -12,11 +12,16 @@
 </tr>
 <tr>
     <td><code>input.minRemainingAckDeadline</code></td>
-    <td>Optional. Default value <code>0.1</code>. Controls when ack deadlines are re-extended, for a message that is close to exceeding its ack deadline. For example, if <code>durationPerAckExtension</code> is <code>600 seconds</code> and <code>minRemainingAckDeadline</code> is <code>0.1</code> then the loader will wait until there is <code>60 seconds</code> left of the remining deadline, before re-extending the message deadline.</td>
+    <td>
+      Optional. Default value <code>0.1</code>.
+      Controls when ack deadlines are re-extended, for a message that is close to exceeding its ack deadline.
+      For example, if <code>durationPerAckExtension</code> is <code>600 seconds</code> and <code>minRemainingAckDeadline</code> is <code>0.1</code> then the loader
+      will wait until there is <code>60 seconds</code> left of the remining deadline, before re-extending the message deadline.
+    </td>
 </tr>
 <tr>
     <td><code>input.maxMessagesPerPull</code></td>
-    <td>Optional. Default value <code>1000</code>. How many pubsub messages to pull from the server in a single request.</td>
+    <td>Optional. Default value 1000. How many Pub/Sub messages to pull from the server in a single request.</td>
 </tr>
 <tr>
     <td><code>output.bad.topic</code></td>
@@ -24,9 +29,13 @@
 </tr>
 <tr>
     <td><code>output.bad.batchSize</code></td>
-    <td>Optional.  Default value 100.  Bad events are sent to Pub/Sub in batches not exceeding this count.</td>
+    <td>Optional.  Default value 1000.  Bad events are sent to Pub/Sub in batches not exceeding this count.</td>
 </tr>
 <tr>
     <td><code>output.bad.requestByteThreshold</code></td>
     <td>Optional.  Default value 1000000.  Bad events are sent to Pub/Sub in batches with a total size not exceeding this byte threshold</td>
+</tr>
+<tr>
+    <td><code>output.bad.maxRecordSize</code></td>
+    <td>Optional.  Default value 10000000.  Any single failed event sent to Pub/Sub should not exceed this size in bytes</td>
 </tr>

--- a/docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/_kafka_config.md
+++ b/docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/_kafka_config.md
@@ -1,3 +1,7 @@
+```mdx-code-block
+import Link from '@docusaurus/Link';
+```
+
 <tr>
     <td><code>input.topicName</code></td>
     <td>Required.  Name of the Kafka topic for the source of enriched events.</td>
@@ -20,7 +24,7 @@
 </tr>
 <tr>
     <td><code>output.bad.producerConf.*</code></td>
-    <td>Optional. A map of key/value pairs for <a href="https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html" target="_blank">any standard Kafka producer configuration option</a>.</td>
+    <td>Optional. A map of key/value pairs for <Link to="https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html">any standard Kafka producer configuration option</Link>.</td>
 </tr>
 <tr>
     <td><code>output.bad.maxRecordSize</code></td>

--- a/docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/_kinesis_config.md
+++ b/docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/_kinesis_config.md
@@ -7,7 +7,7 @@
     <td>Optional, default <code>snowplow-snowflake-loader</code>. Name to use for the dynamodb table, used by the underlying Kinesis Consumer Library for managing leases.</td>
 </tr>
 <tr>
-    <td><code>input.initialPosition</code></td>
+    <td><code>input.initialPosition.type</code></td>
     <td>Optional, default <code>LATEST</code>. Allowed values are <code>LATEST</code>, <code>TRIM_HORIZON</code>, <code>AT_TIMESTAMP</code>. When the loader is deployed for the first time, this controls from where in the kinesis stream it should start consuming events.  On all subsequent deployments of the loader, the loader will resume from the offsets stored in the DynamoDB table.</td>
 </tr>
 <tr>
@@ -32,7 +32,15 @@
 </tr>
 <tr>
     <td><code>input.maxLeasesToStealAtOneTimeFactor</code></td>
-    <td>Optional. Default value <code>2.0</code>. Controls how to pick the max number of shard-leases to steal at one time. E.g. If there are 4 available processors, and <code>maxLeasesToStealAtOneTimeFactor</code> is 2.0, then allow the KCL to steal up to 8 leases. Allows bigger instances to more quickly acquire the shard-leases they need to combat latency.</td>
+    <td>Optional. Default value <code>2.0</code>. Controls how to pick the max number of shard leases to steal at one time. E.g. If there are 4 available processors, and <code>maxLeasesToStealAtOneTimeFactor = 2.0</code>, then allow the loader to steal up to 8 leases. Allows bigger instances to more quickly acquire the shard-leases they need to combat latency.</td>
+</tr>
+<tr>
+    <td><code>input.checkpointThrottledBackoffPolicy.minBackoff</code></td>
+    <td>Optional.  Default value <code>100 milliseconds</code>.  Initial backoff used to retry checkpointing if we exceed the DynamoDB provisioned write limits.</td>
+</tr>
+<tr>
+    <td><code>input.checkpointThrottledBackoffPolicy.maxBackoff</code></td>
+    <td>Optional.  Default value <code>1 second</code>.  Maximum backoff used to retry checkpointing if we exceed the DynamoDB provisioned write limits.</td>
 </tr>
 <tr>
     <td><code>output.bad.streamName</code></td>

--- a/docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/_pubsub_config.md
+++ b/docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/_pubsub_config.md
@@ -4,23 +4,32 @@
 </tr>
 <tr>
     <td><code>input.parallelPullFactor</code></td>
-    <td>Optional. Default value 0.5. <code>parallelPullFactor * cpu count</code> will determine the number of threads used internally by the pubsub client library for fetching events</td>
+    <td>Optional. Default value 0.5. <code>parallelPullFactor * cpu count</code> will determine the number of threads used internally by the Pub/Sub client library for fetching events</td>
 </tr>
 <tr>
-    <td><code>input.bufferMaxBytes</code></td>
-    <td>Optional. Default value 10000000. How many bytes can be buffered by the loader app before blocking the pubsub client library from fetching more events. This is a balance between memory usage vs how efficiently the app can operate.  The default value works well.</td>
+    <td><code>input.durationPerAckExtension</code></td>
+    <td>Optional. Default value <code>60 seconds</code>. Pub/Sub ack deadlines are extended for this duration when needed.</td>
 </tr>
 <tr>
-    <td><code>input.maxAckExtensionPeriod</code></td>
-    <td>Optional. Default value 1 hour. For how long the pubsub client library will continue to re-extend the ack deadline of an unprocessed event.</td>
+    <td><code>input.minRemainingAckDeadline</code></td>
+    <td>
+      Optional. Default value <code>0.1</code>.
+      Controls when ack deadlines are re-extended, for a message that is close to exceeding its ack deadline.
+      For example, if <code>durationPerAckExtension</code> is <code>60 seconds</code> and <code>minRemainingAckDeadline</code> is <code>0.1</code> then the loader
+      will wait until there is <code>6 seconds</code> left of the remining deadline, before re-extending the message deadline.
+    </td>
 </tr>
 <tr>
-    <td><code>input.minDurationPerAckExtension</code></td>
-    <td>Optional. Default value 60 seconds. Sets min boundary on the value by which an ack deadline is extended. The actual value used is guided by runtime statistics collected by the pubsub client library.</td>
+    <td><code>input.maxMessagesPerPull</code></td>
+    <td>Optional. Default value 1000. How many Pub/Sub messages to pull from the server in a single request.</td>
 </tr>
 <tr>
-    <td><code>input.maxDurationPerAckExtension</code></td>
-    <td>Optional. Default value 600 seconds. Sets max boundary on the value by which an ack deadline is extended. The actual value used is guided by runtime statistics collected by the pubsub client library.</td>
+    <td><code>input.debounceRequests</code></td>
+    <td>
+      Optional. Default value <code>100 millis</code>.
+      Adds an artifical delay between consecutive requests to Pub/Sub for more messages.
+      Under some circumstances, this was found to slightly alleviate a problem in which Pub/Sub might re-deliver the same messages multiple times.
+    </td>
 </tr>
 <tr>
     <td><code>output.bad.topic</code></td>
@@ -36,5 +45,5 @@
 </tr>
 <tr>
     <td><code>output.bad.maxRecordSize</code></td>
-    <td>Optional.  Default value 10000000.  Any single failed event sent to Pub/Sub should not exceed this size in bytes</td>
+    <td>Optional.  Default value 9000000.  Any single failed event sent to Pub/Sub should not exceed this size in bytes</td>
 </tr>


### PR DESCRIPTION
Our apps have recently bumped common-streams versions a few times, and we haven't always kept the config reference up to date.

Ideally, we would arrange this documentation to import a shared config reference snippet for all common-streams apps.  But that's out of scope for this PR.  I'm just doing the easy thing and triplicating the same config reference into all three loaders.