### PR TITLE
Bug Fix for Large Tables inside of Tabs Component

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -647,23 +647,26 @@ img.shield {
   vertical-align: text-bottom;
 }
 
-.tabs-container:hover {
-  border: 2px solid var(--ifm-color-primary);
+/* Tabs component inside of Articles Start */
+.tabs-container div {
+  overflow-x: scroll;
 }
-
+.tabs-container:hover {
+  border: 1px solid hsl(var(--primary));
+}
 .tabs-container {
   padding: 7px 14px 14px;
   border: 2px solid transparent;
   border-radius: var(--ifm-alert-border-radius);
   transition: 0.4s cubic-bezier(0.38, 0.14, 0.58, 1) all;
 }
-
 .tabs__item {
   align-self: stretch;
   align-items: center;
   justify-content: center;
   text-align: center;
 }
+/* Tabs component inside of Articles End*/
 
 abbr[data-title] {
   position: relative;


### PR DESCRIPTION
When there are large tables inside the accordion component in an MDX file, the table overflows outside the accordion. 

Fixed this bug by adding a scroll bar inside the accordion if the table is too large. 

<img width="720" height="201" alt="image" src="https://github.com/user-attachments/assets/83d84aa6-241b-49ef-963c-b9891690dc5f" />


<img width="819" height="267" alt="Screenshot 2025-08-27 at 8 33 03 AM" src="https://github.com/user-attachments/assets/7c339878-d664-4d09-9afc-8192d6ccea5d" />

To see the bug on Prod:
https://docs.snowplow.io/docs/destinations/warehouses-lakes/schemas-in-warehouse/?warehouse=bigquery
