### PR TITLE
fix: Prefix `snowbridge` version with 'v'

### DIFF
--- a/docs/destinations/forwarding-events/snowbridge/configuration/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/index.md
@@ -49,5 +49,5 @@ The below example is a complete configuration, which specifies a kinesis source,
 In layman's terms, this configuration will read data from a kinesis stream, filter out any data whose `event_name` field is not `page_view`, run a custom Javascript script upon the data to change the `app_id` to `"1"`, and send the transformed page view data to pubsub. It will also send statistics about what it's doing to a statsD endpoint, and will send information about errors to a sentry endpoint.
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/overview-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/overview-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/monitoring/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/monitoring/index.md
@@ -20,19 +20,19 @@ Snowbridge comes with configurable logging, [pprof](https://github.com/google/pp
 Use the log_level parameter to specify the log level.
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/monitoring/log-level-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/monitoring/log-level-example.hcl
 `}</CodeBlock>
 
 ### Sentry Configuration
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/monitoring/sentry-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/monitoring/sentry-example.hcl
 `}</CodeBlock>
 
 ### StatsD stats receiver configuration
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/monitoring/statsd-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/monitoring/statsd-example.hcl
 `}</CodeBlock>
 
 ### End-to-end latency configuration
@@ -40,7 +40,7 @@ https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/c
 Snowplow Enriched data only:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/metrics/e2e-latency-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/metrics/e2e-latency-example.hcl
 `}</CodeBlock>
 
 Snowbridge sends the following metrics to statsd:

--- a/docs/destinations/forwarding-events/snowbridge/configuration/retries/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/retries/index.md
@@ -27,5 +27,5 @@ Retries will be attempted with an exponential backoff. In other words, on each s
 ## Configuration options
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/retry-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/retry-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/index.md
@@ -18,11 +18,11 @@ Stdin source simply treats stdin as the input. It has one optional configuration
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/stdin-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/stdin-minimal-example.hcl
 `}</CodeBlock>
 
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/stdin-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/stdin-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/kafka.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/kafka.md
@@ -17,11 +17,11 @@ Authentication is done by providing valid credentials in the configuration.
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kafka-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/kafka-minimal-example.hcl
 `}</CodeBlock>
 
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kafka-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/kafka-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/kinesis.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/kinesis.md
@@ -40,11 +40,11 @@ Assuming your AWS credentials have sufficient permission for Kinesis and DynamoD
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kinesis-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/kinesis-minimal-example.hcl
 `}</CodeBlock>
 
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/kinesis-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/kinesis-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/pubsub.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/pubsub.md
@@ -19,11 +19,11 @@ Snowbridge connects to PubSub using [Google's Go Pubsub sdk](https://cloud.googl
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/pubsub-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/pubsub-minimal-example.hcl
 `}</CodeBlock>
 
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/pubsub-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/pubsub-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/sources/sqs.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/sources/sqs.md
@@ -21,11 +21,11 @@ Authentication is done via the [AWS authentication environment variables](https:
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/sqs-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/sqs-minimal-example.hcl
 `}</CodeBlock>
 
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/sources/sqs-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/sources/sqs-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/eventhub.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/eventhub.md
@@ -17,14 +17,14 @@ Authentication for the EventHub target is done by configuring any valid combinat
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/eventhub-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/eventhub-minimal-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/eventhub-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/eventhub-full-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md
@@ -59,7 +59,7 @@ In addition to all base functions available in the Go text/template package, the
 The following example provides an API key via environment variable, and iterates the batch to provide JSON-formatted data one by one into a new key, inserting a comma before all but the first event.
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/http-template-full-example.file
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/http-template-full-example.file
 `}</CodeBlock>
 
 ## Response rules (beta)
@@ -89,14 +89,14 @@ Data that matches a setup response rule is handled by a retry as determined in t
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/http-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/http-minimal-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/http-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/http-full-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/index.md
@@ -18,7 +18,7 @@ Stdout target doesn't have any configurable options - when configured it simply 
 Here is an example of the configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/stdout-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/stdout-full-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use `failure_target` instead of `target`.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/kafka.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/kafka.md
@@ -22,7 +22,7 @@ TLS may be configured by providing the `key_file`, `cert_file` and `ca_file` opt
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kafka-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/kafka-minimal-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
@@ -30,7 +30,7 @@ If you want to use this as a [failure target](/docs/destinations/forwarding-even
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kafka-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/kafka-full-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/kinesis.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/kinesis.md
@@ -21,14 +21,14 @@ As of 2.4.2, the kinesis target handles kinesis write throughput exceptions sepa
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kinesis-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/kinesis-minimal-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/kinesis-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/kinesis-full-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/pubsub.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/pubsub.md
@@ -19,7 +19,7 @@ Snowbridge connects to PubSub using [Google's Go Pubsub sdk](https://cloud.googl
 The PubSub Target has only two required options, and no optional ones.
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/pubsub-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/pubsub-full-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/targets/sqs.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/targets/sqs.md
@@ -18,7 +18,7 @@ Authentication is done via the [AWS authentication environment variables](https:
 Here is an example of the minimum required configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/sqs-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/sqs-minimal-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.
@@ -26,7 +26,7 @@ If you want to use this as a [failure target](/docs/destinations/forwarding-even
 Here is an example of every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/targets/sqs-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/targets/sqs-full-example.hcl
 `}</CodeBlock>
 
 If you want to use this as a [failure target](/docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md#failure-targets), then use failure_target instead of target.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
@@ -19,5 +19,5 @@ This transformation base64 decodes the message's data from a base64 byte array, 
 ## Configuration options
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/base64Decode-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/builtin/base64Decode-minimal-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
@@ -19,5 +19,5 @@ This transformation base64 encodes the message's data to a base 64 byte array.
 ## Configuration options
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/base64Encode-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/builtin/base64Encode-minimal-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
@@ -31,13 +31,13 @@ The jq transformation will remove any keys with null values from the data.
 Minimal configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jq-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jq-minimal-example.hcl
 `}</CodeBlock>
 
 Every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jq-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jq-full-example.hcl
 `}</CodeBlock>
 
 ## Helper functions

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
@@ -29,13 +29,13 @@ This example filters out all data that doesn't have an `app_id` key.
 Minimal configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jqFilter-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jqFilter-minimal-example.hcl
 `}</CodeBlock>
 
 Every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jqFilter-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/builtin/jqFilter-full-example.hcl
 `}</CodeBlock>
 
 ## Helper Functions

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
@@ -21,11 +21,11 @@ This example filters out all data whose `platform` value does not match either `
 Minimal configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-minimal-example.hcl
 `}</CodeBlock>
 
 Every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilter-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
@@ -27,11 +27,11 @@ The below example keeps messages which contain `prod` in the `environment` field
 Minimal configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-minimal-example.hcl
 `}</CodeBlock>
 
 Every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterContext-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
@@ -27,11 +27,11 @@ This example keeps all events whose `add_to_cart` event data at the `sku` field 
 Minimal configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-minimal-example.hcl
 `}</CodeBlock>
 
 Every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedFilterUnstructEvent-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
@@ -16,7 +16,7 @@ import CodeBlock from '@theme/CodeBlock';
 `SpEnrichedSetPk` only takes one option — the field to use for the partition key.
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedSetPk-minimal-example.hcl
 `}</CodeBlock>
 
 Note: currently, setting partition key to fields in custom events and contexts is unsupported.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
@@ -15,7 +15,7 @@ import CodeBlock from '@theme/CodeBlock';
 ## Configuration options
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spEnrichedToJson-minimal-example.hcl
 `}</CodeBlock>
 
 The transformation to JSON is done via the [analytics SDK](/docs/api-reference/analytics-sdk/index.md) logic, specifically in this case the [Golang analytics SDK](/docs/api-reference/analytics-sdk/analytics-sdk-go/index.md).

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
@@ -27,9 +27,9 @@ First, we validate to ensure that the value is a valid base64 string. Second, we
 ## Configuration options
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-minimal-example.hcl
 `}</CodeBlock>
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/snowplow-builtin/spGtmssPreview-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/examples/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/examples/index.md
@@ -26,13 +26,13 @@ For this example, the input data is a json string which looks like this:
 The script filters out any data with a `batmobileCount` less than 1, otherwise it updates the Data's `name` field to "Bruce Wayne", and sets the PartitionKey to the value of `id`:
 
 <CodeBlock language="js" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-script-example.js
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-script-example.js
 `}</CodeBlock>
 
 The configuration for this script is:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-config-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-non-snowplow-config-example.hcl
 `}</CodeBlock>
 
 ## Snowplow data
@@ -44,11 +44,11 @@ The script below filters out non-web data, based on the `platform` value, otherw
 It also sets the partitionKey to `app_id`.
 
 <CodeBlock language="js" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-script-example.js
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-script-example.js
 `}</CodeBlock>
 
 The configuration for this script is:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-config-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/examples/js-snowplow-config-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
@@ -97,7 +97,7 @@ For all the below examples, the input is a string representation of the below JS
 To modify the message data, return an object which conforms to EngineProtocol, with the `Data` field set to the modified data. The `Data` field may be returned as either a string, or an object.
 
 <CodeBlock language="js" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.js
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-modify-example.js
 `}</CodeBlock>
 
 ## Filtering
@@ -105,7 +105,7 @@ https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/c
 If the `FilterOut` field of the output is returned as `true`, the message will be acknowledged immediately and won't be sent to the target. This will be the behavior regardless of what is returned to the other fields in the protocol.
 
 <CodeBlock language="js" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.js
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-filter-example.js
 `}</CodeBlock>
 
 ## Setting the Partition Key
@@ -113,13 +113,13 @@ https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/c
 To set the Partition Key in the message, you can simply set the input's PartitionKey field, and return it:
 
 <CodeBlock language="js" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.js
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-example.js
 `}</CodeBlock>
 
 Or, if modifying the data as well, return the modified data and PartitionKey field:
 
 <CodeBlock language="js" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.js
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-setpk-modify-example.js
 `}</CodeBlock>
 
 ## Setting an HTTP header
@@ -127,7 +127,7 @@ https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/c
 For the `http` target only, you can specify a set of HTTP headers, which will be appended to the configured headers for the `http` target. Do so by providing an object in the `HTTPHeaders` field:
 
 <CodeBlock language="js" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-header-example.js
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/create-a-script-header-example.js
 `}</CodeBlock>
 
 The headers will only be included if the target has the [`dynamic_headers = true` setting](/docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md#configuration-options) configured.

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/javascript-configuration/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/javascript-configuration/index.md
@@ -24,11 +24,11 @@ Scripts must be available to the runtime of the application at the path provided
 Minimal configuration:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/js-configuration-minimal-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/js-configuration-minimal-example.hcl
 `}</CodeBlock>
 
 Every configuration option:
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/js-configuration-full-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/custom-scripts/js-configuration-full-example.hcl
 `}</CodeBlock>

--- a/docs/destinations/forwarding-events/snowbridge/configuration/transformations/index.md
+++ b/docs/destinations/forwarding-events/snowbridge/configuration/transformations/index.md
@@ -32,5 +32,5 @@ Example:
 The below first filters out any `event_name` which does not match the regex `^page_view$`, then runs a custom javascript script to change the app_id value to `"1"`
 
 <CodeBlock language="hcl" reference>{`
-https://github.com/snowplow/snowbridge/blob/${versions.snowbridge}/assets/docs/configuration/transformations/transformations-overview-example.hcl
+https://github.com/snowplow/snowbridge/blob/v${versions.snowbridge}/assets/docs/configuration/transformations/transformations-overview-example.hcl
 `}</CodeBlock>

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -25,7 +25,7 @@ export const versions = {
   enrich: '6.0.0',
   sqs2kinesis: '1.0.4',
   dataflowRunner: '0.7.5',
-  snowbridge: 'v3.5.0',
+  snowbridge: '3.5.0',
 
   // Loaders
   bqLoader: '2.0.1',


### PR DESCRIPTION
Starting from `snowbridge` version 3.5.0, we tag releases with new tag-format
`v<major>.<minor>.<patch>`

Thus correct version to be used in the docs is now `v3.5.0` instead of `3.5.0`