### PR TITLE
Add UTC to timestamp page

### DIFF
--- a/docs/events/timestamps/index.md
+++ b/docs/events/timestamps/index.md
@@ -5,7 +5,7 @@ date: "2025-05-15"
 sidebar_position: 4
 ---
 
-Snowplow events have multiple timestamps that are added as the payload moves through the pipeline. The set of timestamps is designed to account for devices with incorrectly set clocks, or delays in event sending due to network outages. All timestamps are converted to UTC for consistancy across events.
+Snowplow events have multiple timestamps that are added as the payload moves through the pipeline. The set of timestamps is designed to account for devices with incorrectly set clocks, or delays in event sending due to network outages. All timestamps are converted to UTC for consistency across events.
 
 The timestamps are:
 

--- a/docs/events/timestamps/index.md
+++ b/docs/events/timestamps/index.md
@@ -5,7 +5,7 @@ date: "2025-05-15"
 sidebar_position: 4
 ---
 
-Snowplow events have multiple timestamps that are added as the payload moves through the pipeline. The set of timestamps is designed to account for devices with incorrectly set clocks, or delays in event sending due to network outages.
+Snowplow events have multiple timestamps that are added as the payload moves through the pipeline. The set of timestamps is designed to account for devices with incorrectly set clocks, or delays in event sending due to network outages. All timestamps are converted to UTC for consistancy across events.
 
 The timestamps are:
 


### PR DESCRIPTION
Timestamp page didn't mention that events are converted to UTC causing customer confusion