### PR TITLE
Add descriptive JSON-LD schema data to all pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,6 +77,7 @@ module.exports = {
         showLastUpdateTime: true,
       },
     ],
+    './plugins/docusaurus-plugin-snowplow-schema',
   ],
 
   stylesheets: [
@@ -101,8 +102,8 @@ module.exports = {
       navbar: {
         hideOnScroll: false,
         logo: {
-            alt: 'Snowplow Logo',
-            src: 'img/snowplow-logo.svg',
+          alt: 'Snowplow Logo',
+          src: 'img/snowplow-logo.svg',
         },
         items: [
           {
@@ -121,7 +122,7 @@ module.exports = {
           //   position: 'right',
           // },
           // {
-           //  href: 'https://community.snowplow.io/',
+          //  href: 'https://community.snowplow.io/',
           //   label: 'Community',
           //   position: 'right',
           // },
@@ -138,8 +139,8 @@ module.exports = {
           //   position: 'right',
           // },
           {
-             type: 'custom-docsTrackerNavbarButton',
-             position: 'left',
+            type: 'custom-docsTrackerNavbarButton',
+            position: 'left',
           },
         ],
       },
@@ -167,7 +168,6 @@ module.exports = {
                 href: '/docs/glossary/',
                 label: 'Glossary',
               },
-         
             ],
           },
           {
@@ -199,7 +199,6 @@ module.exports = {
                 label: 'Licensing Overview',
                 href: '/docs/resources/copyright-license',
               },
-             
             ],
           },
         ],

--- a/plugins/docusaurus-plugin-snowplow-schema/README.md
+++ b/plugins/docusaurus-plugin-snowplow-schema/README.md
@@ -1,0 +1,34 @@
+# JSON-LD Schema Validation Guide
+
+This project includes automatic **JSON-LD schema generation** for all pages.  
+Follow this guide to validate and debug schema for any page locally or after deployment.
+
+---
+
+## 📝 How to Test JSON-LD Per Page (Google Rich Results)
+
+1. Open the desired page in your browser.
+2. Right-click and select **View Page Source**.
+3. Search for `<script type="application/ld+json">`.
+4. Copy the JSON-LD block.
+5. Visit [Google Rich Results Test](https://search.google.com/test/rich-results).
+6. Paste the URL or JSON-LD code into the tool.
+7. Review any errors or warnings and adjust your schema if needed.
+
+---
+
+## 🧪 Local Validation Command
+
+Use the following command to validate the JSON-LD schema of a page on your **local development server**:
+
+```bash
+# Install jq and curl if not already installed
+# macOS: brew install jq curl
+# Ubuntu/Debian: sudo apt install jq curl
+
+# Replace /docs/example-page with your actual page path
+curl -s http://localhost:3000/docs/example-page \
+  | grep -o '<script type="application/ld+json">.*</script>' \
+  | sed 's/<script type="application\/ld+json">//' \
+  | sed 's/<\/script>//' \
+  | jq .

--- a/plugins/docusaurus-plugin-snowplow-schema/package.json
+++ b/plugins/docusaurus-plugin-snowplow-schema/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "docusaurus-plugin-snowplow-schema",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "peerDependencies": {
+    "@docusaurus/core": ">=2.0.0",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+  }
+}

--- a/plugins/docusaurus-plugin-snowplow-schema/src/index.js
+++ b/plugins/docusaurus-plugin-snowplow-schema/src/index.js
@@ -55,80 +55,80 @@ module.exports = function snowplowSchemaPlugin(context, options) {
     path.join(__dirname, 'schemaData/keywords.md'),
     true
   )
-  
-function loadMDXMetadata(folderPath, basePrefix) {
-  if (!fs.existsSync(folderPath)) return {}
-  const metadata = {}
 
-  function walk(dir, base = '') {
-    const files = fs.readdirSync(dir)
-    for (const file of files) {
-      const fullPath = path.join(dir, file)
-      const stat = fs.statSync(fullPath)
+  function loadMDXMetadata(folderPath, basePrefix) {
+    if (!fs.existsSync(folderPath)) return {}
+    const metadata = {}
 
-      if (stat.isDirectory()) {
-        walk(fullPath, path.join(base, file))
-      } else if (file.endsWith('.md') || file.endsWith('.mdx')) {
-        // Skip partials: files starting with "_"
-        if (file.startsWith('_')) continue
+    function walk(dir, base = '') {
+      const files = fs.readdirSync(dir)
+      for (const file of files) {
+        const fullPath = path.join(dir, file)
+        const stat = fs.statSync(fullPath)
 
-        const rawContent = fs.readFileSync(fullPath, 'utf8')
-        const parsed = matter(rawContent)
-        const { data } = parsed
+        if (stat.isDirectory()) {
+          walk(fullPath, path.join(base, file))
+        } else if (file.endsWith('.md') || file.endsWith('.mdx')) {
+          // Skip partials: files starting with "_"
+          if (file.startsWith('_')) continue
 
-        // 🚫 Never trust frontmatter description → wipe it
-        data.description = undefined
+          const rawContent = fs.readFileSync(fullPath, 'utf8')
+          const parsed = matter(rawContent)
+          const { data } = parsed
 
-        const rawSlug = data.slug
-        const filename = file.replace(/\.mdx?$/, '')
-        let slug
+          // 🚫 Never trust frontmatter description → wipe it
+          data.description = undefined
 
- if (rawSlug) {
-  // Always resolve against basePrefix (docs semantics)
-  const cleanedRaw = String(rawSlug).replace(/^\/+/, '') // drop leading slash
-  slug = '/' + normalizeSlug([basePrefix, cleanedRaw].filter(Boolean).join('/'))
-} else {
-  // Derive from path, then resolve against basePrefix
-  slug = '/' + path.join(base, filename).replace(/\\/g, '/')
-  if (filename === 'index') slug = '/' + base.replace(/\\/g, '/')
-  const parts = slug.split('/')
-  const last = parts[parts.length - 1]
-  const secondLast = parts[parts.length - 2]
-  if (last === secondLast) slug = parts.slice(0, -1).join('/')
+          const rawSlug = data.slug
+          const filename = file.replace(/\.mdx?$/, '')
+          let slug
 
-  const cleaned = String(slug || '').replace(/^\/+/, '')
-  slug = '/' + normalizeSlug([basePrefix, cleaned].filter(Boolean).join('/'))
-}
+          if (rawSlug) {
+            // Always resolve against basePrefix (docs semantics)
+            const cleanedRaw = String(rawSlug).replace(/^\/+/, '') // drop leading slash
+            slug = '/' + normalizeSlug([basePrefix, cleanedRaw].filter(Boolean).join('/'))
+          } else {
+            // Derive from path, then resolve against basePrefix
+            slug = '/' + path.join(base, filename).replace(/\\/g, '/')
+            if (filename === 'index') slug = '/' + base.replace(/\\/g, '/')
+            const parts = slug.split('/')
+            const last = parts[parts.length - 1]
+            const secondLast = parts[parts.length - 2]
+            if (last === secondLast) slug = parts.slice(0, -1).join('/')
 
-        const relPath = normalizePath(path.join(basePrefix, base, file))
-        const lookupPath = relPath
+            const cleaned = String(slug || '').replace(/^\/+/, '')
+            slug = '/' + normalizeSlug([basePrefix, cleaned].filter(Boolean).join('/'))
+          }
 
-        data.description = descriptionMap[lookupPath] || 'Snowplow documentation'
-        if (keywordsMap[lookupPath]) {
-          data.keywords = keywordsMap[lookupPath]
-        }
+          const relPath = normalizePath(path.join(basePrefix, base, file))
+          const lookupPath = relPath
 
-        // ---- Fallbacks ----
-        if (!data.title) {
-          data.title = 'Snowplow documentation'
-        }
-        if (!Array.isArray(data.keywords) || data.keywords.length === 0) {
-          data.keywords = ['Snowplow', 'Behavioral data', 'Customer data integration']
-        }
+          data.description = descriptionMap[lookupPath] || 'Snowplow documentation'
+          if (keywordsMap[lookupPath]) {
+            data.keywords = keywordsMap[lookupPath]
+          }
 
-        metadata[slug] = data
+          // ---- Fallbacks ----
+          if (!data.title) {
+            data.title = 'Snowplow documentation'
+          }
+          if (!Array.isArray(data.keywords) || data.keywords.length === 0) {
+            data.keywords = ['composable CDP', 'composable analytics', 'real-time personalization', 'agentic applications', 'customer data infrastructure', 'event architecture', 'behavioral data', 'event tracking', 'AI-ready data', 'data pipeline', 'first-party data', 'product analytics', 'data governance', 'machine learning data']
+          }
 
-        // Extra safety: if this doc explicitly set slug: '/' store an alias at '/'
-        if (rawSlug && rawSlug.trim() === '/') {
-          metadata['/'] = data
+          metadata[slug] = data
+
+          // Extra safety: if this doc explicitly set slug: '/' store an alias at '/'
+          if (rawSlug && rawSlug.trim() === '/') {
+            metadata['/'] = data
+          }
         }
       }
     }
-  }
 
-  walk(folderPath)
-  return metadata
-}
+    walk(folderPath)
+    return metadata
+  }
 
 
   return {

--- a/plugins/docusaurus-plugin-snowplow-schema/src/index.js
+++ b/plugins/docusaurus-plugin-snowplow-schema/src/index.js
@@ -1,0 +1,165 @@
+const fs = require('fs')
+const path = require('path')
+const matter = require('gray-matter')
+
+function normalizePath(p) {
+  return p.replace(/\\/g, '/').replace(/^\.\/?/, '')
+}
+
+function normalizeSlug(slug) {
+  return slug.replace(/\/$/, '')
+}
+
+function loadMapping(filePath, isKeywords = false) {
+  if (!fs.existsSync(filePath)) return {}
+
+  const lines = fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+
+  const map = {}
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].endsWith('.md')) {
+      const rawPath = normalizePath(lines[i])
+      if (i + 1 < lines.length && !lines[i + 1].endsWith('.md')) {
+        if (isKeywords) {
+          const keywords = lines[i + 1]
+            .split(',')
+            .map((k) => k.replace(/"/g, '').trim())
+            .filter(Boolean)
+          map[rawPath] = keywords
+        } else {
+          const desc = lines[i + 1]
+            .replace(/^description:\s*/, '')
+            .replace(/^"|"$/g, '')
+          map[rawPath] = desc
+        }
+      }
+    }
+  }
+  return map
+}
+
+module.exports = function snowplowSchemaPlugin(context, options) {
+  const siteUrl = (
+    context?.siteConfig?.url || 'https://docs.snowplow.io'
+  ).replace(/\/$/, '')
+  const siteName = context?.siteConfig?.title || 'Snowplow Documentation'
+
+  const descriptionMap = loadMapping(
+    path.join(__dirname, 'schemaData/description.md')
+  )
+  const keywordsMap = loadMapping(
+    path.join(__dirname, 'schemaData/keywords.md'),
+    true
+  )
+
+function loadMDXMetadata(folderPath, basePrefix) {
+  if (!fs.existsSync(folderPath)) return {}
+  const metadata = {}
+
+  function walk(dir, base = '') {
+    const files = fs.readdirSync(dir)
+    for (const file of files) {
+      const fullPath = path.join(dir, file)
+      const stat = fs.statSync(fullPath)
+
+      if (stat.isDirectory()) {
+        walk(fullPath, path.join(base, file))
+      } else if (file.endsWith('.md') || file.endsWith('.mdx')) {
+        const rawContent = fs.readFileSync(fullPath, 'utf8')
+        const parsed = matter(rawContent)
+        const { data } = parsed
+
+        // 🚫 Never trust frontmatter description → wipe it
+        data.description = undefined
+
+        const rawSlug = data.slug
+        const filename = file.replace(/\.mdx?$/, '')
+        let slug
+
+        if (rawSlug) {
+          slug = rawSlug
+        } else {
+          slug = '/' + path.join(base, filename).replace(/\\/g, '/')
+          if (filename === 'index') slug = '/' + base.replace(/\\/g, '/')
+          const pathParts = slug.split('/')
+          const last = pathParts[pathParts.length - 1]
+          const secondLast = pathParts[pathParts.length - 2]
+          if (last === secondLast) slug = pathParts.slice(0, -1).join('/')
+        }
+
+        slug = '/' + normalizeSlug(path.join(basePrefix, slug).replace(/\\/g, '/'))
+
+        const relPath = normalizePath(path.join(basePrefix, base, file))
+        let lookupPath = relPath
+
+        // Special case: homepage
+        if (slug === '/' && file === 'introduction.md') {
+          lookupPath = 'docs/introduction.md'
+
+          // 🚨 Force override: never use frontmatter, only map or fallback
+          data.description = descriptionMap[lookupPath] || 'Snowplow documentation'
+        } else {
+          // Normal pages → apply mapping overrides
+          data.description = descriptionMap[lookupPath] || 'Snowplow documentation'
+        }
+
+        if (keywordsMap[lookupPath]) {
+          data.keywords = keywordsMap[lookupPath]
+        }
+
+        // ---- Fallbacks ----
+        if (!data.title) {
+          data.title = 'Snowplow documentation'
+        }
+
+        if (!data.keywords || !Array.isArray(data.keywords) || data.keywords.length === 0) {
+          data.keywords = ['Snowplow', 'Behavioral data', 'Customer data integration']
+        }
+
+        metadata[slug] = data
+      }
+    }
+  }
+
+  walk(folderPath)
+  return metadata
+}
+
+
+
+  return {
+    name: 'docusaurus-plugin-page-schema',
+
+    async loadContent() {
+      const docsMetadata = loadMDXMetadata(
+        path.join(context.siteDir, 'docs'),
+        'docs'
+      )
+      const tutorialsMetadata = loadMDXMetadata(
+        path.join(context.siteDir, 'tutorials'),
+        'tutorials'
+      )
+      const blogMetadata = loadMDXMetadata(
+        path.join(context.siteDir, 'blog'),
+        'blog'
+      )
+
+      const allPagesMetadata = {
+        ...docsMetadata,
+        ...tutorialsMetadata,
+        ...blogMetadata,
+      }
+
+      return { allPagesMetadata, siteUrl, siteName }
+    },
+
+    async contentLoaded({ content, actions }) {
+      const { setGlobalData } = actions
+      setGlobalData(content)
+    },
+  }
+}

--- a/plugins/docusaurus-plugin-snowplow-schema/src/schemaData/description.md
+++ b/plugins/docusaurus-plugin-snowplow-schema/src/schemaData/description.md
@@ -1,0 +1,3143 @@
+docs/fundamentals/canonical-event/understanding-the-enriched-tsv-format/index.md
+description: "Learn about Snowplow's enriched TSV file format structure and field organization for processing behavioral data in your pipeline."
+
+docs/fundamentals/canonical-event/index.md
+description: "Understand Snowplow's canonical event structure and how behavioral data is organized across warehouse tables and platforms."
+
+docs/fundamentals/destinations/index.md
+description: "Overview of Snowplow destination options for streaming behavioral data to warehouses, lakes, and real-time applications."
+
+docs/fundamentals/schemas/index.md
+description: "Learn about JSON Schema validation in Snowplow for ensuring data quality and structure across your behavioral data pipeline."
+
+docs/fundamentals/failed-events/index.md
+description: "Understand how Snowplow handles failed events and strategies for maintaining high data quality in your pipeline."
+
+docs/fundamentals/index.md
+description: "Essential concepts and building blocks for understanding Snowplow's behavioral data infrastructure and event analytics platform."
+
+docs/fundamentals/data-products/index.md
+description: "Introduction to Snowplow Data Products for organizing and governing your behavioral data collection and schema management."
+
+docs/fundamentals/events/index.md
+description: "Core concepts of Snowplow events including self-describing and structured events for capturing user interactions and behaviors."
+
+docs/fundamentals/entities/index.md
+description: "Learn about Snowplow entities (contexts) that provide rich contextual information to enhance your behavioral event data."
+
+docs/pipeline/security/customer-managed-keys/index.md
+description: "Configure customer-managed encryption keys for enhanced security of your Snowplow pipeline data and infrastructure."
+
+docs/pipeline/security/index.md
+description: "Security best practices and configuration options for protecting your Snowplow behavioral data pipeline and infrastructure."
+
+docs/pipeline/enrichments/filtering-bot-events/index.md
+description: "Configure bot filtering to remove automated traffic and maintain high-quality behavioral data in your Snowplow pipeline."
+
+docs/pipeline/enrichments/available-enrichments/iab-enrichment/index.md
+description: "Enable IAB enrichment to classify web traffic and filter invalid or non-human interactions from your behavioral data."
+
+docs/pipeline/enrichments/available-enrichments/campaign-attribution-enrichment/index.md
+description: "Track marketing campaign performance by enriching events with campaign attribution data from UTM parameters."
+
+docs/pipeline/enrichments/available-enrichments/cookie-extractor-enrichment/index.md
+description: "Extract and parse HTTP cookie values to enhance your behavioral events with additional user context data."
+
+docs/pipeline/enrichments/available-enrichments/custom-api-request-enrichment/index.md
+description: "Enrich events with external API data by making custom HTTP requests during the Snowplow pipeline processing."
+
+docs/pipeline/enrichments/available-enrichments/http-header-extractor-enrichment/index.md
+description: "Extract and parse HTTP header information to add technical context and metadata to your behavioral events."
+
+docs/pipeline/enrichments/available-enrichments/event-fingerprint-enrichment/index.md
+description: "Generate unique fingerprints for events to enable deduplication and data quality monitoring in your pipeline."
+
+docs/pipeline/enrichments/available-enrichments/ip-lookup-enrichment/index.md
+description: "Enhance events with geographic location data using IP address lookup enrichment for geographic analytics."
+
+docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+description: "Parse and classify referrer URLs to understand traffic sources and user journey patterns in your behavioral data."
+
+docs/pipeline/enrichments/available-enrichments/yauaa-enrichment/index.md
+description: "Enhance events with detailed user agent parsing using YAUAA for device, browser, and platform identification."
+
+docs/pipeline/enrichments/available-enrichments/index.md
+description: "Complete guide to Snowplow's built-in enrichments for enhancing behavioral events with contextual data and validation."
+
+docs/pipeline/enrichments/available-enrichments/ua-parser-enrichment/index.md
+description: "Parse user agent strings to extract browser, operating system, and device information for behavioral analysis."
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/testing/index.md
+description: "Test and debug custom JavaScript enrichments before deploying them to your Snowplow production pipeline."
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/index.md
+description: "Create custom JavaScript enrichments to add business-specific logic and data transformations to your events."
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/examples/index.md
+description: "Practical examples of custom JavaScript enrichments for common use cases and business logic implementation."
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/writing/index.md
+description: "Best practices and guidelines for writing effective custom JavaScript enrichments for your Snowplow pipeline."
+
+docs/pipeline/enrichments/available-enrichments/custom-sql-enrichment/index.md
+description: "Enrich events with database lookups using custom SQL queries to add business context and reference data."
+
+docs/pipeline/enrichments/available-enrichments/pii-pseudonymization-enrichment/index.md
+description: "Implement PII pseudonymization to protect sensitive user data while maintaining behavioral analytics capabilities."
+
+docs/pipeline/enrichments/available-enrichments/currency-conversion-enrichment/index.md
+description: "Convert monetary values between currencies in ecommerce events for consistent financial analysis and reporting."
+
+docs/pipeline/enrichments/available-enrichments/cross-navigation-enrichment/index.md
+description: "Track user navigation patterns across domains and subdomains for comprehensive cross-site behavioral analysis."
+
+docs/pipeline/enrichments/available-enrichments/ip-anonymization-enrichment/index.md
+description: "Anonymize IP addresses in behavioral events to comply with privacy regulations while preserving geographic insights."
+
+docs/pipeline/enrichments/managing-enrichments/terraform/index.md
+description: "Deploy and manage Snowplow enrichments using Terraform infrastructure as code for automated pipeline configuration."
+
+docs/pipeline/enrichments/managing-enrichments/index.md
+description: "Configure, deploy, and manage enrichments in your Snowplow pipeline for enhanced behavioral data processing."
+
+docs/pipeline/enrichments/index.md
+description: "Transform raw behavioral events with Snowplow enrichments to add context, validation, and business logic."
+
+docs/pipeline/collector/index.md
+description: "Configure and deploy Snowplow Collector to receive and validate behavioral events from trackers and webhooks."
+
+docs/pipeline/index.md
+description: "Overview of Snowplow's real-time behavioral data pipeline architecture, components, and processing flow."
+
+docs/data-product-studio/data-structures/index.md
+description: "Create and manage JSON Schema data structures for consistent behavioral data validation across your Snowplow implementation."
+
+docs/data-product-studio/data-structures/version-amend/amending/index.md
+description: "Amend existing data structure versions to fix issues while maintaining backward compatibility in your schema evolution."
+
+docs/data-product-studio/data-structures/version-amend/enterprise/index.md
+description: "Enterprise-grade schema versioning and amendment workflows for large-scale behavioral data governance and compliance."
+
+docs/data-product-studio/data-structures/version-amend/index.md
+description: "Version control and amendment strategies for evolving data structures without breaking your behavioral data collection."
+
+docs/data-product-studio/data-structures/version-amend/iglu/index.md
+description: "Use Iglu repository features for advanced data structure versioning and schema registry management workflows."
+
+docs/data-product-studio/data-structures/version-amend/builder/index.md
+description: "Visual schema builder tools for creating and amending data structures through an intuitive user interface."
+
+docs/data-product-studio/data-structures/manage/cli/index.md
+description: "Command-line interface tools for managing data structures and automating schema development workflows."
+
+docs/data-product-studio/data-structures/manage/json-editor/index.md
+description: "Direct JSON editing interface for advanced users to create and modify behavioral data schemas with full control."
+
+docs/data-product-studio/data-structures/manage/index.md
+description: "Comprehensive guide to managing data structure lifecycles from creation to deployment in behavioral data systems."
+
+docs/data-product-studio/data-structures/manage/api/index.md
+description: "REST API endpoints for programmatically managing data structures and automating schema governance workflows."
+
+docs/data-product-studio/data-structures/manage/iglu/index.md
+description: "Integrate with Iglu Schema Registry for enterprise-scale data structure management and version control."
+
+docs/data-product-studio/data-structures/manage/builder/index.md
+description: "User-friendly visual tools for creating and managing behavioral data schemas without requiring JSON expertise."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/flink/index.md
+description: "Execute failed event recovery jobs using Apache Flink for real-time processing of invalid behavioral data."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/index.md
+description: "Manual processes for running failed event recovery to restore data quality in your behavioral analytics pipeline."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/gcp-beam/index.md
+description: "Deploy failed event recovery using Google Cloud Dataflow and Apache Beam for scalable data processing."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/spark/index.md
+description: "Process failed events using Apache Spark for large-scale batch recovery of behavioral data quality issues."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/configuration/index.md
+description: "Configure failed event recovery parameters and settings for optimal data quality restoration workflows."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/configuration/configuration-examples/index.md
+description: "Practical configuration examples for common failed event recovery scenarios and data quality issues."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/troubleshooting/index.md
+description: "Troubleshoot and resolve issues with failed event recovery processes to maintain behavioral data quality."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/testing/index.md
+description: "Test failed event recovery configurations and processes before deploying to production behavioral data systems."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/getting-started/index.md
+description: "Quick start guide for implementing failed event recovery to maintain high-quality behavioral data collection."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/index.md
+description: "Manual workflows for recovering failed behavioral events and restoring data quality in your Snowplow pipeline."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/extending/index.md
+description: "Extend failed event recovery capabilities with custom logic for specific behavioral data quality requirements."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/monitoring/index.md
+description: "Monitor failed event recovery processes and track data quality improvements in your behavioral analytics pipeline."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/hints-workflows/index.md
+description: "Best practices and workflow recommendations for efficient failed event recovery and data quality management."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/index.md
+description: "Recover and fix failed behavioral events to maintain data quality and completeness in your analytics pipeline."
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/builder/index.md
+description: "Visual interface for building failed event recovery workflows without requiring technical implementation knowledge."
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/troubleshooting/index.md
+description: "Diagnose and resolve issues with failed event monitoring to ensure continuous behavioral data quality oversight."
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/classic-alerts/index.md
+description: "Configure traditional alert systems for monitoring failed events and maintaining behavioral data quality standards."
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/index.md
+description: "Set up comprehensive alerting systems to proactively monitor failed events and behavioral data quality issues."
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/creating-alerts/index.md
+description: "Create custom alerts for specific failed event patterns and data quality thresholds in your behavioral pipeline."
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/managing-alerts/index.md
+description: "Manage and maintain failed event alert configurations for ongoing behavioral data quality monitoring."
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/index.md
+description: "Advanced alert configurations for detecting and responding to failed events in real-time behavioral data streams."
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/index.md
+description: "Monitor failed events in your behavioral data pipeline to maintain data quality and identify collection issues."
+
+docs/data-product-studio/data-quality/failed-events/exploring-failed-events/file-storage/index.md
+description: "Access and analyze failed events stored in file systems for detailed behavioral data quality investigation."
+
+docs/data-product-studio/data-quality/failed-events/exploring-failed-events/index.md
+description: "Explore and analyze failed behavioral events to understand data quality issues and improve collection processes."
+
+docs/data-product-studio/data-quality/failed-events/index.md
+description: "Comprehensive guide to handling failed events in Snowplow for maintaining high-quality behavioral data collection."
+
+docs/data-product-studio/data-quality/index.md
+description: "Maintain and improve behavioral data quality across your Snowplow implementation with monitoring and validation tools."
+
+docs/data-product-studio/data-quality/snowplow-micro/ui/index.md
+description: "Navigate Snowplow Micro's user interface for testing and debugging behavioral event tracking implementations."
+
+docs/data-product-studio/data-quality/snowplow-micro/configuring-enrichments/index.md
+description: "Configure enrichments in Snowplow Micro for local testing of behavioral data processing logic."
+
+docs/data-product-studio/data-quality/snowplow-micro/automated-testing/index.md
+description: "Implement automated testing workflows using Snowplow Micro for continuous behavioral data quality assurance."
+
+docs/data-product-studio/data-quality/snowplow-micro/adding-schemas/index.md
+description: "Add custom schemas to Snowplow Micro for testing self-describing events and entities locally."
+
+docs/data-product-studio/data-quality/snowplow-micro/remote-usage/index.md
+description: "Deploy and use Snowplow Micro remotely for team-based testing and behavioral data validation workflows."
+
+docs/data-product-studio/data-quality/snowplow-micro/advanced-usage/index.md
+description: "Advanced Snowplow Micro configurations and workflows for complex behavioral data testing scenarios."
+
+docs/data-product-studio/data-quality/snowplow-micro/basic-usage/index.md
+description: "Basic Snowplow Micro setup and usage for testing behavioral event tracking in development environments."
+
+docs/data-product-studio/data-quality/snowplow-micro/index.md
+description: "Lightweight testing tool for validating behavioral event tracking and schema compliance during development."
+
+docs/data-product-studio/data-quality/snowplow-inspector/adding-schemas/index.md
+description: "Add custom schemas to Snowplow Inspector for enhanced behavioral event validation and debugging capabilities."
+
+docs/data-product-studio/data-quality/snowplow-inspector/importing-events/index.md
+description: "Import and analyze existing behavioral events in Snowplow Inspector for detailed quality assessment and debugging."
+
+docs/data-product-studio/data-quality/snowplow-inspector/index.md
+description: "Browser extension for real-time behavioral event inspection and validation during web application development."
+
+docs/data-product-studio/data-quality/data-structures-ci-tool/index.md
+description: "Continuous integration tools for automated testing and validation of behavioral data schemas and structures."
+
+docs/data-product-studio/event-specifications/tracking-plans/index.md
+description: "Create and manage tracking plans to standardize behavioral event collection across teams and applications."
+
+docs/data-product-studio/event-specifications/index.md
+description: "Define and manage event specifications to ensure consistent behavioral data collection across your organization."
+
+docs/data-product-studio/event-specifications/api/index.md
+description: "REST API for programmatically managing event specifications and automating behavioral data governance workflows."
+
+docs/data-product-studio/snowplow-cli/index.md
+description: "Command-line interface for managing Snowplow data structures, schemas, and behavioral data governance workflows."
+
+docs/data-product-studio/snowplow-cli/reference/index.md
+description: "Complete command reference for Snowplow CLI tools and behavioral data management automation capabilities."
+
+docs/data-product-studio/source-applications/index.md
+description: "Organize and manage source applications that generate behavioral events in your Snowplow data ecosystem."
+
+docs/data-product-studio/index.md
+description: "Comprehensive behavioral data governance platform for managing schemas, data quality, and event specifications."
+
+docs/data-product-studio/snowtype/client-side-validation/index.md
+description: "Implement client-side validation of behavioral events using Snowtype for real-time data quality assurance."
+
+docs/data-product-studio/snowtype/snowtype-config/index.md
+description: "Configure Snowtype settings and parameters for optimal behavioral event validation and type generation."
+
+docs/data-product-studio/snowtype/working-with-gtm/index.md
+description: "Integrate Snowtype with Google Tag Manager for type-safe behavioral event tracking in tag management workflows."
+
+docs/data-product-studio/snowtype/index.md
+description: "TypeScript code generation tool for type-safe behavioral event tracking and data structure validation."
+
+docs/data-product-studio/snowtype/commands/index.md
+description: "Complete command reference for Snowtype CLI tools and automated TypeScript code generation workflows."
+
+docs/data-product-studio/snowtype/using-the-cli/index.md
+description: "Command-line interface usage guide for Snowtype behavioral event validation and TypeScript generation tools."
+
+docs/data-product-studio/data-products/ui/index.md
+description: "User interface guide for managing behavioral data products through Snowplow's visual data governance platform."
+
+docs/data-product-studio/data-products/data-product-templates/index.md
+description: "Pre-built templates for common behavioral data products to accelerate implementation and ensure best practices."
+
+docs/data-product-studio/data-products/cli/index.md
+description: "Command-line tools for creating and managing behavioral data products in automated governance workflows."
+
+docs/data-product-studio/data-products/index.md
+description: "Organize and govern behavioral data collection with data products that encapsulate schemas and business logic."
+
+docs/data-product-studio/data-products/api/index.md
+description: "REST API endpoints for programmatically managing behavioral data products and governance automation."
+
+docs/account-management/managing-users/index.md
+description: "Manage user accounts, roles, and access permissions within your Snowplow organization and behavioral data platform."
+
+docs/account-management/index.md
+description: "Administrative tools and settings for managing your Snowplow organization, users, and behavioral data platform access."
+
+docs/account-management/managing-permissions/index.md
+description: "Configure role-based access control and permissions for secure behavioral data platform administration."
+
+docs/destinations/reverse-etl/index.md
+description: "Send behavioral data from your warehouse back to operational systems using reverse ETL patterns and integrations."
+
+docs/destinations/index.md
+description: "Stream behavioral data to warehouses, lakes, and real-time destinations for analytics and operational use cases."
+
+docs/destinations/forwarding-events/native-integrations/index.md
+description: "Built-in integrations for forwarding behavioral events to popular marketing and analytics platforms."
+
+docs/destinations/forwarding-events/custom-integrations/index.md
+description: "Create custom integrations for forwarding behavioral events to proprietary systems and specialized platforms."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/index.md
+description: "Transform behavioral events during forwarding using Snowbridge's flexible data transformation capabilities."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/javascript-configuration/index.md
+description: "Configure JavaScript transformations for custom behavioral event processing in Snowbridge forwarding workflows."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
+description: "Write custom scripts for advanced behavioral event transformations during Snowbridge forwarding processes."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/examples/index.md
+description: "Practical examples of custom transformation scripts for common behavioral event forwarding scenarios."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
+description: "Use jq JSON processor for powerful behavioral event transformations in Snowbridge forwarding pipelines."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
+description: "Filter behavioral events by context entities using built-in Snowbridge transformation capabilities."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
+description: "Encode behavioral event data using Base64 transformation for secure forwarding to external systems."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
+description: "Transform behavioral events for Google Tag Manager Server-Side preview and debugging workflows."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
+description: "Filter enriched behavioral events based on specified criteria using built-in Snowbridge transformations."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/index.md
+description: "Built-in transformation functions for common behavioral event processing patterns in Snowbridge forwarding."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
+description: "Apply jq-based filtering to behavioral events for selective forwarding using Snowbridge transformations."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
+description: "Decode Base64-encoded behavioral event data using built-in Snowbridge transformation functions."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
+description: "Set primary key fields in enriched behavioral events for downstream processing and identification."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
+description: "Convert enriched behavioral events to JSON format for flexible forwarding to various destination systems."
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
+description: "Filter self-describing events from behavioral data streams using built-in Snowbridge transformation capabilities."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/kafka.md
+description: "Configure Apache Kafka as a destination for real-time behavioral event streaming using Snowbridge."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/pubsub.md
+description: "Set up Google Cloud Pub/Sub as a destination for scalable behavioral event streaming and processing."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/eventhub.md
+description: "Configure Azure Event Hubs for high-throughput behavioral event streaming using Snowbridge forwarding."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/sqs.md
+description: "Set up Amazon SQS queues as destinations for reliable behavioral event forwarding and processing."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/index.md
+description: "Configure destination targets for forwarding behavioral events to streaming platforms and data systems."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/http/google-tag-manager.md
+description: "Forward behavioral events to Google Tag Manager Server-Side via HTTP using Snowbridge configuration."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md
+description: "Configure HTTP endpoints as destinations for behavioral event forwarding using Snowbridge webhooks."
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/kinesis.md
+description: "Set up Amazon Kinesis streams for real-time behavioral event forwarding and analytics processing."
+
+docs/destinations/forwarding-events/snowbridge/configuration/index.md
+description: "Complete configuration guide for Snowbridge behavioral event forwarding and transformation workflows."
+
+docs/destinations/forwarding-events/snowbridge/configuration/retries/index.md
+description: "Configure retry policies and error handling for reliable behavioral event forwarding in Snowbridge."
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/kafka.md
+description: "Configure Apache Kafka as a source for behavioral event forwarding using Snowbridge data pipelines."
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/pubsub.md
+description: "Set up Google Cloud Pub/Sub as a source for behavioral event forwarding and transformation workflows."
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/sqs.md
+description: "Configure Amazon SQS as a source for behavioral event forwarding using Snowbridge processing pipelines."
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/index.md
+description: "Configure source systems for reading behavioral events into Snowbridge forwarding and transformation pipelines."
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/kinesis.md
+description: "Set up Amazon Kinesis as a source for behavioral event forwarding using Snowbridge data processing."
+
+docs/destinations/forwarding-events/snowbridge/configuration/telemetry/index.md
+description: "Configure telemetry and metrics collection for monitoring Snowbridge behavioral event forwarding performance."
+
+docs/destinations/forwarding-events/snowbridge/configuration/monitoring/index.md
+description: "Monitor Snowbridge performance and behavioral event forwarding health with comprehensive observability tools."
+
+docs/destinations/forwarding-events/snowbridge/3-X-X-upgrade-guide/index.md
+description: "Upgrade guide for migrating to Snowbridge 3.x with new behavioral event forwarding features and improvements."
+
+docs/destinations/forwarding-events/snowbridge/testing/index.md
+description: "Test Snowbridge configurations and behavioral event forwarding workflows before production deployment."
+
+docs/destinations/forwarding-events/snowbridge/getting-started/index.md
+description: "Quick start guide for setting up Snowbridge to forward behavioral events to external systems and platforms."
+
+docs/destinations/forwarding-events/snowbridge/index.md
+description: "Real-time behavioral event forwarding platform for streaming Snowplow data to external systems and applications."
+
+docs/destinations/forwarding-events/snowbridge/concepts/transformations/index.md
+description: "Core concepts and patterns for transforming behavioral events during Snowbridge forwarding workflows."
+
+docs/destinations/forwarding-events/snowbridge/concepts/batching-model/index.md
+description: "Understand Snowbridge's batching strategies for efficient behavioral event forwarding and processing."
+
+docs/destinations/forwarding-events/snowbridge/concepts/targets/index.md
+description: "Architecture and design patterns for Snowbridge destination targets and behavioral event forwarding."
+
+docs/destinations/forwarding-events/snowbridge/concepts/scaling/index.md
+description: "Scaling strategies and performance optimization for high-volume behavioral event forwarding with Snowbridge."
+
+docs/destinations/forwarding-events/snowbridge/concepts/index.md
+description: "Fundamental concepts and architecture of Snowbridge for behavioral event forwarding and transformation."
+
+docs/destinations/forwarding-events/snowbridge/concepts/sources/index.md
+description: "Source system concepts and integration patterns for behavioral event ingestion into Snowbridge."
+
+docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md
+description: "Error handling and failure recovery strategies for reliable behavioral event forwarding in Snowbridge."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/http-request-tag-for-gtm-ss/index.md
+description: "Configure HTTP request tags in Google Tag Manager Server-Side for behavioral event forwarding workflows."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/http-request-tag-for-gtm-ss/http-request-tag-configuration/index.md
+description: "Detailed configuration options for HTTP request tags in GTM Server-Side behavioral event forwarding."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-tag-for-gtm-ss/snowplow-tag-configuration/advanced-event-settings/index.md
+description: "Advanced configuration options for Snowplow tags in Google Tag Manager Server-Side implementations."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-tag-for-gtm-ss/snowplow-tag-configuration/index.md
+description: "Configure Snowplow tags in Google Tag Manager Server-Side for behavioral event processing and forwarding."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-tag-for-gtm-ss/index.md
+description: "Snowplow tag implementation for Google Tag Manager Server-Side behavioral event processing workflows."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/testing/index.md
+description: "Test and debug Google Tag Manager Server-Side configurations for behavioral event forwarding accuracy."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/index.md
+description: "Snowplow client configuration for Google Tag Manager Server-Side behavioral event processing integration."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
+description: "Detailed configuration guide for Snowplow client in Google Tag Manager Server-Side environments."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/index.md
+description: "Forward behavioral events through Google Tag Manager Server-Side for enhanced privacy and performance."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/braze-tag-for-gtm-ss/braze-tag-configuration/index.md
+description: "Configure Braze tags in Google Tag Manager Server-Side for behavioral event forwarding to customer engagement platforms."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/braze-tag-for-gtm-ss/index.md
+description: "Forward behavioral events to Braze using Google Tag Manager Server-Side for personalized customer experiences."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/amplitude-tag-for-gtm-ss/index.md
+description: "Send behavioral events to Amplitude analytics platform via Google Tag Manager Server-Side forwarding."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/amplitude-tag-for-gtm-ss/amplitude-tag-configuration/index.md
+description: "Configure Amplitude tags in Google Tag Manager Server-Side for behavioral analytics event forwarding."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/iterable-tag-for-gtm-ss/index.md
+description: "Forward behavioral events to Iterable marketing platform using Google Tag Manager Server-Side integration."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/iterable-tag-for-gtm-ss/iterable-tag-configuration/index.md
+description: "Configure Iterable tags in Google Tag Manager Server-Side for behavioral event forwarding to marketing automation."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/index.md
+description: "Send behavioral events to LaunchDarkly feature management platform via Google Tag Manager Server-Side."
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/launchdarkly-tag-configuration/index.md
+description: "Configure LaunchDarkly tags in Google Tag Manager Server-Side for feature flag behavioral event forwarding."
+
+docs/destinations/forwarding-events/index.md
+description: "Forward behavioral events from Snowplow to external platforms and systems for real-time activation and analysis."
+
+docs/destinations/warehouses-lakes/loading-process/index.md
+description: "Understand how behavioral data is loaded and organized in data warehouses and lakes for analytics."
+
+docs/destinations/warehouses-lakes/querying-data/index.md
+description: "Query behavioral data stored in warehouses and lakes using SQL for analytics and business intelligence."
+
+docs/destinations/warehouses-lakes/schemas-in-warehouse/index.md
+description: "Learn how Snowplow schemas translate to table structures in data warehouses and lake environments."
+
+docs/destinations/warehouses-lakes/index.md
+description: "Load behavioral data into warehouses and lakes for long-term storage and large-scale analytics processing."
+
+docs/resources/discourse.md
+description: "Join the Snowplow community forum for technical discussions, best practices, and behavioral analytics insights."
+
+docs/resources/limited-use-license-faq/index.md
+description: "Frequently asked questions about Snowplow's Limited Use License for behavioral data platform components."
+
+docs/resources/copyright-license/index.md
+description: "Copyright and licensing information for Snowplow behavioral data platform software and documentation."
+
+docs/resources/community-license-faq/index.md
+description: "Community Edition license frequently asked questions for open-source Snowplow behavioral data usage."
+
+docs/resources/index.md
+description: "Community resources, licensing information, and support options for Snowplow behavioral data platform users."
+
+docs/resources/personal-and-academic-license-faq/index.md
+description: "Personal and academic use licensing questions for Snowplow behavioral data platform and research applications."
+
+docs/resources/contributor-license-agreement/index.md
+description: "Contributor License Agreement for participating in Snowplow behavioral data platform open-source development."
+
+docs/api-reference/versions/index.md
+description: "Version compatibility matrix and release information for Snowplow behavioral data platform components."
+
+docs/api-reference/enrichment-components/enrich-kinesis/index.md
+description: "Amazon Kinesis enrichment component API reference for real-time behavioral event processing."
+
+docs/api-reference/enrichment-components/enrich-nsq/index.md
+description: "NSQ enrichment component API reference for distributed behavioral event processing workflows."
+
+docs/api-reference/enrichment-components/enrich-pubsub/index.md
+description: "Google Cloud Pub/Sub enrichment component API reference for scalable behavioral data processing."
+
+docs/api-reference/enrichment-components/upgrade-guides/4-0-x-upgrade-guide/index.md
+description: "Upgrade guide for enrichment components version 4.0.x with behavioral data processing improvements."
+
+docs/api-reference/enrichment-components/upgrade-guides/6-0-x-upgrade-guide/index.md
+description: "Upgrade guide for enrichment components version 6.0.x with enhanced behavioral data processing capabilities."
+
+docs/api-reference/enrichment-components/upgrade-guides/index.md
+description: "Version upgrade guides for Snowplow enrichment components and behavioral data processing systems."
+
+docs/api-reference/enrichment-components/index.md
+description: "API reference for Snowplow enrichment components that process and enhance behavioral event data."
+
+docs/api-reference/enrichment-components/enrich-kafka/index.md
+description: "Apache Kafka enrichment component API reference for stream-based behavioral event processing."
+
+docs/api-reference/enrichment-components/monitoring/index.md
+description: "Monitor enrichment component performance and behavioral data processing health with observability tools."
+
+docs/api-reference/enrichment-components/configuration-reference/index.md
+description: "Complete configuration reference for Snowplow enrichment components and behavioral data processing settings."
+
+docs/api-reference/trackers/api-documentation-rust.md
+description: "Rust tracker API documentation for behavioral event tracking in systems programming applications."
+
+docs/api-reference/trackers/api-reference-golang.md
+description: "Go language tracker API reference for server-side behavioral event tracking and data collection."
+
+docs/api-reference/trackers/api-reference-python.md
+description: "Python tracker API reference for behavioral event tracking in web applications and data pipelines."
+
+docs/api-reference/trackers/api-reference-nodejs.md
+description: "Node.js tracker API reference for server-side behavioral event tracking in JavaScript applications."
+
+docs/api-reference/trackers/index.md
+description: "Complete API reference documentation for all Snowplow tracker SDKs and behavioral event collection methods."
+
+docs/api-reference/trackers/api-reference-lua.md
+description: "Lua tracker API reference for behavioral event tracking in embedded systems and game development."
+
+docs/api-reference/trackers/api-reference-ios.md
+description: "iOS tracker API reference for behavioral event tracking in iPhone and iPad mobile applications."
+
+docs/api-reference/trackers/api-reference-ruby.md
+description: "Ruby tracker API reference for behavioral event tracking in Rails applications and Ruby services."
+
+docs/api-reference/trackers/api-reference-java.md
+description: "Java tracker API reference for behavioral event tracking in enterprise applications and Android development."
+
+docs/api-reference/trackers/api-reference-cpp.md
+description: "C++ tracker API reference for behavioral event tracking in high-performance applications and embedded systems."
+
+docs/api-reference/trackers/api-reference-android.md
+description: "Android tracker API reference for behavioral event tracking in mobile applications and games."
+
+docs/api-reference/analytics-sdk/analytics-sdk-javascript/index.md
+description: "JavaScript Analytics SDK for processing and analyzing Snowplow behavioral event data in web applications."
+
+docs/api-reference/analytics-sdk/analytics-sdk-net/snowplow-event-extractor/index.md
+description: ".NET event extractor for parsing and processing Snowplow behavioral event data in Windows applications."
+
+docs/api-reference/analytics-sdk/analytics-sdk-net/index.md
+description: ".NET Analytics SDK API reference for processing behavioral event data in Microsoft ecosystem applications."
+
+docs/api-reference/analytics-sdk/index.md
+description: "Analytics SDK libraries for processing and analyzing Snowplow behavioral event data across multiple programming languages."
+
+docs/api-reference/analytics-sdk/analytics-sdk-go/index.md
+description: "Go Analytics SDK API reference for processing behavioral event data in scalable backend services."
+
+docs/api-reference/analytics-sdk/analytics-sdk-python/index.md
+description: "Python Analytics SDK for processing and analyzing Snowplow behavioral event data in data science workflows."
+
+docs/api-reference/analytics-sdk/analytics-sdk-scala/index.md
+description: "Scala Analytics SDK API reference for processing behavioral event data in big data and streaming applications."
+
+docs/api-reference/failed-events/index.md
+description: "API reference for handling and processing failed behavioral events in Snowplow data quality workflows."
+
+docs/api-reference/console-api.md
+description: "Snowplow BDP Console API reference for programmatic management of behavioral data platform resources."
+
+docs/api-reference/index.md
+description: "Complete API reference documentation for Snowplow behavioral data platform components and services."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/upgrade-guides/1-0-x-upgrade-guide/index.md
+description: "BigQuery Loader upgrade guide for version 1.0.x with enhanced behavioral data loading capabilities."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/upgrade-guides/index.md
+description: "Version upgrade guides for BigQuery Loader with behavioral data loading improvements and features."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/upgrade-guides/2-0-0-upgrade-guide/index.md
+description: "BigQuery Loader upgrade guide for version 2.0.0 with major behavioral data loading enhancements."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/index.md
+description: "Load behavioral event data into Google BigQuery for large-scale analytics and data warehousing."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-5-0/index.md
+description: "BigQuery Loader version 0.5.0 documentation for legacy behavioral data loading implementations."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-1.x/index.md
+description: "BigQuery Loader version 1.x documentation for previous behavioral data loading implementations."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-1.x/configuration-reference/index.md
+description: "Configuration reference for BigQuery Loader version 1.x behavioral data loading settings and parameters."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-6-0/index.md
+description: "BigQuery Loader version 0.6.0 documentation for historical behavioral data loading configurations."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/index.md
+description: "Previous versions of BigQuery Loader for behavioral data loading with historical documentation."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-3-0/index.md
+description: "BigQuery Loader version 0.3.0 documentation for legacy behavioral data loading implementations."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-4-0/index.md
+description: "BigQuery Loader version 0.4.0 documentation for older behavioral data loading configurations."
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/index.md
+description: "Complete configuration reference for BigQuery Loader behavioral data loading settings and optimization."
+
+docs/api-reference/loaders-storage-targets/google-cloud-storage-loader/index.md
+description: "Load behavioral event data into Google Cloud Storage for data lake analytics and long-term archival."
+
+docs/api-reference/loaders-storage-targets/s3-loader/upgrade-guides/1-0-0-configuration/index.md
+description: "S3 Loader version 1.0.0 configuration upgrade guide for behavioral data loading to Amazon S3."
+
+docs/api-reference/loaders-storage-targets/s3-loader/upgrade-guides/2-2-0-upgrade-guide/index.md
+description: "S3 Loader upgrade guide for version 2.2.0 with improved behavioral data loading performance."
+
+docs/api-reference/loaders-storage-targets/s3-loader/upgrade-guides/index.md
+description: "Version upgrade guides for S3 Loader with behavioral data loading improvements and new features."
+
+docs/api-reference/loaders-storage-targets/s3-loader/upgrade-guides/2-0-0-upgrade-guide/index.md
+description: "S3 Loader upgrade guide for version 2.0.0 with major behavioral data loading enhancements."
+
+docs/api-reference/loaders-storage-targets/s3-loader/index.md
+description: "Load behavioral event data into Amazon S3 for data lake analytics and scalable storage solutions."
+
+docs/api-reference/loaders-storage-targets/s3-loader/monitoring/index.md
+description: "Monitor S3 Loader performance and behavioral data loading health with comprehensive observability tools."
+
+docs/api-reference/loaders-storage-targets/s3-loader/configuration-reference/index.md
+description: "Complete configuration reference for S3 Loader behavioral data loading settings and optimization."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/databricks-loader/index.md
+description: "Load transformed behavioral data into Databricks for advanced analytics and machine learning workflows."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/index.md
+description: "Load transformed behavioral data into relational databases for structured analytics and reporting."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/redshift-loader/index.md
+description: "Load behavioral data into Amazon Redshift for high-performance analytics and data warehousing."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/rdb-loader-configuration-reference/rdb-loader-previous-versions/rdb-loader-3-0-x/index.md
+description: "RDB Loader version 3.0.x configuration reference for behavioral data loading into relational databases."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/rdb-loader-configuration-reference/rdb-loader-previous-versions/index.md
+description: "Previous versions of RDB Loader configuration for behavioral data loading into relational databases."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/rdb-loader-configuration-reference/rdb-loader-previous-versions/rdb-loader-4-0-x/index.md
+description: "RDB Loader version 4.0.x configuration reference for enhanced behavioral data loading capabilities."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/rdb-loader-configuration-reference/index.md
+description: "Complete configuration reference for RDB Loader behavioral data loading into relational databases."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/monitoring/index.md
+description: "Monitor RDB Loader performance and behavioral data loading health into relational databases."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/snowflake-loader/index.md
+description: "Load behavioral data into Snowflake data cloud for advanced analytics and data warehousing."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/1-2-0-upgrade-guide/index.md
+description: "RDB Loader upgrade guide for version 1.2.0 with behavioral data loading improvements."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/r33-upgrade-guide/index.md
+description: "RDB Loader R33 upgrade guide with enhanced behavioral data processing and loading capabilities."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/r32-upgrade-guide/index.md
+description: "RDB Loader R32 upgrade guide with behavioral data loading performance improvements."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/6-0-0-upgrade-guide/index.md
+description: "RDB Loader upgrade guide for version 6.0.0 with major behavioral data loading enhancements."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/index.md
+description: "Version upgrade guides for RDB Loader with behavioral data loading improvements and new features."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/2-0-0-upgrade-guide/index.md
+description: "RDB Loader upgrade guide for version 2.0.0 with significant behavioral data loading improvements."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/r35-upgrade-guide/index.md
+description: "RDB Loader R35 upgrade guide with advanced behavioral data processing and loading features."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/1-0-0-upgrade-guide/index.md
+description: "RDB Loader upgrade guide for version 1.0.0 with foundational behavioral data loading capabilities."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/index.md
+description: "Relational Database Loader for transforming and loading behavioral data into structured database formats."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-1-0-0/index.md
+description: "RDB Loader version 1.0.0 documentation for legacy behavioral data loading implementations."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/event-deduplication/index.md
+description: "Event deduplication strategies in RDB Loader for maintaining behavioral data quality and accuracy."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/shredding-overview/index.md
+description: "Overview of data shredding process in RDB Loader for behavioral event transformation and loading."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/rdb-shredder-configuration-reference/index.md
+description: "Configuration reference for RDB Shredder component in behavioral data transformation workflows."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/dynamodb-table/index.md
+description: "DynamoDB table configuration for RDB Loader behavioral data processing and state management."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/run-the-rdb-loader/index.md
+description: "Execute RDB Loader for behavioral data transformation and loading into relational databases."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/index.md
+description: "Previous version of Snowplow RDB Loader for behavioral data transformation and relational database loading."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/run-the-rdb-shredder/index.md
+description: "Execute RDB Shredder for behavioral event data transformation and preparation for database loading."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/monitoring/index.md
+description: "Monitor RDB Loader components for behavioral data processing performance and health tracking."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/configuration-reference/index.md
+description: "Configuration reference for legacy RDB Loader behavioral data processing and loading settings."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/index.md
+description: "Previous versions of RDB Loader for behavioral data transformation and relational database loading."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-1-1-0/index.md
+description: "RDB Loader version 1.1.0 documentation for historical behavioral data loading implementations."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-r35-earlier/load-event-and-entity-types-that-you-have-defined/index.md
+description: "Load custom event and entity types using RDB Loader R35 and earlier versions for behavioral data."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-r35-earlier/index.md
+description: "RDB Loader R35 and earlier versions for behavioral data transformation and relational database loading."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/deduplication/index.md
+description: "Deduplicate enriched behavioral events during RDB transformation to ensure data quality and accuracy."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/index.md
+description: "Transform enriched behavioral data for loading into relational databases with RDB Loader components."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/spark-transformer/index.md
+description: "Transform behavioral data using Apache Spark for scalable RDB Loader processing workflows."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/spark-transformer/configuration-reference/index.md
+description: "Configuration reference for Spark Transformer in RDB Loader behavioral data processing pipelines."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kinesis/index.md
+description: "Transform behavioral data using Amazon Kinesis streams in RDB Loader processing workflows."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kinesis/configuration-reference/index.md
+description: "Configuration reference for Kinesis Transformer in RDB Loader behavioral data processing pipelines."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-pubsub/index.md
+description: "Transform behavioral data using Google Pub/Sub streams in RDB Loader processing workflows."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-pubsub/configuration-reference/index.md
+description: "Configuration reference for Pub/Sub Transformer in RDB Loader behavioral data processing pipelines."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/index.md
+description: "Stream-based transformation of behavioral data for RDB Loader relational database loading workflows."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kafka/index.md
+description: "Transform behavioral data using Apache Kafka streams in RDB Loader processing workflows."
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kafka/configuration-reference/index.md
+description: "Configuration reference for Kafka Transformer in RDB Loader behavioral data processing pipelines."
+
+docs/api-reference/loaders-storage-targets/index.md
+description: "API reference for loaders and storage targets that deliver behavioral data to warehouses and databases."
+
+docs/api-reference/loaders-storage-targets/lake-loader/partitions/index.md
+description: "Configure data partitioning strategies in Lake Loader for optimal behavioral data organization and querying."
+
+docs/api-reference/loaders-storage-targets/lake-loader/index.md
+description: "Load behavioral event data into data lakes for flexible analytics and large-scale data processing."
+
+docs/api-reference/loaders-storage-targets/lake-loader/maintenance/index.md
+description: "Maintain and optimize Lake Loader performance for continuous behavioral data loading into data lakes."
+
+docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/index.md
+description: "Complete configuration reference for Lake Loader behavioral data loading settings and optimization."
+
+docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/index.md
+description: "Stream behavioral event data directly into Snowflake for real-time analytics and data warehousing."
+
+docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/migrating.md
+description: "Migration guide for upgrading to Snowflake Streaming Loader for enhanced behavioral data loading."
+
+docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/index.md
+description: "Configuration reference for Snowflake Streaming Loader behavioral data loading settings and optimization."
+
+docs/api-reference/loaders-storage-targets/snowplow-postgres-loader/postgres-loader-configuration-reference/index.md
+description: "Configuration reference for PostgreSQL Loader behavioral data loading settings and optimization."
+
+docs/api-reference/loaders-storage-targets/snowplow-postgres-loader/index.md
+description: "Load behavioral event data into PostgreSQL databases for relational analytics and reporting."
+
+docs/api-reference/snowplow-mini/setup-guide-for-gcp/index.md
+description: "Set up Snowplow Mini on Google Cloud Platform for lightweight behavioral data pipeline testing."
+
+docs/api-reference/snowplow-mini/control-plane-api/index.md
+description: "Control plane API reference for managing Snowplow Mini behavioral data pipeline configurations."
+
+docs/api-reference/snowplow-mini/setup-guide-for-aws/index.md
+description: "Deploy Snowplow Mini on Amazon Web Services for behavioral data pipeline development and testing."
+
+docs/api-reference/snowplow-mini/index.md
+description: "Lightweight Snowplow pipeline for development, testing, and proof-of-concept behavioral data implementations."
+
+docs/api-reference/snowplow-mini/usage-guide/index.md
+description: "Usage guide for Snowplow Mini behavioral data pipeline testing and development workflows."
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/setup-guide-for-gcp/index.md
+description: "Setup guide for Snowplow Mini version 0.14 on Google Cloud Platform for behavioral data testing."
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/control-plane-api/index.md
+description: "Control plane API reference for Snowplow Mini version 0.14 behavioral data pipeline management."
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/setup-guide-for-aws/index.md
+description: "Setup guide for Snowplow Mini version 0.14 on Amazon Web Services for behavioral data testing."
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/index.md
+description: "Snowplow Mini version 0.14 documentation for legacy behavioral data pipeline testing implementations."
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/usage-guide/index.md
+description: "Usage guide for Snowplow Mini version 0.14 behavioral data pipeline development and testing."
+
+docs/api-reference/snowplow-mini/previous-releases/index.md
+description: "Previous releases of Snowplow Mini for behavioral data pipeline development and testing."
+
+docs/api-reference/snowplow-micro/index.md
+description: "Snowplow Micro API reference for lightweight behavioral event validation and testing workflows."
+
+docs/api-reference/snowplow-micro/api/index.md
+description: "REST API reference for Snowplow Micro behavioral event testing and validation endpoints."
+
+docs/api-reference/stream-collector/configure/index.md
+description: "Configure Snowplow Stream Collector for optimal behavioral event collection and pipeline performance."
+
+docs/api-reference/stream-collector/setup/index.md
+description: "Set up Snowplow Stream Collector to receive and process behavioral events from trackers and webhooks."
+
+docs/api-reference/stream-collector/3-0-x-upgrade-guide/index.md
+description: "Stream Collector upgrade guide for version 3.0.x with enhanced behavioral event collection capabilities."
+
+docs/api-reference/stream-collector/index.md
+description: "Snowplow Stream Collector API reference for behavioral event collection and real-time data ingestion."
+
+docs/api-reference/iglu/iglu-repositories/iglu-server/setup/index.md
+description: "Set up Iglu Server for centralized schema registry management in behavioral data infrastructure."
+
+docs/api-reference/iglu/iglu-repositories/iglu-server/index.md
+description: "Iglu Server API reference for schema registry management and behavioral data structure governance."
+
+docs/api-reference/iglu/iglu-repositories/iglu-server/reference/index.md
+description: "Complete API reference for Iglu Server schema registry endpoints and behavioral data structure management."
+
+docs/api-reference/iglu/iglu-repositories/static-repo/index.md
+description: "Static Iglu repository configuration for behavioral data schema hosting and version control."
+
+docs/api-reference/iglu/iglu-repositories/index.md
+description: "Iglu repository types and configurations for behavioral data schema storage and management."
+
+docs/api-reference/iglu/iglu-repositories/jvm-embedded-repo/index.md
+description: "JVM embedded Iglu repository for behavioral data schema resolution in Java applications."
+
+docs/api-reference/iglu/iglu-repositories/iglu-central/index.md
+description: "Iglu Central repository for community-maintained behavioral data schemas and structures."
+
+docs/api-reference/iglu/iglu-resolver/index.md
+description: "Iglu Resolver API reference for behavioral data schema resolution and validation workflows."
+
+docs/api-reference/iglu/iglu-clients/scala-client-setup/index.md
+description: "Set up Iglu Scala client for behavioral data schema resolution in Scala applications."
+
+docs/api-reference/iglu/iglu-clients/ruby-client/index.md
+description: "Iglu Ruby client API reference for behavioral data schema resolution in Ruby applications."
+
+docs/api-reference/iglu/iglu-clients/index.md
+description: "Iglu client libraries for behavioral data schema resolution across multiple programming languages."
+
+docs/api-reference/iglu/iglu-clients/objc-client/index.md
+description: "Iglu Objective-C client API reference for behavioral data schema resolution in iOS applications."
+
+docs/api-reference/iglu/igluctl-2/index.md
+description: "Igluctl command-line tool for managing behavioral data schemas and Iglu repository operations."
+
+docs/api-reference/iglu/common-architecture/schemaver/index.md
+description: "SchemaVer versioning scheme for behavioral data schema evolution and compatibility management."
+
+docs/api-reference/iglu/common-architecture/index.md
+description: "Iglu common architecture components for behavioral data schema registry and validation systems."
+
+docs/api-reference/iglu/common-architecture/self-describing-json-schemas/index.md
+description: "Self-describing JSON Schema format for behavioral data structure definition and validation."
+
+docs/api-reference/iglu/common-architecture/schema-resolution/index.md
+description: "Schema resolution mechanisms in Iglu for behavioral data validation and processing workflows."
+
+docs/api-reference/iglu/common-architecture/self-describing-jsons/index.md
+description: "Self-describing JSON format for behavioral events and entities with embedded schema references."
+
+docs/api-reference/iglu/common-architecture/iglu-core/index.md
+description: "Iglu Core libraries for behavioral data schema validation and self-describing JSON processing."
+
+docs/api-reference/iglu/index.md
+description: "Iglu schema registry system for behavioral data structure management and validation workflows."
+
+docs/api-reference/iglu/iglu-central-setup/index.md
+description: "Set up connection to Iglu Central for community behavioral data schemas and structures."
+
+docs/api-reference/elasticsearch/index.md
+description: "Load behavioral event data into Elasticsearch for real-time search and analytics capabilities."
+
+docs/api-reference/dataflow-runner/index.md
+description: "Dataflow Runner for executing behavioral data processing jobs on cloud platforms and clusters."
+
+docs/introduction.md
+description: "Welcome to Snowplow, the leader in customer data infrastructure for AI-powered behavioral analytics and personalization."
+
+docs/sources/trackers/rust-tracker/initialization-and-configuration/index.md
+description: "Initialize and configure the Rust tracker for behavioral event collection in systems programming applications."
+
+docs/sources/trackers/rust-tracker/adding-data/index.md
+description: "Add custom data and context to behavioral events using the Snowplow Rust tracker SDK."
+
+docs/sources/trackers/rust-tracker/tracking-events/index.md
+description: "Track behavioral events in Rust applications using Snowplow's systems programming tracker SDK."
+
+docs/sources/trackers/rust-tracker/getting-started/index.md
+description: "Quick start guide for implementing behavioral event tracking with Snowplow's Rust tracker in systems applications."
+
+docs/sources/trackers/rust-tracker/index.md
+description: "Snowplow Rust tracker for behavioral event collection in high-performance systems programming applications."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/anonymous-tracking/index.md
+description: "Implement anonymous user tracking in React Native v2 tracker for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/custom-tracking-using-schemas/index.md
+description: "Create custom behavioral events with schemas in React Native v2 tracker for flexible event tracking."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/introduction/index.md
+description: "Introduction to React Native v2 tracker for behavioral event collection in mobile applications."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/platform-and-application-context/index.md
+description: "Add platform and application context to behavioral events in React Native v2 tracker implementations."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/exception-tracking/index.md
+description: "Track application exceptions and errors in React Native v2 tracker for behavioral analytics."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/lifecycle-tracking/index.md
+description: "Track application lifecycle events in React Native v2 tracker for user engagement analysis."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/installation-tracking/index.md
+description: "Track app installation events in React Native v2 tracker for user acquisition analytics."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/index.md
+description: "Track behavioral events in React Native v2 applications for mobile analytics and user insights."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/screen-tracking/index.md
+description: "Track screen views and navigation in React Native v2 tracker for mobile user journey analysis."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/session-tracking/index.md
+description: "Track user sessions in React Native v2 tracker for mobile engagement and retention analysis."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/expo/index.md
+description: "Integrate Snowplow React Native v2 tracker with Expo for managed mobile app behavioral analytics."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/client-side-properties/index.md
+description: "Configure client-side properties in React Native v2 tracker for enhanced behavioral event context."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/advanced-usage/index.md
+description: "Advanced configuration and usage patterns for React Native v2 tracker behavioral event collection."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/hybrid-apps/index.md
+description: "Implement React Native v2 tracker in hybrid mobile applications for unified behavioral analytics."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/index.md
+description: "Complete reference documentation for React Native v2 tracker behavioral event collection."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/quick-start-guide/index.md
+description: "Quick start guide for React Native v2 tracker implementation in mobile applications."
+
+docs/sources/trackers/react-native-tracker/previous-version/index.md
+description: "Previous versions of React Native tracker for behavioral event collection in mobile applications."
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v0-reference/index.md
+description: "React Native v0 tracker reference documentation for legacy behavioral event collection implementations."
+
+docs/sources/trackers/react-native-tracker/anonymous-tracking/index.md
+description: "Implement anonymous user tracking in React Native applications for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/react-native-tracker/migration-guides/migrating-from-v1-x-to-v2/index.md
+description: "Migration guide for upgrading React Native tracker from version 1.x to 2 with behavioral tracking improvements."
+
+docs/sources/trackers/react-native-tracker/migration-guides/migrating-from-v2-x-to-v4/index.md
+description: "Migration guide for upgrading React Native tracker from version 2.x to 4 with enhanced features."
+
+docs/sources/trackers/react-native-tracker/migration-guides/index.md
+description: "Version migration guides for React Native tracker with behavioral event tracking improvements."
+
+docs/sources/trackers/react-native-tracker/migration-guides/migrating-from-v0-x-to-v1/index.md
+description: "Migration guide for upgrading React Native tracker from version 0.x to 1 with foundational improvements."
+
+docs/sources/trackers/react-native-tracker/custom-tracking-using-schemas/index.md
+description: "Create custom behavioral events with schemas in React Native tracker for flexible event tracking."
+
+docs/sources/trackers/react-native-tracker/custom-tracking-using-schemas/global-context/index.md
+description: "Configure global context entities in React Native tracker for consistent behavioral event enrichment."
+
+docs/sources/trackers/react-native-tracker/tracking-events/platform-and-application-context/index.md
+description: "Add platform and application context to behavioral events in React Native tracker implementations."
+
+docs/sources/trackers/react-native-tracker/tracking-events/lifecycle-tracking/index.md
+description: "Track application lifecycle events in React Native tracker for user engagement analysis."
+
+docs/sources/trackers/react-native-tracker/tracking-events/installation-tracking/index.md
+description: "Track app installation events in React Native tracker for user acquisition analytics."
+
+docs/sources/trackers/react-native-tracker/tracking-events/index.md
+description: "Track behavioral events in React Native applications for mobile analytics and user insights."
+
+docs/sources/trackers/react-native-tracker/tracking-events/screen-tracking/index.md
+description: "Track screen views and navigation in React Native tracker for mobile user journey analysis."
+
+docs/sources/trackers/react-native-tracker/tracking-events/session-tracking/index.md
+description: "Track user sessions in React Native tracker for mobile engagement and retention analysis."
+
+docs/sources/trackers/react-native-tracker/client-side-properties/index.md
+description: "Configure client-side properties in React Native tracker for enhanced behavioral event context."
+
+docs/sources/trackers/react-native-tracker/advanced-usage/index.md
+description: "Advanced configuration and usage patterns for React Native tracker behavioral event collection."
+
+docs/sources/trackers/react-native-tracker/hybrid-apps/index.md
+description: "Implement React Native tracker in hybrid mobile applications for unified behavioral analytics."
+
+docs/sources/trackers/react-native-tracker/index.md
+description: "React Native tracker for cross-platform mobile behavioral event collection and analytics."
+
+docs/sources/trackers/react-native-tracker/quick-start-guide/index.md
+description: "Quick start guide for React Native tracker implementation in mobile applications."
+
+docs/sources/trackers/golang-tracker/setup/index.md
+description: "Set up the Go tracker for server-side behavioral event collection in Go applications and services."
+
+docs/sources/trackers/golang-tracker/initialization/index.md
+description: "Initialize the Go tracker for behavioral event tracking in server-side Go applications."
+
+docs/sources/trackers/golang-tracker/index.md
+description: "Go tracker for server-side behavioral event collection in scalable backend applications and services."
+
+docs/sources/trackers/golang-tracker/tracking-specific-events/index.md
+description: "Track specific behavioral events using the Go tracker for targeted server-side analytics."
+
+docs/sources/trackers/golang-tracker/emitters/index.md
+description: "Configure event emitters in Go tracker for reliable behavioral data transmission to collectors."
+
+docs/sources/trackers/golang-tracker/adding-extra-data-the-subject-class/index.md
+description: "Add user and session context data to behavioral events using Go tracker subject class."
+
+docs/sources/trackers/ruby-tracker/configuring-how-events-are-sent/index.md
+description: "Configure event transmission settings in Ruby tracker for optimal behavioral data delivery."
+
+docs/sources/trackers/ruby-tracker/adding-data-events/index.md
+description: "Add custom data and context to behavioral events using the Snowplow Ruby tracker."
+
+docs/sources/trackers/ruby-tracker/tracking-events/index.md
+description: "Track behavioral events in Ruby applications using Snowplow's Ruby tracker SDK."
+
+docs/sources/trackers/ruby-tracker/example-rails-app.md
+description: "Example Rails application demonstrating behavioral event tracking implementation with Ruby tracker."
+
+docs/sources/trackers/ruby-tracker/getting-started/index.md
+description: "Quick start guide for implementing behavioral event tracking with Snowplow's Ruby tracker."
+
+docs/sources/trackers/ruby-tracker/index.md
+description: "Ruby tracker for server-side behavioral event collection in Ruby on Rails applications and services."
+
+docs/sources/trackers/google-tag-manager/snowplow-template/plugins/index.md
+description: "Configure plugins for Snowplow Google Tag Manager template to enhance behavioral event tracking."
+
+docs/sources/trackers/google-tag-manager/snowplow-template/index.md
+description: "Snowplow template for Google Tag Manager to implement behavioral event tracking without custom code."
+
+docs/sources/trackers/google-tag-manager/settings-template/index.md
+description: "Settings template for configuring Snowplow tracker parameters in Google Tag Manager implementations."
+
+docs/sources/trackers/google-tag-manager/ecommerce-tag-template/configuration/index.md
+description: "Configure ecommerce tracking template in Google Tag Manager for behavioral commerce analytics."
+
+docs/sources/trackers/google-tag-manager/ecommerce-tag-template/index.md
+description: "Ecommerce tag template for Google Tag Manager to track purchase behavior and commerce events."
+
+docs/sources/trackers/google-tag-manager/index.md
+description: "Implement Snowplow behavioral event tracking through Google Tag Manager with pre-built templates."
+
+docs/sources/trackers/google-tag-manager/snowtype/index.md
+description: "Type-safe behavioral event tracking in Google Tag Manager using Snowtype code generation."
+
+docs/sources/trackers/google-tag-manager/previous-versions/index.md
+description: "Previous versions of Google Tag Manager templates for behavioral event tracking implementations."
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-settings-variable/index.md
+description: "Version 3 settings variable configuration for Google Tag Manager behavioral event tracking."
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/index.md
+description: "Version 3 Google Tag Manager templates for behavioral event tracking with legacy implementations."
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/tag-template-guide/index.md
+description: "Version 3 tag template guide for Google Tag Manager behavioral event tracking implementation."
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/tag-template-guide/plugins.md
+description: "Plugin configuration guide for version 3 Google Tag Manager behavioral event tracking templates."
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/ecommerce-tag-template/ecommerce-tag-configuration/index.md
+description: "Version 3 ecommerce tag configuration for Google Tag Manager behavioral commerce tracking."
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/ecommerce-tag-template/index.md
+description: "Version 3 ecommerce tag template for Google Tag Manager behavioral commerce analytics."
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/index.md
+description: "Version 3 tag templates for Google Tag Manager behavioral event tracking implementations."
+
+docs/sources/trackers/google-tag-manager/previous-versions/template-for-javascript-tracker-v2/index.md
+description: "JavaScript tracker v2 template for Google Tag Manager behavioral event collection."
+
+docs/sources/trackers/google-tag-manager/quick-start/index.md
+description: "Quick start guide for implementing Snowplow behavioral tracking through Google Tag Manager."
+
+docs/sources/trackers/node-js-tracker/configuration/index.md
+description: "Configure Node.js tracker settings for optimal server-side behavioral event collection."
+
+docs/sources/trackers/node-js-tracker/migration-guides/index.md
+description: "Version migration guides for Node.js tracker with behavioral event tracking improvements."
+
+docs/sources/trackers/node-js-tracker/migration-guides/v3-to-v4-migration-guide/index.md
+description: "Migration guide for upgrading Node.js tracker from version 3 to 4 with enhanced features."
+
+docs/sources/trackers/node-js-tracker/tracking-events/index.md
+description: "Track behavioral events in Node.js applications using Snowplow's server-side JavaScript tracker."
+
+docs/sources/trackers/node-js-tracker/initialization/index.md
+description: "Initialize Node.js tracker for server-side behavioral event collection in JavaScript applications."
+
+docs/sources/trackers/node-js-tracker/index.md
+description: "Node.js tracker for server-side behavioral event collection in JavaScript backend applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/configuration/index.md
+description: "Configuration guide for Node.js tracker version 0.3.0 behavioral event collection settings."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/setup/index.md
+description: "Setup guide for Node.js tracker version 0.3.0 in server-side JavaScript applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/initialization/index.md
+description: "Initialize Node.js tracker version 0.3.0 for behavioral event tracking in JavaScript servers."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/index.md
+description: "Node.js tracker version 0.3.0 documentation for legacy behavioral event collection implementations."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/configuration-2/index.md
+description: "Additional configuration options for Node.js tracker version 0.3.0 behavioral event settings."
+
+docs/sources/trackers/node-js-tracker/previous-versions/javascript-tracker-core/index.md
+description: "JavaScript tracker core library for shared behavioral event tracking functionality."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/configuration/index.md
+description: "Configuration guide for Node.js tracker version 0.4.0 behavioral event collection settings."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/setup/index.md
+description: "Setup guide for Node.js tracker version 0.4.0 in server-side JavaScript applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/tracking-events/index.md
+description: "Track behavioral events using Node.js tracker version 0.4.0 in server-side applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/initialization/index.md
+description: "Initialize Node.js tracker version 0.4.0 for behavioral event tracking in JavaScript servers."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/index.md
+description: "Node.js tracker version 0.4.0 documentation for behavioral event collection in JavaScript applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/index.md
+description: "Previous versions of Node.js tracker for server-side behavioral event collection."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/configuration/index.md
+description: "Configuration guide for Node.js tracker version 3 behavioral event collection settings."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/setup/index.md
+description: "Setup guide for Node.js tracker version 3 in server-side JavaScript applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/tracking-events/index.md
+description: "Track behavioral events using Node.js tracker version 3 in server-side applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/initialization/index.md
+description: "Initialize Node.js tracker version 3 for behavioral event tracking in JavaScript servers."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/index.md
+description: "Node.js tracker version 3 documentation for behavioral event collection in JavaScript applications."
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/api-reference.md
+description: "API reference documentation for Node.js tracker version 3 behavioral event methods."
+
+docs/sources/trackers/net-tracker/platform-specific-functions/index.md
+description: "Platform-specific functions in .NET tracker for Windows-optimized behavioral event collection."
+
+docs/sources/trackers/net-tracker/emitter/index.md
+description: "Configure event emitters in .NET tracker for reliable behavioral data transmission."
+
+docs/sources/trackers/net-tracker/subject/index.md
+description: "Configure user and session subjects in .NET tracker for behavioral event context."
+
+docs/sources/trackers/net-tracker/setup/index.md
+description: "Set up the .NET tracker for behavioral event collection in Windows and .NET applications."
+
+docs/sources/trackers/net-tracker/tracker/index.md
+description: "Initialize and configure the .NET tracker for behavioral event collection in Microsoft applications."
+
+docs/sources/trackers/net-tracker/initialization/index.md
+description: "Initialize .NET tracker for behavioral event tracking in Windows and .NET Framework applications."
+
+docs/sources/trackers/net-tracker/index.md
+description: ".NET tracker for behavioral event collection in Windows applications and Microsoft ecosystem services."
+
+docs/sources/trackers/net-tracker/event-tracking/index.md
+description: "Track behavioral events in .NET applications using Snowplow's Windows-focused tracker SDK."
+
+docs/sources/trackers/net-tracker/session/index.md
+description: "Manage user sessions in .NET tracker for behavioral analytics and engagement tracking."
+
+docs/sources/trackers/java-tracker/configuring-how-events-are-sent/index.md
+description: "Configure event transmission settings in Java tracker for optimal behavioral data delivery."
+
+docs/sources/trackers/java-tracker/migration-guides/migration-guide-v0-12/index.md
+description: "Migration guide for upgrading Java tracker from version 0.12 with behavioral tracking improvements."
+
+docs/sources/trackers/java-tracker/migration-guides/index.md
+description: "Version migration guides for Java tracker with behavioral event tracking improvements and features."
+
+docs/sources/trackers/java-tracker/migration-guides/migration-guide-v1/index.md
+description: "Migration guide for upgrading Java tracker to version 1 with enhanced behavioral event capabilities."
+
+docs/sources/trackers/java-tracker/custom-tracking-using-schemas/index.md
+description: "Create custom behavioral events with schemas in Java tracker for flexible enterprise tracking."
+
+docs/sources/trackers/java-tracker/tracking-events/index.md
+description: "Track behavioral events in Java applications using Snowplow's enterprise-focused tracker SDK."
+
+docs/sources/trackers/java-tracker/index.md
+description: "Java tracker for behavioral event collection in enterprise applications and Android mobile development."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/configuring-how-events-are-sent/index.md
+description: "Configure event transmission in Java tracker version 0.12 for behavioral data delivery."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/custom-tracking-using-schemas/index.md
+description: "Create custom behavioral events with schemas in Java tracker version 0.12."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/tracking-events/index.md
+description: "Track behavioral events using Java tracker version 0.12 in enterprise applications."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/index.md
+description: "Java tracker version 0.12 documentation for behavioral event collection in enterprise applications."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/tracking-specific-client-side-properties/index.md
+description: "Track client-side properties using Java tracker version 0.12 for enhanced behavioral context."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/what-do-java-tracker-events-look-like/index.md
+description: "Example behavioral event structures generated by Java tracker version 0.12."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/installation-and-set-up/index.md
+description: "Installation and setup guide for Java tracker version 0.12 in enterprise applications."
+
+docs/sources/trackers/java-tracker/previous-versions/index.md
+description: "Previous versions of Java tracker for behavioral event collection in enterprise applications."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/emitter/index.md
+description: "Configure event emitters in Java tracker version 0.11 for behavioral data transmission."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/setup/index.md
+description: "Set up Java tracker version 0.11 for behavioral event collection in enterprise applications."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/initialization/index.md
+description: "Initialize Java tracker version 0.11 for behavioral event tracking in enterprise systems."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/payload-and-logging/index.md
+description: "Configure payload structure and logging in Java tracker version 0.11 for behavioral events."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/index.md
+description: "Java tracker version 0.11 documentation for behavioral event collection in enterprise applications."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/tracking-specific-events/index.md
+description: "Track specific behavioral events using Java tracker version 0.11 in enterprise applications."
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/adding-extra-data-the-subject-class/index.md
+description: "Add user and session context using Java tracker version 0.11 subject class."
+
+docs/sources/trackers/java-tracker/tracking-specific-client-side-properties/index.md
+description: "Track client-side properties using Java tracker for enhanced behavioral event context."
+
+docs/sources/trackers/java-tracker/what-do-java-tracker-events-look-like/index.md
+description: "Example behavioral event structures and formats generated by Java tracker SDK."
+
+docs/sources/trackers/java-tracker/using-multiple-trackers/index.md
+description: "Configure and manage multiple Java tracker instances for complex behavioral analytics scenarios."
+
+docs/sources/trackers/java-tracker/demos/index.md
+description: "Demo applications and examples showcasing Java tracker behavioral event collection capabilities."
+
+docs/sources/trackers/java-tracker/installation-and-set-up/index.md
+description: "Installation and setup guide for Java tracker in enterprise applications and Android development."
+
+docs/sources/trackers/lua-tracker/index.md
+description: "Lua tracker for behavioral event collection in embedded systems and game development environments."
+
+docs/sources/trackers/lua-tracker/tracking-specific-events/index.md
+description: "Track specific behavioral events using Lua tracker in embedded systems and gaming applications."
+
+docs/sources/trackers/c-tracker/setup/index.md
+description: "Set up the C tracker for behavioral event collection in embedded systems and native applications."
+
+docs/sources/trackers/c-tracker/client-sessions/index.md
+description: "Manage client sessions in C tracker for behavioral analytics in native applications."
+
+docs/sources/trackers/c-tracker/index.md
+description: "C tracker for behavioral event collection in embedded systems and high-performance native applications."
+
+docs/sources/trackers/c-tracker/upgrading-to-newer-versions/index.md
+description: "Upgrade guide for C tracker with behavioral event tracking improvements and new features."
+
+docs/sources/trackers/c-tracker/tracking-specific-events/index.md
+description: "Track specific behavioral events using C tracker in embedded systems and native applications."
+
+docs/sources/trackers/c-tracker/emitters/index.md
+description: "Configure event emitters in C tracker for reliable behavioral data transmission from native apps."
+
+docs/sources/trackers/c-tracker/initialisation/index.md
+description: "Initialize C tracker for behavioral event tracking in embedded systems and native applications."
+
+docs/sources/trackers/c-tracker/adding-extra-data-the-subject-class/index.md
+description: "Add user and session context using C tracker subject class for behavioral event enrichment."
+
+docs/sources/trackers/tracker-maintenance-classification/index.md
+description: "Maintenance classification and support status for different Snowplow tracker SDKs and implementations."
+
+docs/sources/trackers/google-analytics-plugin/index.md
+description: "Google Analytics plugin for Snowplow to enable behavioral event collection from existing GA implementations."
+
+docs/sources/trackers/index.md
+description: "Complete guide to Snowplow tracker SDKs for behavioral event collection across web, mobile, and server platforms."
+
+docs/sources/trackers/web-trackers/anonymous-tracking/index.md
+description: "Implement anonymous user tracking in web applications for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/web-trackers/migration-guides/v2-to-v3-migration-guide/index.md
+description: "Migration guide for upgrading web trackers from version 2 to 3 with enhanced behavioral tracking features."
+
+docs/sources/trackers/web-trackers/migration-guides/index.md
+description: "Version migration guides for web trackers with behavioral event tracking improvements and new capabilities."
+
+docs/sources/trackers/web-trackers/migration-guides/v3-to-v4-migration-guide/index.md
+description: "Migration guide for upgrading web trackers from version 3 to 4 with advanced behavioral features."
+
+docs/sources/trackers/web-trackers/plugins/creating-your-own-plugins/index.md
+description: "Create custom plugins for web trackers to extend behavioral event collection with specialized functionality."
+
+docs/sources/trackers/web-trackers/plugins/index.md
+description: "Web tracker plugins for enhanced behavioral event collection including ecommerce, media, and form tracking."
+
+docs/sources/trackers/web-trackers/plugins/configuring-tracker-plugins/browser/index.md
+description: "Configure browser-specific plugins for web trackers to optimize behavioral event collection."
+
+docs/sources/trackers/web-trackers/plugins/configuring-tracker-plugins/index.md
+description: "Configure and manage plugins in web trackers for enhanced behavioral event tracking capabilities."
+
+docs/sources/trackers/web-trackers/plugins/configuring-tracker-plugins/javascript/index.md
+description: "Configure JavaScript plugins for web trackers to extend behavioral event collection functionality."
+
+docs/sources/trackers/web-trackers/configuring-how-events-sent/index.md
+description: "Configure event transmission settings in web trackers for optimal behavioral data delivery."
+
+docs/sources/trackers/web-trackers/custom-tracking-using-schemas/index.md
+description: "Create custom behavioral events with schemas in web trackers for flexible website analytics."
+
+docs/sources/trackers/web-trackers/custom-tracking-using-schemas/global-context/index.md
+description: "Configure global context entities in web trackers for consistent behavioral event enrichment."
+
+docs/sources/trackers/web-trackers/tracking-events/timezone-geolocation/index.md
+description: "Track timezone and geolocation data in web applications for behavioral analytics with geographic context."
+
+docs/sources/trackers/web-trackers/tracking-events/ads/index.md
+description: "Track advertising interactions and impressions using web trackers for behavioral ad analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/site-search/index.md
+description: "Track internal site search behavior using web trackers for content discovery analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/social-media/index.md
+description: "Track social media interactions and sharing behavior using web trackers for engagement analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/web-vitals/index.md
+description: "Track Core Web Vitals and performance metrics using web trackers for behavioral performance analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/privacy-sandbox/index.md
+description: "Track Privacy Sandbox APIs and features using web trackers for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/timings/index.md
+description: "Track custom timing events and performance metrics using web trackers for behavioral analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/timings/generic/index.md
+description: "Track generic timing events and user interactions using web trackers for performance analysis."
+
+docs/sources/trackers/web-trackers/tracking-events/campaigns-utms/index.md
+description: "Track UTM campaign parameters and marketing attribution using web trackers for campaign analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/ecommerce/index.md
+description: "Track ecommerce transactions and shopping behavior using web trackers for retail analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/ecommerce/enhanced/index.md
+description: "Track enhanced ecommerce events with detailed product and purchase data using web trackers."
+
+docs/sources/trackers/web-trackers/tracking-events/element-tracking/index.md
+description: "Track HTML element interactions and clicks using web trackers for detailed behavioral analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/client-hints/index.md
+description: "Track Client Hints data for device and browser information using web trackers for behavioral context."
+
+docs/sources/trackers/web-trackers/tracking-events/screen-views/index.md
+description: "Track screen views and viewport changes using web trackers for behavioral analytics in single-page apps."
+
+docs/sources/trackers/web-trackers/tracking-events/form-tracking/index.md
+description: "Track form interactions and submissions using web trackers for conversion and usability analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/optimizely/index.md
+description: "Track Optimizely A/B test interactions using web trackers for experimentation and behavioral analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/event-specifications/index.md
+description: "Implement event specifications and tracking plans using web trackers for consistent behavioral data."
+
+docs/sources/trackers/web-trackers/tracking-events/webview/index.md
+description: "Track behavioral events in WebView components using web trackers for hybrid app analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/page-views/index.md
+description: "Track page view events and navigation behavior using web trackers for website analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/link-click/index.md
+description: "Track link clicks and outbound navigation using web trackers for behavioral navigation analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/ga-cookies/index.md
+description: "Track Google Analytics cookie data using web trackers for behavioral analytics migration."
+
+docs/sources/trackers/web-trackers/tracking-events/activity-page-pings/index.md
+description: "Track user activity and page engagement using web trackers for behavioral analytics and attention metrics."
+
+docs/sources/trackers/web-trackers/tracking-events/consent-gdpr/index.md
+description: "Track user consent and GDPR compliance using web trackers for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/index.md
+description: "Track behavioral events in web applications using JavaScript tracker for comprehensive website analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/focalmeter/index.md
+description: "Track attention and focus metrics using Focalmeter integration with web trackers for behavioral analysis."
+
+docs/sources/trackers/web-trackers/tracking-events/errors/index.md
+description: "Track JavaScript errors and exceptions using web trackers for behavioral analytics and debugging."
+
+docs/sources/trackers/web-trackers/tracking-events/button-click/index.md
+description: "Track button clicks and user interface interactions using web trackers for behavioral UX analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/media/html5/index.md
+description: "Track HTML5 media player interactions using web trackers for behavioral video and audio analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/media/vimeo/index.md
+description: "Track Vimeo video player interactions using web trackers for behavioral video engagement analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/media/youtube/index.md
+description: "Track YouTube video player interactions using web trackers for behavioral video analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/media/snowplow/index.md
+description: "Track Snowplow media player interactions using web trackers for comprehensive behavioral video analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/media/index.md
+description: "Track media player interactions and video engagement using web trackers for behavioral media analytics."
+
+docs/sources/trackers/web-trackers/tracking-events/session/index.md
+description: "Track user sessions and engagement duration using web trackers for behavioral analytics."
+
+docs/sources/trackers/web-trackers/testing-debugging/index.md
+description: "Test and debug web tracker implementations for accurate behavioral event collection and validation."
+
+docs/sources/trackers/web-trackers/example-app.md
+description: "Example web application demonstrating behavioral event tracking implementation with JavaScript tracker."
+
+docs/sources/trackers/web-trackers/browsers/index.md
+description: "Browser compatibility and support information for web trackers across different behavioral tracking scenarios."
+
+docs/sources/trackers/web-trackers/tracker-setup/managing-multiple-trackers/index.md
+description: "Configure and manage multiple web tracker instances for complex behavioral analytics implementations."
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/self-hosting-the-javascript-tracker-aws/index.md
+description: "Self-host JavaScript tracker on Amazon Web Services for behavioral event collection infrastructure."
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/self-hosting-the-javascript-tracker-on-google-cloud/index.md
+description: "Self-host JavaScript tracker on Google Cloud Platform for behavioral event collection infrastructure."
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/index.md
+description: "Host JavaScript tracker infrastructure for behavioral event collection with various deployment options."
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/third-party-cdn-hosting/index.md
+description: "Host JavaScript tracker using third-party CDN services for behavioral event collection distribution."
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/creating-a-whitelabel-build/index.md
+description: "Create custom whitelabel builds of JavaScript tracker for behavioral event collection branding."
+
+docs/sources/trackers/web-trackers/tracker-setup/initialization-options/index.md
+description: "Configure JavaScript tracker initialization options for optimal behavioral event collection settings."
+
+docs/sources/trackers/web-trackers/tracker-setup/index.md
+description: "Set up JavaScript web trackers for comprehensive behavioral event collection in web applications."
+
+docs/sources/trackers/web-trackers/tracker-setup/snowplow-plugin-for-analytics-npm-package/index.md
+description: "Integrate Snowplow with analytics npm package for behavioral event collection in JavaScript applications."
+
+docs/sources/trackers/web-trackers/cookies-and-local-storage/configuring-cookies/index.md
+description: "Configure cookie settings in web trackers for behavioral analytics while respecting user privacy."
+
+docs/sources/trackers/web-trackers/cookies-and-local-storage/index.md
+description: "Manage cookies and local storage in web trackers for behavioral analytics data persistence."
+
+docs/sources/trackers/web-trackers/cookies-and-local-storage/getting-cookie-values/index.md
+description: "Retrieve and analyze cookie values using web trackers for behavioral analytics context."
+
+docs/sources/trackers/web-trackers/index.md
+description: "JavaScript web trackers for comprehensive behavioral event collection from websites and web applications."
+
+docs/sources/trackers/web-trackers/cross-domain-tracking/index.md
+description: "Implement cross-domain tracking using web trackers for unified behavioral analytics across multiple sites."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/performance-timing/index.md
+description: "Performance timing plugin for browser tracker v3 to measure behavioral analytics performance metrics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/vimeo-tracking/index.md
+description: "Vimeo tracking plugin for browser tracker v3 to analyze behavioral video engagement."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/web-vitals/index.md
+description: "Web Vitals plugin for browser tracker v3 to track Core Web Vitals behavioral performance metrics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/privacy-sandbox/index.md
+description: "Privacy Sandbox plugin for browser tracker v3 to track behavioral analytics with privacy compliance."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/creating-your-own-plugins/index.md
+description: "Create custom plugins for browser tracker v3 to extend behavioral event collection capabilities."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/timezone/index.md
+description: "Timezone plugin for browser tracker v3 to add temporal context to behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/ecommerce/index.md
+description: "Ecommerce plugin for browser tracker v3 to track behavioral commerce and purchase analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/client-hints/index.md
+description: "Client Hints plugin for browser tracker v3 to capture behavioral analytics device context."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/enhanced-ecommerce/index.md
+description: "Enhanced ecommerce plugin for browser tracker v3 to track detailed behavioral commerce analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/form-tracking/index.md
+description: "Form tracking plugin for browser tracker v3 to analyze behavioral form interaction analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/youtube-tracking/index.md
+description: "YouTube tracking plugin for browser tracker v3 to analyze behavioral video engagement analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/optimizely-classic/index.md
+description: "Optimizely Classic plugin for browser tracker v3 to track behavioral A/B testing analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/adding-plugins-to-your-tracker/index.md
+description: "Add and configure plugins for browser tracker v3 to enhance behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/site-tracking/index.md
+description: "Site tracking plugin for browser tracker v3 to capture comprehensive behavioral website analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/browser-features/index.md
+description: "Browser features plugin for browser tracker v3 to track behavioral analytics browser capabilities."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/ga-cookies/index.md
+description: "Google Analytics cookies plugin for browser tracker v3 to migrate behavioral analytics data."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/error-tracking/index.md
+description: "Error tracking plugin for browser tracker v3 to monitor behavioral analytics JavaScript errors."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/consent/index.md
+description: "Consent plugin for browser tracker v3 to manage behavioral analytics privacy compliance."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/index.md
+description: "Plugin system for browser tracker v3 to extend behavioral event collection functionality."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/geolocation/index.md
+description: "Geolocation plugin for browser tracker v3 to add geographic context to behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/debugger/index.md
+description: "Debugger plugin for browser tracker v3 to troubleshoot behavioral event collection issues."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/optimizely-x/index.md
+description: "Optimizely X plugin for browser tracker v3 to track behavioral experimentation analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/snowplow-ecommerce/index.md
+description: "Snowplow ecommerce plugin for browser tracker v3 to track behavioral commerce analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/enhanced-consent/index.md
+description: "Enhanced consent plugin for browser tracker v3 to manage advanced behavioral analytics privacy."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/performance-navigation-timing/index.md
+description: "Performance navigation timing plugin for browser tracker v3 to measure behavioral page performance."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/link-click-tracking/index.md
+description: "Link click tracking plugin for browser tracker v3 to analyze behavioral navigation patterns."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/ad-tracking/index.md
+description: "Ad tracking plugin for browser tracker v3 to monitor behavioral advertising analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/media-tracking/index.md
+description: "Media tracking plugin for browser tracker v3 to analyze behavioral media engagement analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/media/index.md
+description: "Media plugins for browser tracker v3 to track behavioral video and audio analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracking-events/index.md
+description: "Track behavioral events using browser tracker v3 for comprehensive web analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/index.md
+description: "Advanced usage patterns for browser tracker v3 behavioral event collection and configuration."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/tracker-information/index.md
+description: "Access tracker information and metadata in browser tracker v3 for behavioral analytics debugging."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/using-an-id-service/index.md
+description: "Integrate ID service with browser tracker v3 for behavioral analytics user identification."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/optional-timestamp-argument/index.md
+description: "Use optional timestamp arguments in browser tracker v3 for behavioral analytics event timing."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/additional-options/index.md
+description: "Additional configuration options for browser tracker v3 behavioral event collection setup."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/managing-multiple-trackers/index.md
+description: "Manage multiple browser tracker v3 instances for complex behavioral analytics implementations."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/installing-the-tracker-from-npm/index.md
+description: "Install browser tracker v3 from npm for behavioral event collection in JavaScript applications."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
+description: "Configure browser tracker v3 initialization options for optimal behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/index.md
+description: "Set up browser tracker v3 for behavioral event collection in web applications."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/index.md
+description: "Browser tracker version 3 reference documentation for behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/api-reference.md
+description: "API reference documentation for browser tracker version 3 behavioral event methods."
+
+docs/sources/trackers/web-trackers/previous-versions/index.md
+description: "Previous versions of web trackers for behavioral event collection in web applications."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/anonymous-tracking/index.md
+description: "Implement anonymous tracking in web trackers v3 for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/plugins/creating-your-own-plugins/index.md
+description: "Create custom plugins for web trackers v3 to extend behavioral event collection capabilities."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/plugins/index.md
+description: "Plugin system for web trackers v3 to enhance behavioral event collection functionality."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/plugins/configuring-tracker-plugins/browser/index.md
+description: "Configure browser plugins for web trackers v3 to optimize behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/plugins/configuring-tracker-plugins/index.md
+description: "Configure and manage plugins in web trackers v3 for enhanced behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/plugins/configuring-tracker-plugins/javascript/index.md
+description: "Configure JavaScript plugins for web trackers v3 to extend behavioral event functionality."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/configuring-how-events-sent/index.md
+description: "Configure event transmission settings in web trackers v3 for optimal behavioral data delivery."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/custom-tracking-using-schemas/index.md
+description: "Create custom behavioral events with schemas in web trackers v3 for flexible analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/custom-tracking-using-schemas/global-context/index.md
+description: "Configure global context entities in web trackers v3 for consistent behavioral event enrichment."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/timezone-geolocation/index.md
+description: "Track timezone and geolocation data in web trackers v3 for behavioral analytics context."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/ads/index.md
+description: "Track advertising interactions using web trackers v3 for behavioral ad analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/site-search/index.md
+description: "Track internal site search behavior using web trackers v3 for content discovery analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/social-media/index.md
+description: "Track social media interactions using web trackers v3 for behavioral engagement analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/web-vitals/index.md
+description: "Track Core Web Vitals using web trackers v3 for behavioral performance analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/privacy-sandbox/index.md
+description: "Track Privacy Sandbox APIs using web trackers v3 for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/timings/index.md
+description: "Track custom timing events using web trackers v3 for behavioral performance analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/timings/generic/index.md
+description: "Track generic timing events using web trackers v3 for behavioral interaction analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/campaigns-utms/index.md
+description: "Track UTM campaign parameters using web trackers v3 for behavioral marketing attribution."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/ecommerce/original/index.md
+description: "Track original ecommerce events using web trackers v3 for behavioral commerce analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/ecommerce/index.md
+description: "Track ecommerce transactions using web trackers v3 for behavioral retail analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/ecommerce/enhanced/index.md
+description: "Track enhanced ecommerce events using web trackers v3 for detailed behavioral commerce analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/client-hints/index.md
+description: "Track Client Hints data using web trackers v3 for behavioral analytics device context."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/form-tracking/index.md
+description: "Track form interactions using web trackers v3 for behavioral conversion analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/optimizely/index.md
+description: "Track Optimizely experiments using web trackers v3 for behavioral A/B testing analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/event-specifications/index.md
+description: "Implement event specifications using web trackers v3 for consistent behavioral data collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/page-views/index.md
+description: "Track page views using web trackers v3 for behavioral website navigation analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/link-click/index.md
+description: "Track link clicks using web trackers v3 for behavioral navigation analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/ga-cookies/index.md
+description: "Track Google Analytics cookies using web trackers v3 for behavioral analytics migration."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/activity-page-pings/index.md
+description: "Track page activity and engagement using web trackers v3 for behavioral attention analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/consent-gdpr/original/index.md
+description: "Track original GDPR consent using web trackers v3 for behavioral privacy compliance analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/consent-gdpr/index.md
+description: "Track GDPR consent and privacy preferences using web trackers v3 for compliance analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/index.md
+description: "Track behavioral events using web trackers v3 for comprehensive website analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/focalmeter/index.md
+description: "Track attention metrics using Focalmeter and web trackers v3 for behavioral engagement analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/errors/index.md
+description: "Track JavaScript errors using web trackers v3 for behavioral analytics and debugging."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/button-click/index.md
+description: "Track button clicks using web trackers v3 for behavioral user interface analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/media/html5/index.md
+description: "Track HTML5 media interactions using web trackers v3 for behavioral video analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/media/vimeo/index.md
+description: "Track Vimeo video interactions using web trackers v3 for behavioral media analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/media/youtube/index.md
+description: "Track YouTube video interactions using web trackers v3 for behavioral video analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/media/snowplow/index.md
+description: "Track Snowplow media player using web trackers v3 for behavioral media analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/media/index.md
+description: "Track media player interactions using web trackers v3 for behavioral video and audio analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/session/index.md
+description: "Track user sessions using web trackers v3 for behavioral engagement analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/testing-debugging/index.md
+description: "Test and debug web trackers v3 implementations for accurate behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/example-app.md
+description: "Example application demonstrating web trackers v3 behavioral event collection implementation."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/browsers/index.md
+description: "Browser compatibility guide for web trackers v3 behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/managing-multiple-trackers/index.md
+description: "Manage multiple web trackers v3 instances for complex behavioral analytics implementations."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/hosting-the-javascript-tracker/self-hosting-the-javascript-tracker-aws/index.md
+description: "Self-host JavaScript tracker on AWS using web trackers v3 for behavioral event infrastructure."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/hosting-the-javascript-tracker/self-hosting-the-javascript-tracker-on-google-cloud/index.md
+description: "Self-host JavaScript tracker on Google Cloud using web trackers v3 for behavioral event infrastructure."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/hosting-the-javascript-tracker/index.md
+description: "Host JavaScript tracker infrastructure using web trackers v3 for behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/hosting-the-javascript-tracker/third-party-cdn-hosting/index.md
+description: "Use third-party CDN hosting for web trackers v3 behavioral event collection distribution."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/hosting-the-javascript-tracker/creating-a-whitelabel-build/index.md
+description: "Create whitelabel builds of web trackers v3 for behavioral event collection branding."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/initialization-options/index.md
+description: "Configure initialization options for web trackers v3 behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/index.md
+description: "Set up web trackers v3 for behavioral event collection in web applications."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/snowplow-plugin-for-analytics-npm-package/index.md
+description: "Integrate web trackers v3 with analytics npm package for behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-settings-variable/index.md
+description: "Configure v3 settings variable for Google Tag Manager behavioral event tracking template."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/index.md
+description: "Custom Google Tag Manager template for web trackers v3 behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/tag-template-guide/index.md
+description: "Tag template guide for Google Tag Manager v3 behavioral event tracking implementation."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/tag-template-guide/plugins.md
+description: "Plugin configuration for Google Tag Manager v3 behavioral event tracking templates."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/ecommerce-tag-template/ecommerce-tag-configuration/index.md
+description: "Configure ecommerce tags in Google Tag Manager v3 for behavioral commerce tracking."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/ecommerce-tag-template/index.md
+description: "Ecommerce tag template for Google Tag Manager v3 behavioral commerce analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/index.md
+description: "Tag templates for Google Tag Manager v3 behavioral event tracking implementation."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/cookies-and-local-storage/configuring-cookies/index.md
+description: "Configure cookies in web trackers v3 for behavioral analytics data persistence."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/cookies-and-local-storage/index.md
+description: "Manage cookies and local storage in web trackers v3 for behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/cookies-and-local-storage/getting-cookie-values/index.md
+description: "Retrieve cookie values using web trackers v3 for behavioral analytics context."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/index.md
+description: "Web trackers version 3 documentation for behavioral event collection in web applications."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/cross-domain-tracking/index.md
+description: "Implement cross-domain tracking using web trackers v3 for unified behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/quick-start-guide/index.md
+description: "Quick start guide for web trackers v3 behavioral event collection implementation."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/advanced-usage/callbacks/index.md
+description: "Configure callbacks in JavaScript tracker v2 for behavioral event processing workflows."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/advanced-usage/index.md
+description: "Advanced usage patterns for JavaScript tracker v2 behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/advanced-usage/getting-the-most-out-of-performance-timing/index.md
+description: "Optimize performance timing measurement in JavaScript tracker v2 for behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/advanced-usage/optional-timestamp-argument/index.md
+description: "Use optional timestamp arguments in JavaScript tracker v2 for behavioral event timing."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/loading/index.md
+description: "Load and initialize JavaScript tracker v2 for behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/managing-multiple-trackers/index.md
+description: "Manage multiple JavaScript tracker v2 instances for complex behavioral analytics."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/index.md
+description: "Set up JavaScript tracker v2 for behavioral event collection in web applications."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
+description: "Initialize JavaScript tracker v2 for behavioral event tracking in web applications."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/other-parameters-2/index.md
+description: "Configure additional parameters in JavaScript tracker v2 for behavioral event collection."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/index.md
+description: "JavaScript tracker version 2 documentation for behavioral event collection in web applications."
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracking-specific-events/index.md
+description: "Track specific behavioral events using JavaScript tracker v2 for targeted analytics."
+
+docs/sources/trackers/web-trackers/quick-start-guide/index.md
+description: "Quick start guide for implementing JavaScript web trackers for behavioral event collection."
+
+docs/sources/trackers/webview-tracker/index.md
+description: "WebView tracker for behavioral event collection in hybrid mobile applications and embedded browsers."
+
+docs/sources/trackers/php-tracker/setup/index.md
+description: "Set up PHP tracker for server-side behavioral event collection in PHP applications."
+
+docs/sources/trackers/php-tracker/initialization/index.md
+description: "Initialize PHP tracker for behavioral event tracking in server-side PHP applications."
+
+docs/sources/trackers/php-tracker/index.md
+description: "PHP tracker for server-side behavioral event collection in PHP web applications and services."
+
+docs/sources/trackers/php-tracker/subjects/index.md
+description: "Configure user subjects in PHP tracker for behavioral event context and identification."
+
+docs/sources/trackers/php-tracker/emitters/index.md
+description: "Configure event emitters in PHP tracker for reliable behavioral data transmission."
+
+docs/sources/trackers/php-tracker/tracking-an-event/index.md
+description: "Track behavioral events using PHP tracker for server-side analytics in PHP applications."
+
+docs/sources/trackers/mobile-trackers/configuring-how-events-are-sent/index.md
+description: "Configure event transmission settings in mobile trackers for optimal behavioral data delivery."
+
+docs/sources/trackers/mobile-trackers/anonymous-tracking/index.md
+description: "Implement anonymous user tracking in mobile applications for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-ios-tracker-sdk-from-version-1-x-to-2-0/index.md
+description: "Migration guide for iOS tracker upgrade from version 1.x to 2.0 with behavioral tracking improvements."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-from-version-3-x-to-4-0/index.md
+description: "Migration guide for mobile trackers upgrade from version 3.x to 4.0 with enhanced features."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-ios-tracker-sdk-from-version-2-x-to-3-0/index.md
+description: "Migration guide for iOS tracker upgrade from version 2.x to 3.0 with behavioral analytics improvements."
+
+docs/sources/trackers/mobile-trackers/migration-guides/index.md
+description: "Version migration guides for mobile trackers with behavioral event tracking improvements."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-to-new-ecommerce/index.md
+description: "Migration guide for upgrading to new ecommerce tracking in mobile trackers for behavioral commerce analytics."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-android-tracker-sdk-from-version-1-x-to-2-0/index.md
+description: "Migration guide for Android tracker upgrade from version 1.x to 2.0 with behavioral tracking improvements."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-from-version-4-x-to-5-0/index.md
+description: "Migration guide for mobile trackers upgrade from version 4.x to 5.0 with advanced features."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-android-tracker-sdk-from-version-2-x-to-3-0/index.md
+description: "Migration guide for Android tracker upgrade from version 2.x to 3.0 with behavioral analytics improvements."
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
+description: "Migration guide for mobile trackers upgrade from version 5.x to 6.0 with enhanced capabilities."
+
+docs/sources/trackers/mobile-trackers/plugins/focal-meter/index.md
+description: "Focal Meter plugin for mobile trackers to measure behavioral attention and engagement analytics."
+
+docs/sources/trackers/mobile-trackers/plugins/index.md
+description: "Plugin system for mobile trackers to extend behavioral event collection functionality."
+
+docs/sources/trackers/mobile-trackers/custom-tracking-using-schemas/index.md
+description: "Create custom behavioral events with schemas in mobile trackers for flexible mobile analytics."
+
+docs/sources/trackers/mobile-trackers/custom-tracking-using-schemas/global-context/index.md
+description: "Configure global context entities in mobile trackers for consistent behavioral event enrichment."
+
+docs/sources/trackers/mobile-trackers/tracking-events/platform-and-application-context/index.md
+description: "Add platform and application context to behavioral events in mobile tracker implementations."
+
+docs/sources/trackers/mobile-trackers/tracking-events/exception-tracking/index.md
+description: "Track application exceptions and crashes in mobile trackers for behavioral analytics and debugging."
+
+docs/sources/trackers/mobile-trackers/tracking-events/lifecycle-tracking/index.md
+description: "Track application lifecycle events in mobile trackers for user engagement analysis."
+
+docs/sources/trackers/mobile-trackers/tracking-events/installation-tracking/index.md
+description: "Track app installation events in mobile trackers for user acquisition analytics."
+
+docs/sources/trackers/mobile-trackers/tracking-events/gdpr-tracking/index.md
+description: "Track GDPR consent and privacy preferences in mobile trackers for compliance analytics."
+
+docs/sources/trackers/mobile-trackers/tracking-events/visionos/index.md
+description: "Track behavioral events in visionOS applications using mobile trackers for spatial computing analytics."
+
+docs/sources/trackers/mobile-trackers/tracking-events/index.md
+description: "Track behavioral events in mobile applications using native iOS and Android tracker SDKs."
+
+docs/sources/trackers/mobile-trackers/tracking-events/screen-tracking/index.md
+description: "Track screen views and navigation patterns in mobile applications using native trackers."
+
+docs/sources/trackers/mobile-trackers/tracking-events/ecommerce-tracking/index.md
+description: "Track ecommerce transactions and shopping behavior in mobile applications using native trackers."
+
+docs/sources/trackers/mobile-trackers/tracking-events/session-tracking/index.md
+description: "Track user sessions and engagement in mobile applications using native trackers."
+
+docs/sources/trackers/mobile-trackers/tracking-events/media-tracking/index.md
+description: "Track media player interactions and engagement in mobile applications using native trackers."
+
+docs/sources/trackers/mobile-trackers/client-side-properties/index.md
+description: "Configure client-side properties in mobile trackers for enhanced behavioral event context."
+
+docs/sources/trackers/mobile-trackers/android-google-play-data-safety/index.md
+description: "Android Google Play data safety compliance guide for mobile tracker behavioral analytics implementation."
+
+docs/sources/trackers/mobile-trackers/hybrid-apps/index.md
+description: "Implement mobile trackers in hybrid applications for unified behavioral analytics across platforms."
+
+docs/sources/trackers/mobile-trackers/index.md
+description: "Native mobile trackers for iOS and Android behavioral event collection in mobile applications and games."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/introduction/index.md
+description: "Introduction to mobile trackers version 2.x for behavioral event collection in mobile applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/tracking-events/index.md
+description: "Track behavioral events using mobile trackers version 2.x in iOS and Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/index.md
+description: "Mobile trackers version 2.x documentation for behavioral event collection in mobile applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/remote-configuration/index.md
+description: "Configure mobile trackers version 2.x remotely for behavioral analytics settings management."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/quick-start-guide/index.md
+description: "Quick start guide for mobile trackers version 2.x behavioral event collection implementation."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-0-0/index.md
+description: "Objective-C tracker version 1.0.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-4-0/index.md
+description: "Objective-C tracker version 0.4.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-4-0/index.md
+description: "iOS tracker version 1.4.0 documentation for behavioral event collection in iOS applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-3-0/index.md
+description: "Objective-C tracker version 0.3.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-9-0/index.md
+description: "Objective-C tracker version 0.9.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-3/index.md
+description: "Objective-C tracker version 1.1.3 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-4/index.md
+description: "Objective-C tracker version 1.1.4 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-5/index.md
+description: "Objective-C tracker version 1.1.5 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-2/index.md
+description: "Objective-C tracker version 1.1.2 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-7-0/index.md
+description: "Objective-C tracker version 0.7.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-7-0/index.md
+description: "iOS tracker version 1.7.0 documentation for behavioral event collection in iOS applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-8-0/index.md
+description: "Objective-C tracker version 0.8.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-2-0/index.md
+description: "Objective-C tracker version 0.2.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-2-0/index.md
+description: "Objective-C tracker version 1.2.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-6-0/index.md
+description: "Objective-C tracker version 0.6.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/index.md
+description: "Previous versions of Objective-C tracker for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-6-0/index.md
+description: "iOS tracker version 1.6.0 documentation for behavioral event collection in iOS applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-0/index.md
+description: "Objective-C tracker version 1.1.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-1-0/index.md
+description: "Objective-C tracker version 0.1.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-5-0/index.md
+description: "Objective-C tracker version 0.5.0 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker/index.md
+description: "iOS tracker documentation for behavioral event collection in iPhone and iPad applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-1/index.md
+description: "Objective-C tracker version 1.1.1 documentation for iOS behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-5-0/index.md
+description: "iOS tracker version 1.5.0 documentation for behavioral event collection in iOS applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/index.md
+description: "Previous versions of mobile trackers for iOS and Android behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/introduction/index.md
+description: "Introduction to mobile trackers version 3.x for behavioral event collection in mobile applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/tracking-events/index.md
+description: "Track behavioral events using mobile trackers version 3.x in iOS and Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/index.md
+description: "Mobile trackers version 3.x documentation for behavioral event collection in mobile applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/remote-configuration/index.md
+description: "Configure mobile trackers version 3.x remotely for behavioral analytics settings management."
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/quick-start-guide/index.md
+description: "Quick start guide for mobile trackers version 3.x behavioral event collection implementation."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-4-0/index.md
+description: "Android tracker version 1.4.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-4-0/index.md
+description: "Android tracker version 0.4.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-0-0/index.md
+description: "Android tracker version 1.0.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-2-0-java-0-6-0/index.md
+description: "Android tracker version 0.2.0 and Java 0.6.0 documentation for behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-7-0/index.md
+description: "Android tracker version 0.7.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-7-0/index.md
+description: "Android tracker version 1.7.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-3-0/index.md
+description: "Android tracker version 1.3.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-3-0/index.md
+description: "Android tracker version 0.3.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-2-1/index.md
+description: "Android tracker version 1.2.1 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-6-0/index.md
+description: "Android tracker version 0.6.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-6-0/index.md
+description: "Android tracker version 1.6.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-2-0/index.md
+description: "Android tracker version 1.2.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-8-0/index.md
+description: "Android tracker version 0.8.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/index.md
+description: "Previous versions of Android tracker for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-1-0-java-0-5-0/index.md
+description: "Android tracker version 0.1.0 and Java 0.5.0 documentation for behavioral event collection."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-5-0/index.md
+description: "Android tracker version 1.5.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-5-0/index.md
+description: "Android tracker version 0.5.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-1-0/index.md
+description: "Android tracker version 1.1.0 documentation for behavioral event collection in Android applications."
+
+docs/sources/trackers/mobile-trackers/remote-configuration/index.md
+description: "Configure mobile trackers remotely for behavioral analytics settings and parameter management."
+
+docs/sources/trackers/mobile-trackers/demos/index.md
+description: "Demo applications showcasing mobile tracker behavioral event collection capabilities and implementation."
+
+docs/sources/trackers/mobile-trackers/installation-and-set-up/index.md
+description: "Installation and setup guide for native mobile trackers in iOS and Android applications."
+
+docs/sources/trackers/pixel-tracker/index.md
+description: "Pixel tracker for server-side behavioral event collection through image pixel requests."
+
+docs/sources/trackers/unity-tracker/emitter/index.md
+description: "Configure event emitters in Unity tracker for reliable behavioral data transmission from games."
+
+docs/sources/trackers/unity-tracker/subject/index.md
+description: "Configure user subjects in Unity tracker for behavioral event context and player identification."
+
+docs/sources/trackers/unity-tracker/setup/index.md
+description: "Set up Unity tracker for behavioral event collection in Unity games and interactive applications."
+
+docs/sources/trackers/unity-tracker/tracker/index.md
+description: "Initialize and configure Unity tracker for behavioral event collection in game development."
+
+docs/sources/trackers/unity-tracker/initialization/index.md
+description: "Initialize Unity tracker for behavioral event tracking in Unity games and applications."
+
+docs/sources/trackers/unity-tracker/example-app.md
+description: "Example Unity application demonstrating behavioral event tracking implementation with Unity tracker."
+
+docs/sources/trackers/unity-tracker/utilities/index.md
+description: "Utility functions and helper methods for Unity tracker behavioral event collection implementation."
+
+docs/sources/trackers/unity-tracker/index.md
+description: "Unity tracker for behavioral event collection in Unity games and interactive entertainment applications."
+
+docs/sources/trackers/unity-tracker/event-tracking/index.md
+description: "Track behavioral events in Unity games using Snowplow's game development tracker SDK."
+
+docs/sources/trackers/unity-tracker/session/index.md
+description: "Manage player sessions in Unity tracker for behavioral analytics and game engagement tracking."
+
+docs/sources/trackers/google-amp-tracker/index.md
+description: "Google AMP tracker for behavioral event collection in Accelerated Mobile Pages implementations."
+
+docs/sources/trackers/flutter-tracker/initialization-and-configuration/index.md
+description: "Initialize and configure Flutter tracker for cross-platform mobile behavioral event collection."
+
+docs/sources/trackers/flutter-tracker/adding-data/index.md
+description: "Add custom data and context to behavioral events using Flutter tracker SDK."
+
+docs/sources/trackers/flutter-tracker/anonymous-tracking/index.md
+description: "Implement anonymous user tracking in Flutter applications for privacy-compliant behavioral analytics."
+
+docs/sources/trackers/flutter-tracker/tracking-events/index.md
+description: "Track behavioral events in Flutter applications using cross-platform mobile tracker SDK."
+
+docs/sources/trackers/flutter-tracker/tracking-events/media-tracking/index.md
+description: "Track media player interactions and engagement in Flutter applications using mobile tracker."
+
+docs/sources/trackers/flutter-tracker/sessions-and-data-model/index.md
+description: "Manage user sessions and data models in Flutter tracker for behavioral analytics."
+
+docs/sources/trackers/flutter-tracker/getting-started/index.md
+description: "Quick start guide for implementing behavioral event tracking with Flutter tracker in mobile apps."
+
+docs/sources/trackers/flutter-tracker/hybrid-apps/index.md
+description: "Implement Flutter tracker in hybrid applications for unified behavioral analytics across platforms."
+
+docs/sources/trackers/flutter-tracker/index.md
+description: "Flutter tracker for cross-platform mobile behavioral event collection in iOS and Android applications."
+
+docs/sources/trackers/roku-tracker/adding-data/index.md
+description: "Add custom data and context to behavioral events using Roku tracker for streaming analytics."
+
+docs/sources/trackers/roku-tracker/configuration/index.md
+description: "Configure Roku tracker settings for optimal behavioral event collection in streaming applications."
+
+docs/sources/trackers/roku-tracker/example-app/index.md
+description: "Example Roku application demonstrating behavioral event tracking implementation for streaming analytics."
+
+docs/sources/trackers/roku-tracker/tracking-events/index.md
+description: "Track behavioral events in Roku streaming applications using connected TV tracker SDK."
+
+docs/sources/trackers/roku-tracker/device-context/index.md
+description: "Configure device context in Roku tracker for behavioral analytics with streaming device information."
+
+docs/sources/trackers/roku-tracker/index.md
+description: "Roku tracker for behavioral event collection in streaming TV applications and connected TV analytics."
+
+docs/sources/trackers/roku-tracker/quick-start-guide/index.md
+description: "Quick start guide for implementing Roku tracker in streaming TV applications for behavioral analytics."
+
+docs/sources/trackers/roku-tracker/media-tracking/v1/index.md
+description: "Media tracking version 1 for Roku tracker to analyze streaming behavioral engagement analytics."
+
+docs/sources/trackers/roku-tracker/media-tracking/v2/index.md
+description: "Media tracking version 2 for Roku tracker with enhanced streaming behavioral analytics capabilities."
+
+docs/sources/trackers/roku-tracker/media-tracking/index.md
+description: "Track media playback and streaming behavior in Roku applications for connected TV analytics."
+
+docs/sources/trackers/snowplow-tracking-cli/additional-information/index.md
+description: "Additional information and advanced usage for Snowplow CLI tracking tool."
+
+docs/sources/trackers/snowplow-tracking-cli/usage/index.md
+description: "Usage guide for Snowplow CLI tracking tool for command-line behavioral event collection."
+
+docs/sources/trackers/snowplow-tracking-cli/installation/index.md
+description: "Install Snowplow CLI tracking tool for command-line behavioral event collection and testing."
+
+docs/sources/trackers/snowplow-tracking-cli/index.md
+description: "Command-line interface tool for behavioral event tracking and testing Snowplow implementations."
+
+docs/sources/trackers/python-tracker/previous_versions/index.md
+description: "Previous versions of Python tracker for server-side behavioral event collection."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/the-redisworker-class/index.md
+description: "RedisWorker class in Python tracker v0.15 for behavioral event queue processing."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/contracts/index.md
+description: "Data contracts and validation in Python tracker v0.15 for behavioral event structure."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/setup/index.md
+description: "Setup guide for Python tracker version 0.15 in server-side applications."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/intialization/index.md
+description: "Initialize Python tracker version 0.15 for behavioral event tracking in Python applications."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/index.md
+description: "Python tracker version 0.15 documentation for server-side behavioral event collection."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/tracking-specific-events/index.md
+description: "Track specific behavioral events using Python tracker version 0.15 in server applications."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/upgrading/index.md
+description: "Upgrade guide for Python tracker version 0.15 with behavioral tracking improvements."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/emitters/index.md
+description: "Configure event emitters in Python tracker version 0.15 for behavioral data transmission."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/logging/index.md
+description: "Configure logging in Python tracker version 0.15 for behavioral event debugging."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/api-reference.md
+description: "API reference documentation for Python tracker version 0.15 behavioral event methods."
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/adding-extra-data-the-subject-class/index.md
+description: "Add user context using Python tracker v0.15 subject class for behavioral event enrichment."
+
+docs/sources/trackers/python-tracker/contracts/index.md
+description: "Data contracts and validation in Python tracker for behavioral event structure integrity."
+
+docs/sources/trackers/python-tracker/subject/index.md
+description: "Configure user subjects in Python tracker for behavioral event context and identification."
+
+docs/sources/trackers/python-tracker/setup/index.md
+description: "Set up Python tracker for server-side behavioral event collection in Python applications."
+
+docs/sources/trackers/python-tracker/intialization/index.md
+description: "Initialize Python tracker for behavioral event tracking in server-side Python applications."
+
+docs/sources/trackers/python-tracker/index.md
+description: "Python tracker for server-side behavioral event collection in web applications and data processing pipelines."
+
+docs/sources/trackers/python-tracker/tracking-specific-events/index.md
+description: "Track specific behavioral events using Python tracker for targeted server-side analytics."
+
+docs/sources/trackers/python-tracker/upgrading/index.md
+description: "Upgrade guide for Python tracker with behavioral event tracking improvements and new features."
+
+docs/sources/trackers/python-tracker/emitters/index.md
+description: "Configure event emitters in Python tracker for reliable behavioral data transmission to collectors."
+
+docs/sources/trackers/python-tracker/demos/index.md
+description: "Demo applications showcasing Python tracker behavioral event collection capabilities and implementation."
+
+docs/sources/trackers/python-tracker/logging/index.md
+description: "Configure logging in Python tracker for behavioral event debugging and troubleshooting."
+
+docs/sources/trackers/scala-tracker/sending-events/index.md
+description: "Send behavioral events using Scala tracker for functional programming and big data applications."
+
+docs/sources/trackers/scala-tracker/subject-methods/index.md
+description: "Configure user subjects in Scala tracker for behavioral event context and identification methods."
+
+docs/sources/trackers/scala-tracker/setup/index.md
+description: "Set up Scala tracker for behavioral event collection in Scala applications and big data systems."
+
+docs/sources/trackers/scala-tracker/initialization/index.md
+description: "Initialize Scala tracker for behavioral event tracking in functional programming applications."
+
+docs/sources/trackers/scala-tracker/index.md
+description: "Scala tracker for behavioral event collection in big data applications and functional programming systems."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/sending-events/index.md
+description: "Send behavioral events using Scala tracker version 0.6.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/subject-methods/index.md
+description: "Subject methods in Scala tracker version 0.6.0 for behavioral event context configuration."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/setup/index.md
+description: "Setup guide for Scala tracker version 0.6.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/initialization/index.md
+description: "Initialize Scala tracker version 0.6.0 for behavioral event tracking in Scala applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/index.md
+description: "Scala tracker version 0.6.0 documentation for behavioral event collection in functional applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/sending-events/index.md
+description: "Send behavioral events using Scala tracker version 0.5.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/subject-methods/index.md
+description: "Subject methods in Scala tracker version 0.5.0 for behavioral event context configuration."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/setup/index.md
+description: "Setup guide for Scala tracker version 0.5.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/initialization/index.md
+description: "Initialize Scala tracker version 0.5.0 for behavioral event tracking in Scala applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/index.md
+description: "Scala tracker version 0.5.0 documentation for behavioral event collection in functional applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/sending-events/index.md
+description: "Send behavioral events using Scala tracker version 1.0.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/subject-methods/index.md
+description: "Subject methods in Scala tracker version 1.0.0 for behavioral event context configuration."
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/setup/index.md
+description: "Setup guide for Scala tracker version 1.0.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/initialization/index.md
+description: "Initialize Scala tracker version 1.0.0 for behavioral event tracking in Scala applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/index.md
+description: "Scala tracker version 1.0.0 documentation for behavioral event collection in functional applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/index.md
+description: "Previous versions of Scala tracker for behavioral event collection in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/sending-events/index.md
+description: "Send behavioral events using Scala tracker version 0.7.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/subject-methods/index.md
+description: "Subject methods in Scala tracker version 0.7.0 for behavioral event context configuration."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/setup/index.md
+description: "Setup guide for Scala tracker version 0.7.0 in functional programming applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/initialization/index.md
+description: "Initialize Scala tracker version 0.7.0 for behavioral event tracking in Scala applications."
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/index.md
+description: "Scala tracker version 0.7.0 documentation for behavioral event collection in functional applications."
+
+docs/sources/first-party-tracking/index.md
+description: "Implement first-party behavioral event tracking to improve data accuracy and bypass ad blockers."
+
+docs/sources/index.md
+description: "Complete guide to Snowplow data sources including trackers, webhooks, and behavioral event collection methods."
+
+docs/sources/webhooks/iterable/index.md
+description: "Integrate Iterable webhook events into Snowplow for behavioral marketing automation analytics."
+
+docs/sources/webhooks/iglu-webhook/index.md
+description: "Generic Iglu webhook for collecting behavioral events from third-party systems via HTTP requests."
+
+docs/sources/webhooks/adjust-webhook/index.md
+description: "Integrate Adjust mobile attribution webhook events into Snowplow for behavioral mobile analytics."
+
+docs/sources/webhooks/sendgrid/index.md
+description: "Integrate SendGrid email webhook events into Snowplow for behavioral email marketing analytics."
+
+docs/sources/webhooks/mandrill/index.md
+description: "Integrate Mandrill email webhook events into Snowplow for behavioral email engagement analytics."
+
+docs/sources/webhooks/index.md
+description: "Webhook integrations for collecting behavioral events from third-party platforms and services."
+
+docs/sources/webhooks/zendesk/index.md
+description: "Integrate Zendesk support webhook events into Snowplow for behavioral customer service analytics."
+
+docs/sources/webhooks/mailgun/index.md
+description: "Integrate Mailgun email webhook events into Snowplow for behavioral email delivery analytics."
+
+docs/glossary/index.md
+description: "Comprehensive glossary of behavioral data analytics terms, Snowplow concepts, and event tracking terminology."
+
+docs/events/timestamps/index.md
+description: "Understand event timestamps in Snowplow behavioral data for accurate temporal analysis and ordering."
+
+docs/events/going-deeper/example-requests/index.md
+description: "Example HTTP requests and payload structures for Snowplow behavioral event collection."
+
+docs/events/going-deeper/http-headers/index.md
+description: "HTTP headers used in Snowplow behavioral event collection for context and metadata transmission."
+
+docs/events/going-deeper/index.md
+description: "Deep dive into Snowplow behavioral event structure, processing, and advanced collection concepts."
+
+docs/events/going-deeper/event-parameters/index.md
+description: "Detailed breakdown of event parameters and fields in Snowplow behavioral data collection."
+
+docs/events/ootb-data/links-and-referrers/index.md
+description: "Out-of-the-box link and referrer tracking in Snowplow for behavioral navigation and traffic analytics."
+
+docs/events/ootb-data/page-activity-tracking/index.md
+description: "Page activity tracking capabilities in Snowplow for behavioral engagement and attention analytics."
+
+docs/events/ootb-data/mobile-lifecycle-events/index.md
+description: "Mobile application lifecycle events tracked automatically by Snowplow for behavioral mobile analytics."
+
+docs/events/ootb-data/page-and-screen-view-events/index.md
+description: "Page view and screen view events captured automatically by Snowplow trackers for behavioral analytics."
+
+docs/events/ootb-data/ecommerce-events/index.md
+description: "Built-in ecommerce event tracking in Snowplow for behavioral commerce and transaction analytics."
+
+docs/events/ootb-data/app-information/index.md
+description: "Application information captured automatically by Snowplow trackers for behavioral context analytics."
+
+docs/events/ootb-data/media-events/index.md
+description: "Media player events tracked automatically by Snowplow for behavioral video and audio analytics."
+
+docs/events/ootb-data/user-and-session-identification/index.md
+description: "User and session identification mechanisms in Snowplow for behavioral analytics user tracking."
+
+docs/events/ootb-data/index.md
+description: "Out-of-the-box behavioral data collected automatically by Snowplow trackers without custom implementation."
+
+docs/events/ootb-data/app-performance/index.md
+description: "Application performance metrics captured automatically by Snowplow for behavioral analytics optimization."
+
+docs/events/ootb-data/geolocation/index.md
+description: "Geolocation data captured by Snowplow trackers for behavioral analytics with geographic context."
+
+docs/events/ootb-data/visionos-swiftui/index.md
+description: "VisionOS and SwiftUI specific behavioral event data captured by Snowplow for spatial computing analytics."
+
+docs/events/ootb-data/consent-events/index.md
+description: "Consent and privacy events tracked automatically by Snowplow for behavioral compliance analytics."
+
+docs/events/ootb-data/device-and-browser/index.md
+description: "Device and browser information captured automatically by Snowplow for behavioral analytics context."
+
+docs/events/ootb-data/app-error-events/index.md
+description: "Application error events tracked automatically by Snowplow for behavioral analytics debugging."
+
+docs/events/cookie-extension/index.md
+description: "Cookie extension capabilities in Snowplow for enhanced behavioral analytics data collection."
+
+docs/events/index.md
+description: "Comprehensive guide to behavioral events in Snowplow including out-of-box tracking and custom event implementation."
+
+docs/events/custom-events/structured-events/index.md
+description: "Create structured behavioral events with predefined parameters for standardized analytics tracking."
+
+docs/events/custom-events/index.md
+description: "Create custom behavioral events to capture unique business interactions and user behaviors."
+
+docs/events/custom-events/context-entities/index.md
+description: "Add context entities to behavioral events for rich contextual information and enhanced analytics."
+
+docs/events/custom-events/self-describing-events/index.md
+description: "Create self-describing behavioral events with JSON schemas for flexible and extensible event tracking."
+
+docs/modeling-your-data/visualization/funnel-builder/index.md
+description: "Build conversion funnels from behavioral data for user journey analysis and optimization insights."
+
+docs/modeling-your-data/visualization/ecommerce-analytics/index.md
+description: "Create ecommerce analytics dashboards from behavioral data for retail performance and customer insights."
+
+docs/modeling-your-data/visualization/video-media/index.md
+description: "Visualize video and media engagement analytics from behavioral data for content performance insights."
+
+docs/modeling-your-data/visualization/attribution-modeling/index.md
+description: "Build marketing attribution models from behavioral data for multi-touch campaign analysis and optimization."
+
+docs/modeling-your-data/visualization/index.md
+description: "Create compelling data visualizations and dashboards from transformed behavioral analytics data."
+
+docs/modeling-your-data/visualization/marketing-dashboards/index.md
+description: "Build marketing performance dashboards from behavioral data for campaign analysis and optimization."
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/dbt/index.md
+description: "Run dbt data models through Snowplow BDP Console for managed behavioral data transformation workflows."
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/dbt/resolving-data-model-failures/index.md
+description: "Troubleshoot and resolve dbt model failures in Snowplow BDP for reliable behavioral data processing."
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/retrieving-job-execution-data-via-the-api/index.md
+description: "Retrieve job execution data via Snowplow BDP API for behavioral data model monitoring and debugging."
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/index.md
+description: "Execute and manage data models through Snowplow BDP Console for streamlined behavioral analytics workflows."
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/sql-runner-mobile-data-model/index.md
+description: "Build mobile analytics data models using SQL Runner for behavioral mobile app analysis."
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/migrating-to-dbt/index.md
+description: "Migrate from SQL Runner to dbt for more sophisticated behavioral data modeling and transformation workflows."
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/index.md
+description: "Transform behavioral data using SQL Runner for custom analytics models and data processing workflows."
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/sql-runner-web-data-model/index.md
+description: "Build web analytics data models using SQL Runner for behavioral website analysis and reporting."
+
+docs/modeling-your-data/index.md
+description: "Transform raw behavioral events into analytics-ready data models for business intelligence and data science."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/ecommerce/index.md
+description: "Migration guide for dbt ecommerce data model with behavioral commerce analytics improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/web/index.md
+description: "Migration guide for dbt web data model with behavioral website analytics improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/web_to_unified/index.md
+description: "Migration guide from dbt web model to unified model for comprehensive behavioral analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/media-player/index.md
+description: "Migration guide for dbt media player data model with behavioral video analytics improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/unified/index.md
+description: "Migration guide for dbt unified data model with cross-platform behavioral analytics improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/utils/index.md
+description: "Migration guide for dbt utils package with behavioral data modeling utility improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/normalize/index.md
+description: "Migration guide for dbt normalize package with behavioral data normalization improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/index.md
+description: "Version migration guides for dbt packages with behavioral data modeling improvements and features."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/mobile/index.md
+description: "Migration guide for dbt mobile data model with behavioral mobile analytics improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/attribution/index.md
+description: "Migration guide for dbt attribution data model with behavioral marketing attribution improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/fractribution/index.md
+description: "Migration guide for dbt fractribution data model with behavioral attribution analytics improvements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/index.md
+description: "Model behavioral data using dbt (data build tool) for scalable analytics transformations and data warehousing."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-normalize-data-model/index.md
+description: "Normalize behavioral data using dbt for consistent formatting and standardization across analytics workflows."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-media-player-data-model/index.md
+description: "Transform media player behavioral data using dbt for video engagement and content performance analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-attribution-data-model/keeping-cohesion-with-unified/index.md
+description: "Maintain data cohesion between attribution and unified models for comprehensive behavioral marketing analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-attribution-data-model/index.md
+description: "Build marketing attribution models using dbt for multi-touch behavioral campaign analysis and optimization."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-attribution-data-model/custom-implementations/index.md
+description: "Implement custom attribution models using dbt for specialized behavioral marketing analysis requirements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-mobile-data-model/app-errors-module/index.md
+description: "App errors module in legacy dbt mobile model for behavioral mobile application debugging analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-mobile-data-model/index.md
+description: "Legacy dbt mobile data model for behavioral mobile app analytics and user engagement tracking."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/core-web-vitals-module/index.md
+description: "Core Web Vitals module in legacy dbt web model for behavioral website performance analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/conversions/index.md
+description: "Conversion tracking in legacy dbt web model for behavioral website optimization analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/consent-module/index.md
+description: "Consent module in legacy dbt web model for behavioral privacy compliance analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/index.md
+description: "Legacy dbt web data model for behavioral website analytics and user journey tracking."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/index.md
+description: "Legacy dbt data models for behavioral analytics with historical implementation patterns."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-fractribution-data-model/index.md
+description: "Legacy dbt fractribution model for behavioral marketing attribution and campaign analysis."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-ecommerce-data-model/index.md
+description: "Transform ecommerce behavioral data using dbt for retail analytics and customer purchase analysis."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-utils-data-model/index.md
+description: "Utility functions and macros in dbt utils package for behavioral data modeling workflows."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/index.md
+description: "Pre-built dbt data models for transforming behavioral data into analytics-ready datasets."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/app-errors-module/index.md
+description: "App errors module in dbt unified model for cross-platform behavioral application debugging analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/core-web-vitals-module/index.md
+description: "Core Web Vitals module in dbt unified model for behavioral website performance analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/overridable-macros/index.md
+description: "Customizable macros in dbt unified model for flexible behavioral data transformation workflows."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/conversions/index.md
+description: "Conversion tracking in dbt unified model for cross-platform behavioral optimization analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/consent-module/index.md
+description: "Consent module in dbt unified model for behavioral privacy compliance analytics across platforms."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/index.md
+description: "Unified dbt data model for combining web and mobile behavioral data into comprehensive cross-platform analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/dbt-tests/index.md
+description: "Implement dbt tests for behavioral data quality validation and model integrity assurance."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/debugging/index.md
+description: "Debug dbt models and transformations for reliable behavioral data processing workflows."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/backfilling/index.md
+description: "Backfill historical behavioral data using dbt for complete analytics datasets and reporting."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/full-or-partial-refreshes/index.md
+description: "Manage full and partial refreshes in dbt for efficient behavioral data model updates."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/disabling-models/index.md
+description: "Disable and manage dbt models for behavioral data processing workflow optimization."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/async-runs/index.md
+description: "Execute asynchronous dbt runs for scalable behavioral data transformation processing."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/index.md
+description: "Operational best practices for running and maintaining dbt behavioral data models in production."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/lakes/index.md
+description: "Deploy dbt models for behavioral data processing in data lake environments and architectures."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/model-selection/index.md
+description: "Select and run specific dbt models for targeted behavioral data transformation workflows."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/this-run-tables/index.md
+description: "Understand this-run tables in dbt packages for incremental behavioral data processing."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/overridable-macros/index.md
+description: "Customize overridable macros in dbt packages for flexible behavioral data transformation logic."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/dispatch/index.md
+description: "Macro dispatch mechanism in dbt packages for behavioral data processing across different warehouses."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/late-arriving-data/index.md
+description: "Handle late-arriving behavioral data in dbt packages for accurate analytics and reporting."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/deduplication/index.md
+description: "Implement deduplication logic in dbt packages for clean behavioral data processing."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/optimized-upserts/index.md
+description: "Optimized upsert operations in dbt packages for efficient behavioral data updates."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/incremental-processing/full-run-calculation/index.md
+description: "Full run calculations in incremental dbt processing for comprehensive behavioral data analysis."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/incremental-processing/index.md
+description: "Incremental processing mechanics in dbt packages for scalable behavioral data transformations."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/index.md
+description: "Technical mechanics of dbt Snowplow packages for behavioral data modeling and transformation workflows."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/manifest-tables/index.md
+description: "Manifest tables in dbt packages for tracking behavioral data processing state and metadata."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/index.md
+description: "Create custom dbt models for specialized behavioral data analysis and business-specific requirements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/new-derived-model/index.md
+description: "Example of creating new derived models in dbt for custom behavioral data analysis requirements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/additional-sql-on-events-this-run/index.md
+description: "Add custom SQL logic to events-this-run tables for enhanced behavioral data processing."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/daily-aggregate-table/index.md
+description: "Create daily aggregate tables in dbt for behavioral data summarization and reporting."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/index.md
+description: "Practical examples of custom dbt models for specialized behavioral data analysis scenarios."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/using-mulit-valued-entities/index.md
+description: "Work with multi-valued entities in custom dbt models for complex behavioral data relationships."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/adding-fields-to-derived-table/index.md
+description: "Add custom fields to derived tables in dbt for enhanced behavioral data analysis capabilities."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/using-different-sessionisation/index.md
+description: "Implement custom sessionization logic in dbt for specialized behavioral analytics requirements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/incorporating-non-snowplow-data/index.md
+description: "Incorporate external data sources into dbt behavioral analytics models for comprehensive analysis."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/high-volume-optimizations/index.md
+description: "Optimize dbt models for high-volume behavioral data processing and performance requirements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/custom-identifiers/index.md
+description: "Configure custom user identifiers in dbt packages for behavioral analytics identity resolution."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/modeling-entities/index.md
+description: "Model context entities in dbt packages for rich behavioral data analysis and reporting."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/custom-aggregations/index.md
+description: "Create custom aggregations in dbt packages for specialized behavioral data analysis requirements."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/identity-stitching/index.md
+description: "Implement identity stitching in dbt packages for unified behavioral analytics across user sessions."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/index.md
+description: "Advanced features in dbt Snowplow packages for enhanced behavioral data modeling capabilities."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/passthrough-fields/index.md
+description: "Configure passthrough fields in dbt packages to include additional behavioral data columns."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/table-grants/index.md
+description: "Manage table permissions and grants in dbt packages for secure behavioral data access."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/ecommerce/index.md
+description: "Quick start guide for dbt ecommerce data model implementation for behavioral commerce analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/media-player/index.md
+description: "Quick start guide for dbt media player data model implementation for behavioral video analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/unified/index.md
+description: "Quick start guide for dbt unified data model implementation for cross-platform behavioral analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/web/index.md
+description: "Quick start guide for legacy dbt web data model implementation for behavioral website analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/index.md
+description: "Quick start guides for legacy dbt data models for behavioral analytics implementation."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/mobile/index.md
+description: "Quick start guide for legacy dbt mobile data model implementation for behavioral mobile analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/fractribution/index.md
+description: "Quick start guide for legacy dbt fractribution data model implementation for behavioral attribution analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/utils/index.md
+description: "Quick start guide for dbt utils package implementation for behavioral data modeling utilities."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/normalize/index.md
+description: "Quick start guide for dbt normalize package implementation for behavioral data standardization."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/index.md
+description: "Quick start guides for implementing dbt data models for behavioral analytics and data transformation."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/attribution/index.md
+description: "Quick start guide for dbt attribution data model implementation for behavioral marketing analytics."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.mdx
+description: "Configuration guide for dbt ecommerce data model behavioral commerce analytics settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/media-player/index.mdx
+description: "Configuration guide for dbt media player data model behavioral video analytics settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
+description: "Configuration guide for dbt unified data model cross-platform behavioral analytics settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/web/index.mdx
+description: "Configuration guide for legacy dbt web data model behavioral website analytics settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/index.md
+description: "Configuration guides for legacy dbt data models behavioral analytics settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/mobile/index.mdx
+description: "Configuration guide for legacy dbt mobile data model behavioral mobile analytics settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/fractribution/index.mdx
+description: "Configuration guide for legacy dbt fractribution data model behavioral attribution analytics settings."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/utils/index.mdx
+description: "Configuration guide for dbt utils package behavioral data modeling utility settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/normalize/index.mdx
+description: "Configuration guide for dbt normalize package behavioral data standardization settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/index.md
+description: "Configuration guides for dbt Snowplow packages behavioral data modeling settings and parameters."
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/attribution/index.mdx
+description: "Configuration guide for dbt attribution data model behavioral marketing analytics settings and parameters."
+
+docs/get-started/tooling/index.md
+description: "Essential tools and platforms for implementing Snowplow behavioral data infrastructure and analytics workflows."
+
+docs/get-started/feature-comparison/index.md
+description: "Compare Snowplow Community Edition and Behavioral Data Platform features for choosing the right behavioral analytics solution."
+
+docs/get-started/modeling/index.md
+description: "Introduction to data modeling concepts and approaches for transforming behavioral events into analytics insights."
+
+docs/get-started/failed-events/index.md
+description: "Understand and handle failed events in Snowplow behavioral data collection for maintaining data quality."
+
+docs/get-started/index.md
+description: "Complete getting started guide for implementing Snowplow behavioral data infrastructure and event analytics platform."
+
+docs/get-started/custom-events/index.md
+description: "Introduction to creating custom behavioral events for capturing unique business interactions and user behaviors."
+
+docs/get-started/tracking/cookies-and-ad-blockers/index.md
+description: "Handle cookies and ad blockers in behavioral event tracking for accurate data collection and user privacy."
+
+docs/get-started/tracking/index.md
+description: "Implement behavioral event tracking across web, mobile, and server-side applications using Snowplow trackers."
+
+docs/get-started/snowplow-bdp/setup-guide-gcp/index.md
+description: "Set up Snowplow Behavioral Data Platform on Google Cloud Platform for enterprise behavioral analytics infrastructure."
+
+docs/get-started/snowplow-bdp/index.md
+description: "Get started with Snowplow Behavioral Data Platform for enterprise-scale customer data infrastructure and analytics."
+
+docs/get-started/snowplow-bdp/setup-guide-azure/index.md
+description: "Deploy Snowplow Behavioral Data Platform on Microsoft Azure for enterprise behavioral analytics infrastructure."
+
+docs/get-started/snowplow-bdp/setup-guide-aws/index.md
+description: "Set up Snowplow Behavioral Data Platform on Amazon Web Services for enterprise behavioral analytics infrastructure."
+
+docs/get-started/querying/index.md
+description: "Query and analyze behavioral data in your data warehouse using SQL for business intelligence and insights."
+
+docs/get-started/snowplow-community-edition/faq/index.md
+description: "Frequently asked questions about Snowplow Community Edition open-source behavioral data platform."
+
+docs/get-started/snowplow-community-edition/what-is-deployed/index.md
+description: "Understand the infrastructure components deployed with Snowplow Community Edition behavioral data platform."
+
+docs/get-started/snowplow-community-edition/index.md
+description: "Deploy Snowplow Community Edition for open-source behavioral data collection and analytics infrastructure."
+
+docs/get-started/snowplow-community-edition/quick-start/index.md
+description: "Quick start guide for deploying Snowplow Community Edition behavioral data platform infrastructure."
+
+docs/get-started/snowplow-community-edition/telemetry/index.md
+description: "Telemetry and usage analytics collected by Snowplow Community Edition for platform improvement."
+
+docs/get-started/snowplow-community-edition/upgrade-guide/index.md
+description: "Upgrade guide for Snowplow Community Edition with behavioral data platform improvements and new features."
+
+docs/get-started/snowplow-community-edition/what-is-quick-start/index.md
+description: "Overview of Snowplow Community Edition Quick Start deployment options for behavioral data infrastructure."
+
+tutorials/unified-digital/setting-up-locally.md
+description: "Set up unified digital analytics locally for combining web and mobile behavioral data analysis."
+
+tutorials/unified-digital/setting-up-via-console.md
+description: "Configure unified digital analytics through Snowplow Console for cross-platform behavioral data modeling."
+
+tutorials/unified-digital/intro.md
+description: "Introduction to unified digital analytics for comprehensive cross-platform behavioral data insights."
+
+tutorials/unified-digital/viewing-output-data.md
+description: "View and analyze unified digital analytics output data for cross-platform behavioral insights."
+
+tutorials/kafka-live-viewer-profiles/conclusion.md
+description: "Conclusion and next steps for Kafka live viewer profiles tutorial for real-time behavioral data streaming."
+
+tutorials/kafka-live-viewer-profiles/quickstart-localstack.md
+description: "Quick start guide for Kafka live viewer with LocalStack for behavioral data streaming development."
+
+tutorials/kafka-live-viewer-profiles/introduction.md
+description: "Introduction to Kafka live viewer profiles for real-time behavioral data streaming and analysis."
+
+tutorials/kafka-live-viewer-profiles/deploy-aws-terraform.md
+description: "Deploy Kafka live viewer on AWS using Terraform for scalable behavioral data streaming infrastructure."
+
+tutorials/enrichments/enabling-via-terraform.md
+description: "Enable Snowplow enrichments using Terraform for automated behavioral data processing configuration."
+
+tutorials/enrichments/intro.md
+description: "Introduction to Snowplow enrichments for enhancing behavioral events with additional context and validation."
+
+tutorials/enrichments/configurable-enrichment-list.md
+description: "Configurable enrichment options for customizing behavioral data processing and enhancement workflows."
+
+tutorials/android-event-tracking/examining-events.md
+description: "Examine and validate Android behavioral events for mobile analytics implementation verification."
+
+tutorials/android-event-tracking/screen-views.md
+description: "Track screen view events in Android applications for mobile behavioral analytics and user journey analysis."
+
+tutorials/android-event-tracking/installation.md
+description: "Install and configure Android tracker for behavioral event collection in mobile applications."
+
+tutorials/data-structures-in-git/conclusion.md
+description: "Conclusion and best practices for managing Snowplow data structures using Git version control workflows."
+
+tutorials/data-structures-in-git/verify-github-setup.md
+description: "Verify GitHub setup for Snowplow data structure management and collaborative schema development workflows."
+
+tutorials/data-structures-in-git/follow-up-with-data-products.md
+description: "Follow up data structure management with data products for comprehensive behavioral data governance."
+
+tutorials/data-structures-in-git/introduction.md
+description: "Introduction to managing Snowplow data structures using Git for collaborative schema development workflows."
+
+tutorials/data-structures-in-git/validation-and-publishing.md
+description: "Validate and publish Snowplow data structures through Git workflows for behavioral data schema governance."
+
+tutorials/data-structures-in-git/automate-with-github-actions.md
+description: "Automate data structure workflows using GitHub Actions for continuous behavioral data schema management."
+
+tutorials/data-structures-in-git/local-setup.md
+description: "Set up local development environment for Git-based Snowplow data structure management workflows."
+
+tutorials/snowplow-cli-mcp/setup.md
+description: "Set up Snowplow CLI with Model Context Protocol for advanced behavioral data management automation."
+
+tutorials/snowplow-cli-mcp/introduction.md
+description: "Introduction to Snowplow CLI Model Context Protocol integration for behavioral data management workflows."
+
+tutorials/snowplow-cli-mcp/next-steps.md
+description: "Next steps and advanced usage for Snowplow CLI Model Context Protocol behavioral data management."
+
+tutorials/snowplow-cli-mcp/basic-workflow.md
+description: "Basic workflow for using Snowplow CLI with Model Context Protocol for behavioral data operations."
+
+tutorials/index.md
+description: "Step-by-step tutorials for implementing behavioral data collection, modeling, and analytics with Snowplow."
+
+tutorials/attribution/setting-up-locally.md
+description: "Set up marketing attribution modeling locally for behavioral data analysis and campaign optimization."
+
+tutorials/attribution/setting-up-via-console.md
+description: "Configure marketing attribution models through Snowplow Console for behavioral campaign analysis."
+
+tutorials/attribution/intro.md
+description: "Introduction to marketing attribution modeling using Snowplow behavioral data for multi-touch analysis."
+
+tutorials/attribution/optional-configuring-channel-group-classification.md
+description: "Configure channel group classification for marketing attribution behavioral data analysis customization."
+
+tutorials/attribution/before-you-start.md
+description: "Prerequisites and preparation for marketing attribution modeling with Snowplow behavioral data."
+
+tutorials/attribution/enabling-unified-conversions.md
+description: "Enable unified conversions tracking for comprehensive behavioral attribution modeling across platforms."
+
+tutorials/attribution/optional-adding-marketing-spend-source.md
+description: "Add marketing spend data sources to attribution models for ROI behavioral analysis optimization."
+
+tutorials/abandoned-browse-ccdp/reverse-etl.md
+description: "Implement reverse ETL for abandoned browse campaigns using behavioral data for customer re-engagement."
+
+tutorials/abandoned-browse-ccdp/conclusion.md
+description: "Conclusion and optimization strategies for abandoned browse behavioral data customer engagement campaigns."
+
+tutorials/abandoned-browse-ccdp/data-modeling.md
+description: "Model abandoned browse behavioral data for customer engagement and re-targeting campaign analysis."
+
+tutorials/abandoned-browse-ccdp/braze-campaign.md
+description: "Create Braze campaigns using abandoned browse behavioral data for personalized customer re-engagement."
+
+tutorials/abandoned-browse-ccdp/introduction.md
+description: "Introduction to abandoned browse customer data platform tutorial using behavioral analytics for re-engagement."
+
+tutorials/abandoned-browse-ccdp/tracking-setup.md
+description: "Set up tracking for abandoned browse behavioral events to power customer re-engagement campaigns."
+
+tutorials/data-products-base-tracking/create-custom-dp.md
+description: "Create custom data products for specialized behavioral data collection and governance requirements."
+
+tutorials/data-products-base-tracking/create-base-dp.md
+description: "Create base data products for foundational behavioral data collection and schema management."
+
+tutorials/data-products-base-tracking/setup-custom-ds.md
+description: "Set up custom data structures for specialized behavioral event tracking and validation requirements."
+
+tutorials/data-products-base-tracking/create-source-application.md
+description: "Create source applications for organizing behavioral event collection across different platforms and services."
+
+tutorials/data-products-base-tracking/add-event-specs.md
+description: "Add event specifications to data products for standardized behavioral data collection workflows."
+
+tutorials/data-products-base-tracking/snowtype.md
+description: "Use Snowtype for type-safe behavioral event tracking code generation in data products workflow."
+
+tutorials/data-products-base-tracking/verify-dp-events.md
+description: "Verify data product events for accurate behavioral data collection and schema compliance validation."
+
+tutorials/data-products-base-tracking/start.md
+description: "Getting started with data products for behavioral event tracking and schema governance workflows."
+
+tutorials/data-products-base-tracking/generate-tracking-code.md
+description: "Generate tracking code from data products for consistent behavioral event collection implementation."
+
+tutorials/data-products-base-tracking/setup-basic-tracking.md
+description: "Set up basic tracking implementation using data products for behavioral event collection workflows."
+
+tutorials/flink-live-shopper-features/conclusion.md
+description: "Conclusion and optimization strategies for Flink live shopper features using behavioral data streaming."
+
+tutorials/flink-live-shopper-features/add-calculation.md
+description: "Add custom calculations to Flink live shopper features for real-time behavioral data processing."
+
+tutorials/flink-live-shopper-features/introduction.md
+description: "Introduction to building live shopper features using Apache Flink and behavioral data streaming."
+
+tutorials/flink-live-shopper-features/run.md
+description: "Run and deploy Flink live shopper features for real-time behavioral data processing and personalization."
+
+tutorials/flink-live-shopper-features/calculations.md
+description: "Implement behavioral data calculations for live shopper features using Apache Flink stream processing."

--- a/plugins/docusaurus-plugin-snowplow-schema/src/schemaData/keywords.md
+++ b/plugins/docusaurus-plugin-snowplow-schema/src/schemaData/keywords.md
@@ -1,0 +1,3042 @@
+docs/fundamentals/canonical-event/understanding-the-enriched-tsv-format/index.md
+"Canonical Event", "Enriched TSV", "Event Format", "TSV Schema", "Data Structure", "Event Processing"
+
+docs/fundamentals/canonical-event/index.md
+"Canonical Event", "Event Model", "Snowplow Events", "Data Schema", "Event Structure", "Analytics Model"
+
+docs/fundamentals/destinations/index.md
+"Data Destinations", "Event Storage", "Warehouse Loading", "Data Export", "Pipeline Output", "Analytics Storage"
+
+docs/fundamentals/schemas/index.md
+"JSON Schema", "Data Validation", "Schema Registry", "Event Schema", "Iglu Schema", "Data Structure"
+
+docs/fundamentals/failed-events/index.md
+"Failed Events", "Error Handling", "Event Validation", "Data Quality", "Pipeline Errors", "Event Recovery"
+
+docs/fundamentals/index.md
+"Snowplow Fundamentals", "Analytics Platform", "Event Tracking", "Data Pipeline", "Customer Analytics", "Behavioral Data"
+
+docs/fundamentals/data-products/index.md
+"Data Products", "Analytics Assets", "Data Management", "Product Analytics", "Event Modeling", "Data Governance"
+
+docs/fundamentals/events/index.md
+"Event Tracking", "Analytics Events", "Behavioral Events", "Custom Events", "Event Types", "Data Collection"
+
+docs/fundamentals/entities/index.md
+"Event Entities", "Context Data", "Entity Schema", "Event Context", "Data Enrichment", "Structured Data"
+
+docs/pipeline/security/customer-managed-keys/index.md
+"Customer Keys", "Data Encryption", "Security Pipeline", "Key Management", "Privacy Security", "Data Protection"
+
+docs/pipeline/security/index.md
+"Pipeline Security", "Data Privacy", "Encryption", "Access Control", "Security Model", "Data Protection"
+
+docs/pipeline/enrichments/filtering-bot-events/index.md
+"Bot Filtering", "Traffic Quality", "Bot Detection", "Event Filtering", "Data Quality", "Spam Prevention"
+
+docs/pipeline/enrichments/available-enrichments/iab-enrichment/index.md
+"IAB Enrichment", "Ad Blocking", "Traffic Classification", "Bot Detection", "IAB Standards", "Quality Filter"
+
+docs/pipeline/enrichments/available-enrichments/campaign-attribution-enrichment/index.md
+"Campaign Attribution", "Marketing Attribution", "UTM Tracking", "Campaign Analysis", "Attribution Model", "Marketing Analytics"
+
+docs/pipeline/enrichments/available-enrichments/cookie-extractor-enrichment/index.md
+"Cookie Extraction", "Cookie Parsing", "Cookie Data", "Web Analytics", "Session Data", "Browser Cookies"
+
+docs/pipeline/enrichments/available-enrichments/custom-api-request-enrichment/index.md
+"API Enrichment", "Custom Enrichment", "External API", "Data Enrichment", "Third Party", "API Integration"
+
+docs/pipeline/enrichments/available-enrichments/http-header-extractor-enrichment/index.md
+"HTTP Headers", "Header Extraction", "Request Headers", "Web Headers", "HTTP Data", "Header Parsing"
+
+docs/pipeline/enrichments/available-enrichments/event-fingerprint-enrichment/index.md
+"Event Fingerprint", "Event Deduplication", "Duplicate Detection", "Data Quality", "Event Uniqueness", "Fingerprinting"
+
+docs/pipeline/enrichments/available-enrichments/ip-lookup-enrichment/index.md
+"IP Geolocation", "IP Lookup", "Geographic Data", "Location Enrichment", "GeoIP", "IP Intelligence"
+
+docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+"Referrer Parsing", "Traffic Source", "Referrer Analysis", "Source Attribution", "Web Analytics", "Traffic Analysis"
+
+docs/pipeline/enrichments/available-enrichments/yauaa-enrichment/index.md
+"User Agent", "Device Detection", "Browser Analysis", "YAUAA Parser", "Device Intelligence", "Browser Parsing"
+
+docs/pipeline/enrichments/available-enrichments/index.md
+"Data Enrichments", "Pipeline Enrichment", "Event Enhancement", "Data Processing", "Analytics Enhancement", "Event Enrichment"
+
+docs/pipeline/enrichments/available-enrichments/ua-parser-enrichment/index.md
+"User Agent", "UA Parsing", "Browser Detection", "Device Analysis", "Browser Intelligence", "Agent Parser"
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/testing/index.md
+"JavaScript Testing", "Enrichment Testing", "Custom Logic", "JS Validation", "Test Framework", "Code Testing"
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/index.md
+"JavaScript Enrichment", "Custom JS", "Event Processing", "JavaScript Logic", "Custom Code", "JS Enhancement"
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/examples/index.md
+"JS Examples", "Enrichment Examples", "JavaScript Code", "Custom Logic", "Code Samples", "Implementation Guide"
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/writing/index.md
+"Writing JavaScript", "JS Development", "Enrichment Code", "Custom Functions", "JavaScript Guide", "Code Writing"
+
+docs/pipeline/enrichments/available-enrichments/custom-sql-enrichment/index.md
+"SQL Enrichment", "Custom SQL", "Database Query", "SQL Logic", "Data Query", "SQL Processing"
+
+docs/pipeline/enrichments/available-enrichments/pii-pseudonymization-enrichment/index.md
+"PII Pseudonymization", "Privacy Protection", "Data Anonymization", "GDPR Compliance", "Personal Data", "Privacy Enhancement"
+
+docs/pipeline/enrichments/available-enrichments/currency-conversion-enrichment/index.md
+"Currency Conversion", "Exchange Rates", "Multi Currency", "Financial Data", "Currency Analytics", "Conversion Rates"
+
+docs/pipeline/enrichments/available-enrichments/cross-navigation-enrichment/index.md
+"Cross Navigation", "Navigation Analysis", "User Journey", "Session Flow", "Page Flow", "Navigation Tracking"
+
+docs/pipeline/enrichments/available-enrichments/ip-anonymization-enrichment/index.md
+"IP Anonymization", "Privacy Protection", "IP Masking", "GDPR Compliance", "Data Privacy", "IP Security"
+
+docs/pipeline/enrichments/managing-enrichments/terraform/index.md
+"Terraform Management", "Infrastructure Code", "Enrichment Deployment", "IaC", "Terraform Config", "Infrastructure Automation"
+
+docs/pipeline/enrichments/managing-enrichments/index.md
+"Enrichment Management", "Pipeline Config", "Enrichment Setup", "Data Processing", "Pipeline Management", "Configuration"
+
+docs/pipeline/enrichments/index.md
+"Data Enrichments", "Event Enhancement", "Pipeline Processing", "Data Transformation", "Analytics Enhancement", "Event Processing"
+
+docs/pipeline/collector/index.md
+"Event Collector", "Data Collection", "Tracking Endpoint", "Event Ingestion", "Data Intake", "Collection Pipeline"
+
+docs/pipeline/index.md
+"Data Pipeline", "Event Processing", "Analytics Pipeline", "Data Flow", "Processing Engine", "Pipeline Architecture"
+
+docs/data-product-studio/data-structures/index.md
+"Data Structures", "Schema Management", "Event Schema", "Data Models", "Structure Definition", "Schema Design"
+
+docs/data-product-studio/data-structures/version-amend/amending/index.md
+"Schema Amending", "Version Control", "Schema Updates", "Structure Changes", "Schema Evolution", "Version Management"
+
+docs/data-product-studio/data-structures/version-amend/enterprise/index.md
+"Enterprise Schema", "Schema Management", "Enterprise Features", "Advanced Schema", "Business Schema", "Schema Governance"
+
+docs/data-product-studio/data-structures/version-amend/index.md
+"Schema Versioning", "Version Control", "Schema Evolution", "Structure Updates", "Version Management", "Schema Changes"
+
+docs/data-product-studio/data-structures/version-amend/iglu/index.md
+"Iglu Schema", "Schema Registry", "Iglu Server", "Schema Storage", "Schema Repository", "Iglu Management"
+
+docs/data-product-studio/data-structures/version-amend/builder/index.md
+"Schema Builder", "Visual Editor", "Schema Creation", "Structure Builder", "Schema Design", "Visual Tool"
+
+docs/data-product-studio/data-structures/manage/cli/index.md
+"CLI Management", "Command Line", "Schema CLI", "Developer Tools", "Terminal Interface", "CLI Commands"
+
+docs/data-product-studio/data-structures/manage/json-editor/index.md
+"JSON Editor", "Schema Editor", "Code Editor", "JSON Schema", "Manual Editing", "Schema Code"
+
+docs/data-product-studio/data-structures/manage/index.md
+"Schema Management", "Structure Admin", "Schema Control", "Data Governance", "Schema Operations", "Structure Management"
+
+docs/data-product-studio/data-structures/manage/api/index.md
+"Schema API", "Management API", "REST API", "API Integration", "Programmatic Access", "API Endpoints"
+
+docs/data-product-studio/data-structures/manage/iglu/index.md
+"Iglu Management", "Schema Registry", "Iglu Admin", "Schema Control", "Registry Management", "Iglu Operations"
+
+docs/data-product-studio/data-structures/manage/builder/index.md
+"Builder Management", "Visual Management", "Schema Builder", "GUI Management", "Visual Control", "Builder Interface"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/flink/index.md
+"Flink Recovery", "Stream Processing", "Event Recovery", "Flink Jobs", "Real Time", "Stream Recovery"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/index.md
+"Manual Recovery", "Event Recovery", "Failed Events", "Data Recovery", "Event Repair", "Manual Process"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/gcp-beam/index.md
+"Beam Recovery", "Google Cloud", "Dataflow Recovery", "Beam Processing", "GCP Pipeline", "Cloud Recovery"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/spark/index.md
+"Spark Recovery", "Batch Processing", "Spark Jobs", "Event Recovery", "Big Data", "Spark Processing"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/configuration/index.md
+"Recovery Configuration", "Recovery Setup", "Config Management", "Recovery Settings", "Configuration Guide", "Setup Process"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/configuration/configuration-examples/index.md
+"Config Examples", "Recovery Examples", "Configuration Samples", "Setup Examples", "Config Templates", "Example Configs"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/troubleshooting/index.md
+"Recovery Troubleshooting", "Error Resolution", "Debug Guide", "Problem Solving", "Issue Resolution", "Recovery Issues"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/testing/index.md
+"Recovery Testing", "Test Recovery", "Validation Testing", "Recovery Verification", "Test Process", "Quality Testing"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/getting-started/index.md
+"Recovery Guide", "Getting Started", "Recovery Setup", "Initial Setup", "Recovery Basics", "Start Guide"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/index.md
+"Manual Recovery", "Event Recovery", "Failed Events", "Data Recovery", "Manual Process", "Event Repair"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/extending/index.md
+"Recovery Extension", "Custom Recovery", "Extended Recovery", "Advanced Recovery", "Recovery Enhancement", "Custom Logic"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/monitoring/index.md
+"Recovery Monitoring", "Process Monitoring", "Recovery Metrics", "Performance Monitoring", "Recovery Tracking", "Monitoring Tools"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/hints-workflows/index.md
+"Recovery Workflows", "Process Hints", "Recovery Tips", "Workflow Guide", "Best Practices", "Process Optimization"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/index.md
+"Event Recovery", "Failed Events", "Data Recovery", "Event Repair", "Quality Recovery", "Data Restoration"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/builder/index.md
+"Builder Recovery", "Visual Recovery", "GUI Recovery", "Recovery Interface", "Visual Tools", "Builder Interface"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/troubleshooting/index.md
+"Monitoring Troubleshooting", "Alert Issues", "Monitor Problems", "Debug Monitoring", "Alert Debugging", "Monitor Troubleshooting"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/classic-alerts/index.md
+"Classic Alerts", "Legacy Alerts", "Traditional Alerts", "Alert System", "Notification System", "Alert Management"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/index.md
+"Event Alerts", "Monitoring Alerts", "Quality Alerts", "Alert System", "Notification Management", "Alert Configuration"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/creating-alerts/index.md
+"Creating Alerts", "Alert Setup", "Alert Configuration", "Alert Creation", "Notification Setup", "Alert Builder"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/managing-alerts/index.md
+"Alert Management", "Managing Alerts", "Alert Administration", "Alert Control", "Notification Management", "Alert Operations"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/index.md
+"Failed Event Alerts", "Event Monitoring", "Quality Alerts", "Error Alerts", "Event Notifications", "Failure Alerts"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/index.md
+"Event Monitoring", "Failed Events", "Quality Monitoring", "Event Tracking", "Data Quality", "Monitor Events"
+
+docs/data-product-studio/data-quality/failed-events/exploring-failed-events/file-storage/index.md
+"File Storage", "Event Storage", "Failed Events", "Storage Analysis", "File Analysis", "Storage Explorer"
+
+docs/data-product-studio/data-quality/failed-events/exploring-failed-events/index.md
+"Exploring Events", "Event Analysis", "Failed Events", "Event Investigation", "Data Exploration", "Event Debugging"
+
+docs/data-product-studio/data-quality/failed-events/index.md
+"Failed Events", "Data Quality", "Event Errors", "Quality Management", "Event Validation", "Error Handling"
+
+docs/data-product-studio/data-quality/index.md
+"Data Quality", "Quality Management", "Data Validation", "Quality Control", "Data Monitoring", "Quality Assurance"
+
+docs/data-product-studio/data-quality/snowplow-micro/ui/index.md
+"Micro UI", "Testing Interface", "Micro Interface", "Testing Tool", "Development UI", "Micro Dashboard"
+
+docs/data-product-studio/data-quality/snowplow-micro/configuring-enrichments/index.md
+"Micro Enrichments", "Testing Enrichments", "Local Enrichments", "Enrichment Testing", "Development Setup", "Micro Configuration"
+
+docs/data-product-studio/data-quality/snowplow-micro/automated-testing/index.md
+"Automated Testing", "Test Automation", "Micro Testing", "Testing Framework", "Automated QA", "Test Suite"
+
+docs/data-product-studio/data-quality/snowplow-micro/adding-schemas/index.md
+"Micro Schemas", "Testing Schemas", "Local Schemas", "Schema Testing", "Development Schemas", "Schema Setup"
+
+docs/data-product-studio/data-quality/snowplow-micro/remote-usage/index.md
+"Remote Micro", "Remote Testing", "Micro Remote", "Distributed Testing", "Remote Access", "Remote Development"
+
+docs/data-product-studio/data-quality/snowplow-micro/advanced-usage/index.md
+"Advanced Micro", "Micro Advanced", "Advanced Testing", "Power Features", "Expert Usage", "Advanced Features"
+
+docs/data-product-studio/data-quality/snowplow-micro/basic-usage/index.md
+"Micro Basics", "Basic Testing", "Getting Started", "Micro Introduction", "Testing Basics", "Basic Setup"
+
+docs/data-product-studio/data-quality/snowplow-micro/index.md
+"Snowplow Micro", "Local Testing", "Development Tool", "Testing Environment", "Micro Pipeline", "Testing Framework"
+
+docs/data-product-studio/data-quality/snowplow-inspector/adding-schemas/index.md
+"Inspector Schemas", "Browser Extension", "Schema Validation", "Inspector Tool", "Browser Debugging", "Schema Inspector"
+
+docs/data-product-studio/data-quality/snowplow-inspector/importing-events/index.md
+"Event Import", "Inspector Events", "Event Debugging", "Browser Events", "Event Analysis", "Inspector Import"
+
+docs/data-product-studio/data-quality/snowplow-inspector/index.md
+"Snowplow Inspector", "Browser Extension", "Event Debugging", "Browser Tool", "Debugging Extension", "Inspector Tool"
+
+docs/data-product-studio/data-quality/data-structures-ci-tool/index.md
+"CI Tool", "Continuous Integration", "Schema CI", "Automated Testing", "CI Pipeline", "Schema Validation"
+
+docs/data-product-studio/event-specifications/tracking-plans/index.md
+"Tracking Plans", "Event Planning", "Analytics Plan", "Event Specification", "Tracking Strategy", "Event Documentation"
+
+docs/data-product-studio/event-specifications/index.md
+"Event Specifications", "Event Specs", "Analytics Specifications", "Event Definition", "Tracking Specs", "Event Documentation"
+
+docs/data-product-studio/event-specifications/api/index.md
+"Specifications API", "Event API", "Specs API", "API Management", "Specification Management", "API Interface"
+
+docs/data-product-studio/snowplow-cli/index.md
+"Snowplow CLI", "Command Line", "Developer Tools", "CLI Interface", "Terminal Tools", "Command Interface"
+
+docs/data-product-studio/snowplow-cli/reference/index.md
+"CLI Reference", "Command Reference", "CLI Documentation", "Command Guide", "CLI Commands", "Reference Guide"
+
+docs/data-product-studio/source-applications/index.md
+"Source Applications", "App Management", "Application Sources", "App Configuration", "Source Setup", "Application Registry"
+
+docs/data-product-studio/index.md
+"Data Product Studio", "Product Management", "Data Products", "Analytics Studio", "Product Analytics", "Data Management"
+
+docs/data-product-studio/snowtype/client-side-validation/index.md
+"Client Validation", "TypeScript Validation", "Client Side", "Type Validation", "Frontend Validation", "Browser Validation"
+
+docs/data-product-studio/snowtype/snowtype-config/index.md
+"Snowtype Configuration", "TypeScript Config", "Type Configuration", "Config Setup", "Type Settings", "Configuration Guide"
+
+docs/data-product-studio/snowtype/working-with-gtm/index.md
+"GTM Integration", "Google Tag Manager", "GTM Setup", "Tag Management", "GTM Configuration", "Tag Integration"
+
+docs/data-product-studio/snowtype/index.md
+"Snowtype", "TypeScript Types", "Type Generation", "Type Safety", "TypeScript Integration", "Code Generation"
+
+docs/data-product-studio/snowtype/commands/index.md
+"Snowtype Commands", "Type Commands", "CLI Commands", "TypeScript CLI", "Command Reference", "Type Generation"
+
+docs/data-product-studio/snowtype/using-the-cli/index.md
+"Snowtype CLI", "Type CLI", "Command Usage", "CLI Guide", "TypeScript CLI", "CLI Interface"
+
+docs/data-product-studio/data-products/ui/index.md
+"Data Products UI", "Product Interface", "Management UI", "Product Dashboard", "Visual Interface", "Product Management"
+
+docs/data-product-studio/data-products/data-product-templates/index.md
+"Product Templates", "Data Templates", "Template Library", "Product Blueprints", "Template Gallery", "Reusable Templates"
+
+docs/data-product-studio/data-products/cli/index.md
+"Data Products CLI", "Product CLI", "Command Interface", "CLI Management", "Product Commands", "CLI Tools"
+
+docs/data-product-studio/data-products/index.md
+"Data Products", "Product Analytics", "Analytics Products", "Product Management", "Data Assets", "Product Suite"
+
+docs/data-product-studio/data-products/api/index.md
+"Data Products API", "Product API", "Management API", "Product Integration", "API Interface", "Product Endpoints"
+
+docs/account-management/managing-users/index.md
+"User Management", "Account Users", "User Administration", "Access Control", "User Permissions", "Account Access"
+
+docs/account-management/index.md
+"Account Management", "User Administration", "Account Settings", "Organization Management", "Account Control", "User Access"
+
+docs/account-management/managing-permissions/index.md
+"Permission Management", "Access Control", "User Permissions", "Role Management", "Security Permissions", "Access Rights"
+
+docs/destinations/reverse-etl/index.md
+"Reverse ETL", "Data Activation", "Customer Data", "Data Sync", "Operational Analytics", "Data Export"
+
+docs/destinations/index.md
+"Data Destinations", "Event Export", "Data Warehouses", "Storage Targets", "Analytics Destinations", "Data Output"
+
+docs/destinations/forwarding-events/native-integrations/index.md
+"Native Integrations", "Event Forwarding", "Built-in Integrations", "Native Connectors", "Platform Integrations", "Event Export"
+
+docs/destinations/forwarding-events/custom-integrations/index.md
+"Custom Integrations", "Custom Export", "Custom Destinations", "Integration Development", "Custom Connectors", "Bespoke Integration"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/index.md
+"Event Transformations", "Data Transformation", "Event Processing", "Data Mapping", "Event Modification", "Transform Events"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/javascript-configuration/index.md
+"JavaScript Config", "JS Transformation", "Custom JavaScript", "Script Configuration", "JS Config", "JavaScript Setup"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/index.md
+"Custom Scripts", "Transformation Scripts", "Custom Logic", "Script Processing", "Custom Code", "Script Transformation"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/custom-scripts/examples/index.md
+"Script Examples", "Transformation Examples", "Code Examples", "Script Samples", "Example Scripts", "Code Samples"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jq.md
+"JQ Transformation", "JSON Processing", "JQ Filter", "JSON Manipulation", "Data Processing", "JQ Query"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterContext.md
+"Context Filter", "Event Context", "Context Processing", "Entity Filtering", "Context Data", "Event Entities"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Encode.md
+"Base64 Encode", "Data Encoding", "Binary Encoding", "String Encoding", "Encode Transform", "Data Conversion"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spGtmssPreview.md
+"GTM Preview", "Server Side", "GTM Processing", "Tag Manager", "Preview Mode", "GTM Integration"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilter.md
+"Event Filter", "Enriched Filter", "Event Processing", "Data Filtering", "Event Selection", "Filter Logic"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/index.md
+"Built-in Transformations", "Native Transforms", "Standard Transforms", "Default Processing", "Core Transforms", "Built-in Functions"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/jqFilter.md
+"JQ Filter", "JSON Filter", "Query Filter", "Data Filter", "JSON Query", "Filter Expression"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/base64Decode.md
+"Base64 Decode", "Data Decoding", "Binary Decoding", "String Decoding", "Decode Transform", "Data Conversion"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedSetPk.md
+"Partition Key", "Event Partitioning", "Key Setting", "Data Partitioning", "PK Setting", "Partition Strategy"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedToJson.md
+"JSON Conversion", "Event JSON", "Data Format", "JSON Transform", "Format Conversion", "JSON Output"
+
+docs/destinations/forwarding-events/snowbridge/configuration/transformations/builtin/spEnrichedFilterUnstructEvent.md
+"Event Filtering", "Unstructured Events", "Event Selection", "Custom Events", "Event Types", "Event Processing"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/kafka.md
+"Kafka Target", "Kafka Export", "Stream Export", "Kafka Integration", "Message Queue", "Event Streaming"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/pubsub.md
+"PubSub Target", "Google PubSub", "Message Queue", "GCP Integration", "Stream Export", "Event Streaming"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/eventhub.md
+"Event Hub", "Azure EventHub", "Azure Integration", "Stream Export", "Message Queue", "Event Streaming"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/sqs.md
+"SQS Target", "Amazon SQS", "AWS Integration", "Message Queue", "Queue Export", "Event Queuing"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/index.md
+"Export Targets", "Data Targets", "Event Destinations", "Output Configuration", "Target Setup", "Export Configuration"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/http/google-tag-manager.md
+"GTM HTTP", "Tag Manager", "HTTP Export", "GTM Integration", "Server Side", "Tag Management"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/http/index.md
+"HTTP Target", "HTTP Export", "Webhook Export", "API Export", "HTTP Integration", "REST Export"
+
+docs/destinations/forwarding-events/snowbridge/configuration/targets/kinesis.md
+"Kinesis Target", "AWS Kinesis", "Stream Export", "AWS Integration", "Data Streaming", "Event Streaming"
+
+docs/destinations/forwarding-events/snowbridge/configuration/index.md
+"Snowbridge Configuration", "Event Forwarding", "Export Setup", "Configuration Guide", "Setup Process", "Export Configuration"
+
+docs/destinations/forwarding-events/snowbridge/configuration/retries/index.md
+"Retry Configuration", "Error Handling", "Retry Logic", "Failure Recovery", "Retry Strategy", "Error Recovery"
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/kafka.md
+"Kafka Source", "Kafka Input", "Stream Input", "Event Ingestion", "Kafka Integration", "Message Source"
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/pubsub.md
+"PubSub Source", "Google PubSub", "GCP Source", "Stream Input", "Message Source", "Event Ingestion"
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/sqs.md
+"SQS Source", "Amazon SQS", "AWS Source", "Queue Source", "Message Source", "Event Ingestion"
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/index.md
+"Event Sources", "Data Sources", "Input Configuration", "Source Setup", "Event Ingestion", "Input Sources"
+
+docs/destinations/forwarding-events/snowbridge/configuration/sources/kinesis.md
+"Kinesis Source", "AWS Kinesis", "Stream Source", "AWS Integration", "Data Ingestion", "Event Streaming"
+
+docs/destinations/forwarding-events/snowbridge/configuration/telemetry/index.md
+"Telemetry Configuration", "Monitoring Setup", "Metrics Collection", "Performance Monitoring", "System Monitoring", "Observability"
+
+docs/destinations/forwarding-events/snowbridge/configuration/monitoring/index.md
+"Monitoring Configuration", "System Monitoring", "Performance Monitoring", "Health Monitoring", "Monitoring Setup", "Observability"
+
+docs/destinations/forwarding-events/snowbridge/3-X-X-upgrade-guide/index.md
+"Snowbridge Upgrade", "Version Migration", "Upgrade Guide", "Migration Guide", "Version Update", "Breaking Changes"
+
+docs/destinations/forwarding-events/snowbridge/testing/index.md
+"Snowbridge Testing", "Integration Testing", "Testing Framework", "Export Testing", "Test Configuration", "Quality Testing"
+
+docs/destinations/forwarding-events/snowbridge/getting-started/index.md
+"Snowbridge Setup", "Getting Started", "Installation Guide", "Initial Setup", "Quick Start", "Setup Guide"
+
+docs/destinations/forwarding-events/snowbridge/index.md
+"Snowbridge", "Event Forwarding", "Real Time Export", "Event Streaming", "Data Export", "Event Processing"
+
+docs/destinations/forwarding-events/snowbridge/concepts/transformations/index.md
+"Transformation Concepts", "Data Transformation", "Event Processing", "Transform Logic", "Data Mapping", "Processing Concepts"
+
+docs/destinations/forwarding-events/snowbridge/concepts/batching-model/index.md
+"Batching Model", "Batch Processing", "Event Batching", "Batch Strategy", "Performance Optimization", "Throughput Management"
+
+docs/destinations/forwarding-events/snowbridge/concepts/targets/index.md
+"Target Concepts", "Export Targets", "Destination Types", "Target Architecture", "Export Strategy", "Target Design"
+
+docs/destinations/forwarding-events/snowbridge/concepts/scaling/index.md
+"Scaling Concepts", "Performance Scaling", "Load Management", "Capacity Planning", "Scale Strategy", "Throughput Scaling"
+
+docs/destinations/forwarding-events/snowbridge/concepts/index.md
+"Snowbridge Concepts", "Architecture Overview", "Core Concepts", "Design Principles", "System Architecture", "Conceptual Model"
+
+docs/destinations/forwarding-events/snowbridge/concepts/sources/index.md
+"Source Concepts", "Input Sources", "Source Architecture", "Source Design", "Input Strategy", "Source Types"
+
+docs/destinations/forwarding-events/snowbridge/concepts/failure-model/index.md
+"Failure Model", "Error Handling", "Failure Strategy", "Error Recovery", "Fault Tolerance", "Resilience Design"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/http-request-tag-for-gtm-ss/index.md
+"GTM HTTP Tag", "Server Side", "HTTP Request", "Tag Manager", "GTM Integration", "Server Side Tags"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/http-request-tag-for-gtm-ss/http-request-tag-configuration/index.md
+"HTTP Tag Config", "GTM Configuration", "Tag Setup", "HTTP Configuration", "Server Side Config", "Tag Configuration"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-tag-for-gtm-ss/snowplow-tag-configuration/advanced-event-settings/index.md
+"Advanced Settings", "Tag Configuration", "Event Settings", "Advanced Config", "Tag Options", "Configuration Options"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-tag-for-gtm-ss/snowplow-tag-configuration/index.md
+"Snowplow Tag Config", "GTM Configuration", "Tag Setup", "Server Side Config", "Tag Configuration", "GTM Setup"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-tag-for-gtm-ss/index.md
+"Snowplow GTM Tag", "Server Side Tag", "GTM Integration", "Tag Manager", "Snowplow Tag", "Server Side"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/testing/index.md
+"GTM Testing", "Server Side Testing", "Tag Testing", "GTM Validation", "Testing Framework", "Tag Validation"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/index.md
+"Snowplow Client", "GTM Client", "Server Side Client", "Client Template", "GTM Integration", "Client Setup"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/snowplow-client-for-gtm-ss/snowplow-client-configuration/index.md
+"Client Configuration", "GTM Client Config", "Client Setup", "Server Side Config", "Client Options", "GTM Configuration"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/index.md
+"GTM Server Side", "Google Tag Manager", "Server Side", "Tag Manager", "GTM Integration", "Server Side Tagging"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/braze-tag-for-gtm-ss/braze-tag-configuration/index.md
+"Braze Tag Config", "Braze Integration", "GTM Braze", "Tag Configuration", "Marketing Automation", "Braze Setup"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/braze-tag-for-gtm-ss/index.md
+"Braze GTM Tag", "Braze Integration", "Marketing Tag", "Customer Engagement", "GTM Braze", "Marketing Automation"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/amplitude-tag-for-gtm-ss/index.md
+"Amplitude Tag", "Analytics Integration", "GTM Amplitude", "Product Analytics", "Event Tracking", "Analytics Tag"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/amplitude-tag-for-gtm-ss/amplitude-tag-configuration/index.md
+"Amplitude Config", "Analytics Config", "Tag Configuration", "Amplitude Setup", "Analytics Integration", "Event Configuration"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/iterable-tag-for-gtm-ss/index.md
+"Iterable Tag", "Email Marketing", "Marketing Automation", "GTM Iterable", "Campaign Management", "Customer Engagement"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/iterable-tag-for-gtm-ss/iterable-tag-configuration/index.md
+"Iterable Config", "Marketing Config", "Email Configuration", "Campaign Setup", "Marketing Automation", "Iterable Setup"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/index.md
+"LaunchDarkly Tag", "Feature Flags", "A/B Testing", "Feature Management", "GTM LaunchDarkly", "Experimentation"
+
+docs/destinations/forwarding-events/google-tag-manager-server-side/launchdarkly-tag-for-gtm-ss/launchdarkly-tag-configuration/index.md
+"LaunchDarkly Config", "Feature Flag Config", "Experimentation Setup", "A/B Test Config", "Feature Management", "Flag Configuration"
+
+docs/destinations/forwarding-events/index.md
+"Event Forwarding", "Real Time Export", "Event Streaming", "Data Export", "Event Distribution", "Live Data"
+
+docs/destinations/warehouses-lakes/loading-process/index.md
+"Data Loading", "Warehouse Loading", "ETL Process", "Data Ingestion", "Batch Loading", "Data Pipeline"
+
+docs/destinations/warehouses-lakes/querying-data/index.md
+"Data Querying", "SQL Queries", "Analytics Queries", "Data Analysis", "Query Optimization", "Data Exploration"
+
+docs/destinations/warehouses-lakes/schemas-in-warehouse/index.md
+"Warehouse Schemas", "Data Schemas", "Table Structure", "Database Schema", "Data Models", "Schema Design"
+
+docs/destinations/warehouses-lakes/index.md
+"Data Warehouses", "Data Lakes", "Storage Solutions", "Analytics Storage", "Big Data Storage", "Data Storage"
+
+docs/sources/trackers/rust-tracker/initialization-and-configuration/index.md
+"Rust Tracker", "Rust Configuration", "Tracker Setup", "Rust Analytics", "Configuration Guide", "Rust Integration"
+
+docs/sources/trackers/rust-tracker/adding-data/index.md
+"Rust Data", "Event Data", "Tracker Data", "Data Collection", "Rust Events", "Custom Data"
+
+docs/sources/trackers/rust-tracker/tracking-events/index.md
+"Rust Events", "Event Tracking", "Rust Analytics", "Behavior Tracking", "Event Collection", "Analytics Events"
+
+docs/sources/trackers/rust-tracker/getting-started/index.md
+"Rust Tracker", "Getting Started", "Rust Setup", "Quick Start", "Installation Guide", "Rust Guide"
+
+docs/sources/trackers/rust-tracker/index.md
+"Rust Tracker", "Rust Analytics", "Event Tracking", "Rust SDK", "Analytics SDK", "Rust Integration"
+
+docs/sources/trackers/react-native-tracker/anonymous-tracking/index.md
+"Anonymous Tracking", "Privacy Tracking", "React Native", "User Privacy", "Anonymous Analytics", "Privacy Protection"
+
+docs/sources/trackers/react-native-tracker/custom-tracking-using-schemas/index.md
+"Custom Tracking", "React Native", "Custom Events", "Schema Tracking", "Event Schemas", "Custom Analytics"
+
+docs/sources/trackers/react-native-tracker/custom-tracking-using-schemas/global-context/index.md
+"Global Context", "React Native", "Event Context", "Context Data", "Global Entities", "Context Tracking"
+
+docs/sources/trackers/react-native-tracker/tracking-events/platform-and-application-context/index.md
+"Platform Context", "App Context", "React Native", "Device Context", "Application Data", "Platform Data"
+
+docs/sources/trackers/react-native-tracker/tracking-events/lifecycle-tracking/index.md
+"Lifecycle Tracking", "App Lifecycle", "React Native", "App Events", "Lifecycle Events", "App State"
+
+docs/sources/trackers/react-native-tracker/tracking-events/installation-tracking/index.md
+"Installation Tracking", "App Install", "React Native", "Install Events", "First Launch", "App Installation"
+
+docs/sources/trackers/react-native-tracker/tracking-events/index.md
+"React Native Events", "Event Tracking", "Mobile Events", "App Analytics", "Event Collection", "Mobile Analytics"
+
+docs/sources/trackers/react-native-tracker/tracking-events/screen-tracking/index.md
+"Screen Tracking", "Screen Views", "React Native", "Navigation Tracking", "Screen Analytics", "Page Views"
+
+docs/sources/trackers/react-native-tracker/tracking-events/session-tracking/index.md
+"Session Tracking", "User Sessions", "React Native", "Session Analytics", "Session Management", "User Activity"
+
+docs/sources/trackers/react-native-tracker/client-side-properties/index.md
+"Client Properties", "React Native", "Device Properties", "Client Data", "Device Information", "Client Context"
+
+docs/sources/trackers/react-native-tracker/advanced-usage/index.md
+"Advanced Usage", "React Native", "Advanced Features", "Expert Guide", "Advanced Analytics", "Power Features"
+
+docs/sources/trackers/react-native-tracker/hybrid-apps/index.md
+"Hybrid Apps", "React Native", "WebView Tracking", "Cross Platform", "Hybrid Analytics", "WebView Integration"
+
+docs/sources/trackers/react-native-tracker/index.md
+"React Native Tracker", "Mobile Analytics", "React Native", "Mobile Tracking", "Cross Platform", "Mobile SDK"
+
+docs/sources/trackers/react-native-tracker/quick-start-guide/index.md
+"React Native Guide", "Quick Start", "Getting Started", "Setup Guide", "Installation Guide", "Mobile Setup"
+
+docs/sources/trackers/golang-tracker/setup/index.md
+"Golang Setup", "Go Tracker", "Go Configuration", "Setup Guide", "Go Analytics", "Golang Integration"
+
+docs/sources/trackers/golang-tracker/initialization/index.md
+"Go Initialization", "Tracker Init", "Go Setup", "Golang Config", "Go Analytics", "Tracker Configuration"
+
+docs/sources/trackers/golang-tracker/index.md
+"Golang Tracker", "Go Analytics", "Go SDK", "Server Analytics", "Go Tracking", "Backend Analytics"
+
+docs/sources/trackers/golang-tracker/tracking-specific-events/index.md
+"Go Events", "Golang Events", "Event Tracking", "Go Analytics", "Custom Events", "Behavior Tracking"
+
+docs/sources/trackers/golang-tracker/emitters/index.md
+"Go Emitters", "Event Sending", "Go Configuration", "Batch Processing", "Event Delivery", "Transport Layer"
+
+docs/sources/trackers/golang-tracker/adding-extra-data-the-subject-class/index.md
+"Go Subject", "User Data", "Subject Class", "User Context", "Go Context", "User Information"
+
+docs/sources/trackers/ruby-tracker/configuring-how-events-are-sent/index.md
+"Ruby Configuration", "Event Sending", "Ruby Setup", "Transport Config", "Ruby Analytics", "Event Delivery"
+
+docs/sources/trackers/ruby-tracker/adding-data-events/index.md
+"Ruby Data", "Event Data", "Ruby Events", "Custom Data", "Ruby Analytics", "Event Context"
+
+docs/sources/trackers/ruby-tracker/tracking-events/index.md
+"Ruby Events", "Event Tracking", "Ruby Analytics", "Behavior Tracking", "Ruby SDK", "Event Collection"
+
+docs/sources/trackers/ruby-tracker/getting-started/index.md
+"Ruby Tracker", "Getting Started", "Ruby Setup", "Quick Start", "Ruby Guide", "Installation Guide"
+
+docs/sources/trackers/ruby-tracker/index.md
+"Ruby Tracker", "Ruby Analytics", "Ruby SDK", "Server Tracking", "Ruby Integration", "Backend Analytics"
+
+docs/sources/trackers/google-tag-manager/snowplow-template/plugins/index.md
+"GTM Plugins", "Tag Manager", "GTM Extensions", "Snowplow GTM", "Tag Plugins", "GTM Features"
+
+docs/sources/trackers/google-tag-manager/snowplow-template/index.md
+"GTM Template", "Snowplow GTM", "Tag Manager", "GTM Integration", "Tag Template", "Google Tags"
+
+docs/sources/trackers/google-tag-manager/settings-template/index.md
+"GTM Settings", "Tag Manager", "GTM Configuration", "Settings Template", "GTM Setup", "Tag Configuration"
+
+docs/sources/trackers/google-tag-manager/ecommerce-tag-template/configuration/index.md
+"Ecommerce GTM", "GTM Ecommerce", "Ecommerce Tags", "Shopping Analytics", "GTM Configuration", "Ecommerce Tracking"
+
+docs/sources/trackers/google-tag-manager/ecommerce-tag-template/index.md
+"GTM Ecommerce", "Ecommerce Template", "Shopping Tags", "Ecommerce Analytics", "GTM Template", "Retail Analytics"
+
+docs/sources/trackers/google-tag-manager/index.md
+"Google Tag Manager", "GTM Integration", "Tag Manager", "Web Tracking", "GTM Snowplow", "Tag Management"
+
+docs/sources/trackers/google-tag-manager/snowtype/index.md
+"GTM Snowtype", "TypeScript GTM", "Type Safety", "GTM Types", "Tag Manager", "TypeScript Integration"
+
+docs/sources/trackers/google-tag-manager/quick-start/index.md
+"GTM Quick Start", "GTM Setup", "Tag Manager", "Getting Started", "GTM Guide", "Quick Setup"
+
+docs/sources/trackers/node-js-tracker/configuration/index.md
+"Node.js Configuration", "Server Configuration", "Node Setup", "NodeJS Analytics", "Backend Config", "Server Analytics"
+
+docs/sources/trackers/node-js-tracker/tracking-events/index.md
+"Node.js Events", "Server Events", "NodeJS Analytics", "Backend Tracking", "Server Analytics", "Event Collection"
+
+docs/sources/trackers/node-js-tracker/initialization/index.md
+"Node.js Init", "Server Init", "NodeJS Setup", "Backend Setup", "Server Analytics", "Tracker Init"
+
+docs/sources/trackers/node-js-tracker/index.md
+"Node.js Tracker", "NodeJS Analytics", "Server Tracking", "Backend Analytics", "JavaScript Server", "Server SDK"
+
+docs/sources/trackers/net-tracker/platform-specific-functions/index.md
+".NET Platform", "Platform Functions", ".NET Features", "Framework Features", "Platform Specific", ".NET Integration"
+
+docs/sources/trackers/net-tracker/emitter/index.md
+".NET Emitter", "Event Sending", ".NET Configuration", "Transport Layer", "Event Delivery", ".NET Analytics"
+
+docs/sources/trackers/net-tracker/subject/index.md
+".NET Subject", "User Context", "Subject Class", "User Data", ".NET Context", "User Information"
+
+docs/sources/trackers/net-tracker/setup/index.md
+".NET Setup", "Tracker Setup", ".NET Configuration", "Setup Guide", ".NET Analytics", ".NET Integration"
+
+docs/sources/trackers/net-tracker/tracker/index.md
+".NET Tracker", "Tracker Class", ".NET Analytics", "Event Tracking", ".NET SDK", "Analytics Framework"
+
+docs/sources/trackers/net-tracker/initialization/index.md
+".NET Initialization", "Tracker Init", ".NET Setup", "Framework Init", ".NET Configuration", "Analytics Init"
+
+docs/sources/trackers/net-tracker/index.md
+".NET Tracker", ".NET Analytics", "C# Tracking", "Desktop Analytics", ".NET SDK", "Framework Analytics"
+
+docs/sources/trackers/net-tracker/event-tracking/index.md
+".NET Events", "Event Tracking", ".NET Analytics", "C# Events", "Desktop Events", "Framework Events"
+
+docs/sources/trackers/net-tracker/session/index.md
+".NET Sessions", "Session Tracking", "User Sessions", ".NET Analytics", "Session Management", "Desktop Sessions"
+
+docs/sources/trackers/java-tracker/configuring-how-events-are-sent/index.md
+"Java Configuration", "Event Sending", "Java Setup", "Transport Config", "Java Analytics", "Event Delivery"
+
+docs/sources/trackers/java-tracker/custom-tracking-using-schemas/index.md
+"Java Custom Tracking", "Custom Events", "Schema Tracking", "Java Analytics", "Custom Schemas", "Event Schemas"
+
+docs/sources/trackers/java-tracker/tracking-events/index.md
+"Java Events", "Event Tracking", "Java Analytics", "Behavior Tracking", "Java SDK", "Event Collection"
+
+docs/sources/trackers/java-tracker/index.md
+"Java Tracker", "Java Analytics", "Java SDK", "Server Tracking", "Enterprise Analytics", "Backend Analytics"
+
+docs/sources/trackers/java-tracker/tracking-specific-client-side-properties/index.md
+"Java Properties", "Client Properties", "Java Context", "Client Data", "Java Analytics", "Context Data"
+
+docs/sources/trackers/java-tracker/what-do-java-tracker-events-look-like/index.md
+"Java Event Format", "Event Structure", "Java Data", "Event Schema", "Data Format", "Event Examples"
+
+docs/sources/trackers/java-tracker/using-multiple-trackers/index.md
+"Multiple Trackers", "Java Multi", "Tracker Management", "Multi Instance", "Java Configuration", "Multiple Apps"
+
+docs/sources/trackers/java-tracker/installation-and-set-up/index.md
+"Java Installation", "Java Setup", "Installation Guide", "Java Config", "Getting Started", "Java Integration"
+
+docs/sources/trackers/lua-tracker/index.md
+"Lua Tracker", "Lua Analytics", "Lua SDK", "Scripting Analytics", "Lua Integration", "Game Analytics"
+
+docs/sources/trackers/lua-tracker/tracking-specific-events/index.md
+"Lua Events", "Event Tracking", "Lua Analytics", "Game Events", "Scripting Events", "Custom Events"
+
+docs/sources/trackers/c-tracker/setup/index.md
+"C Tracker Setup", "C Configuration", "C Analytics", "Native Tracking", "C SDK", "System Analytics"
+
+docs/sources/trackers/c-tracker/client-sessions/index.md
+"C Sessions", "Session Tracking", "Client Sessions", "C Analytics", "Session Management", "Native Sessions"
+
+docs/sources/trackers/c-tracker/index.md
+"C Tracker", "C Analytics", "Native Tracking", "System Analytics", "C SDK", "Embedded Analytics"
+
+docs/sources/trackers/c-tracker/tracking-specific-events/index.md
+"C Events", "Event Tracking", "C Analytics", "Native Events", "System Events", "Embedded Events"
+
+docs/sources/trackers/c-tracker/emitters/index.md
+"C Emitters", "Event Sending", "C Configuration", "Transport Layer", "Native Analytics", "C SDK"
+
+docs/sources/trackers/c-tracker/initialisation/index.md
+"C Initialization", "Tracker Init", "C Setup", "Native Init", "C Configuration", "System Init"
+
+docs/sources/trackers/c-tracker/adding-extra-data-the-subject-class/index.md
+"C Subject", "User Context", "Subject Class", "C Analytics", "User Data", "Native Context"
+
+docs/sources/trackers/tracker-maintenance-classification/index.md
+"Tracker Maintenance", "SDK Status", "Support Level", "Tracker Lifecycle", "Maintenance Policy", "SDK Support"
+
+docs/sources/trackers/google-analytics-plugin/index.md
+"Google Analytics", "GA Plugin", "Analytics Integration", "GA Migration", "Universal Analytics", "GA4 Integration"
+
+docs/sources/trackers/index.md
+"Event Trackers", "Analytics SDKs", "Data Collection", "Tracking Libraries", "Analytics Tracking", "Event Collection"
+
+docs/sources/trackers/web-trackers/anonymous-tracking/index.md
+"Anonymous Tracking", "Privacy Protection", "Web Privacy", "GDPR Compliance", "Anonymous Analytics", "Privacy Mode"
+
+docs/sources/trackers/web-trackers/plugins/creating-your-own-plugins/index.md
+"Custom Plugins", "Plugin Development", "Web Extensions", "JavaScript Plugins", "Custom Features", "Plugin Creation"
+
+docs/sources/trackers/web-trackers/plugins/index.md
+"Web Plugins", "Tracker Plugins", "JavaScript Extensions", "Analytics Plugins", "Web Features", "Plugin System"
+
+docs/sources/trackers/web-trackers/plugins/configuring-tracker-plugins/browser/index.md
+"Browser Plugins", "Web Configuration", "Browser Setup", "Plugin Config", "Web Analytics", "Browser Features"
+
+docs/sources/trackers/web-trackers/plugins/configuring-tracker-plugins/index.md
+"Plugin Configuration", "Web Plugins", "Plugin Setup", "Analytics Config", "Feature Config", "Plugin Management"
+
+docs/sources/trackers/web-trackers/plugins/configuring-tracker-plugins/javascript/index.md
+"JavaScript Plugins", "JS Configuration", "Web Features", "JS Analytics", "Browser JavaScript", "Client Side"
+
+docs/sources/trackers/web-trackers/configuring-how-events-sent/index.md
+"Event Configuration", "Transport Config", "Web Analytics", "Event Sending", "Browser Config", "Analytics Setup"
+
+docs/sources/trackers/web-trackers/custom-tracking-using-schemas/index.md
+"Custom Tracking", "Web Events", "Custom Events", "Schema Tracking", "Event Schemas", "Custom Analytics"
+
+docs/sources/trackers/web-trackers/custom-tracking-using-schemas/global-context/index.md
+"Global Context", "Web Context", "Event Context", "Context Data", "Global Entities", "Context Tracking"
+
+docs/sources/trackers/web-trackers/tracking-events/timezone-geolocation/index.md
+"Geolocation Tracking", "Timezone Data", "Location Analytics", "Geographic Data", "Web Location", "Timezone Tracking"
+
+docs/sources/trackers/web-trackers/tracking-events/ads/index.md
+"Ad Tracking", "Advertisement Analytics", "Ad Events", "Marketing Analytics", "Ad Performance", "Advertising Data"
+
+docs/sources/trackers/web-trackers/tracking-events/site-search/index.md
+"Site Search", "Search Analytics", "Search Tracking", "Internal Search", "Search Events", "Search Behavior"
+
+docs/sources/trackers/web-trackers/tracking-events/social-media/index.md
+"Social Media", "Social Tracking", "Social Events", "Social Analytics", "Social Engagement", "Social Buttons"
+
+docs/sources/trackers/web-trackers/tracking-events/web-vitals/index.md
+"Web Vitals", "Performance Metrics", "Core Vitals", "Page Performance", "User Experience", "Performance Analytics"
+
+docs/sources/trackers/web-trackers/tracking-events/privacy-sandbox/index.md
+"Privacy Sandbox", "Chrome Privacy", "Privacy API", "Attribution API", "Privacy Enhanced", "Chrome Features"
+
+docs/sources/trackers/web-trackers/tracking-events/timings/index.md
+"Performance Timing", "Page Timing", "Navigation Timing", "Performance Metrics", "Load Times", "Timing Events"
+
+docs/sources/trackers/web-trackers/tracking-events/timings/generic/index.md
+"Generic Timing", "Custom Timing", "Performance Events", "Timing Metrics", "Custom Performance", "Timing Analytics"
+
+docs/sources/trackers/web-trackers/tracking-events/campaigns-utms/index.md
+"Campaign Tracking", "UTM Parameters", "Marketing Campaigns", "Campaign Analytics", "UTM Tracking", "Marketing Attribution"
+
+docs/sources/trackers/web-trackers/tracking-events/ecommerce/index.md
+"Ecommerce Tracking", "Shopping Analytics", "Purchase Events", "Retail Analytics", "Transaction Tracking", "Commerce Events"
+
+docs/sources/trackers/web-trackers/tracking-events/ecommerce/enhanced/index.md
+"Enhanced Ecommerce", "Advanced Commerce", "Detailed Shopping", "Commerce Analytics", "Shopping Funnel", "Product Analytics"
+
+docs/sources/trackers/web-trackers/tracking-events/element-tracking/index.md
+"Element Tracking", "DOM Tracking", "Page Elements", "Element Events", "UI Tracking", "Web Elements"
+
+docs/sources/trackers/web-trackers/tracking-events/client-hints/index.md
+"Client Hints", "Browser Hints", "Device Detection", "User Agent", "Client Information", "Browser Features"
+
+docs/sources/trackers/web-trackers/tracking-events/screen-views/index.md
+"Screen Views", "Page Views", "View Tracking", "Page Analytics", "Navigation Tracking", "View Events"
+
+docs/sources/trackers/web-trackers/tracking-events/form-tracking/index.md
+"Form Tracking", "Form Analytics", "Form Events", "User Input", "Form Behavior", "Input Tracking"
+
+docs/sources/trackers/web-trackers/tracking-events/optimizely/index.md
+"Optimizely Integration", "A/B Testing", "Experimentation", "Test Analytics", "Conversion Testing", "Optimization"
+
+docs/sources/trackers/web-trackers/tracking-events/event-specifications/index.md
+"Event Specifications", "Event Standards", "Tracking Standards", "Event Documentation", "Analytics Standards", "Event Rules"
+
+docs/sources/trackers/web-trackers/tracking-events/webview/index.md
+"WebView Tracking", "Hybrid Apps", "Mobile WebView", "Cross Platform", "WebView Integration", "Hybrid Analytics"
+
+docs/sources/trackers/web-trackers/tracking-events/page-views/index.md
+"Page Views", "Page Tracking", "Navigation Analytics", "Page Events", "Web Analytics", "Page Performance"
+
+docs/sources/trackers/web-trackers/tracking-events/link-click/index.md
+"Link Tracking", "Click Events", "Link Analytics", "Click Tracking", "User Interactions", "Link Behavior"
+
+docs/sources/trackers/web-trackers/tracking-events/ga-cookies/index.md
+"Google Analytics", "GA Cookies", "Analytics Migration", "Cookie Data", "GA Integration", "Analytics Transition"
+
+docs/sources/trackers/web-trackers/tracking-events/activity-page-pings/index.md
+"Activity Tracking", "Page Engagement", "User Activity", "Engagement Analytics", "Active Time", "Activity Events"
+
+docs/sources/trackers/web-trackers/tracking-events/consent-gdpr/index.md
+"Consent Tracking", "GDPR Compliance", "Privacy Consent", "Cookie Consent", "Privacy Analytics", "Consent Management"
+
+docs/sources/trackers/web-trackers/tracking-events/index.md
+"Web Events", "Event Tracking", "Web Analytics", "Behavior Tracking", "User Events", "Web Tracking"
+
+docs/sources/trackers/web-trackers/tracking-events/focalmeter/index.md
+"Focalmeter Integration", "Attention Analytics", "Focus Tracking", "Attention Metrics", "Eye Tracking", "Engagement Metrics"
+
+docs/sources/trackers/web-trackers/tracking-events/errors/index.md
+"Error Tracking", "JavaScript Errors", "Error Analytics", "Bug Tracking", "Error Monitoring", "Client Errors"
+
+docs/sources/trackers/web-trackers/tracking-events/button-click/index.md
+"Button Tracking", "Click Events", "Button Analytics", "UI Interactions", "Button Events", "Click Analytics"
+
+docs/sources/trackers/web-trackers/tracking-events/media/html5/index.md
+"HTML5 Media", "Video Tracking", "Audio Tracking", "Media Analytics", "HTML5 Events", "Media Events"
+
+docs/sources/trackers/web-trackers/tracking-events/media/vimeo/index.md
+"Vimeo Tracking", "Video Analytics", "Vimeo Events", "Video Engagement", "Vimeo Integration", "Video Metrics"
+
+docs/sources/trackers/web-trackers/tracking-events/media/youtube/index.md
+"YouTube Tracking", "Video Analytics", "YouTube Events", "Video Engagement", "YouTube Integration", "Video Metrics"
+
+docs/sources/trackers/web-trackers/tracking-events/media/snowplow/index.md
+"Snowplow Media", "Media Tracking", "Video Analytics", "Media Events", "Video Engagement", "Media Analytics"
+
+docs/sources/trackers/web-trackers/tracking-events/media/index.md
+"Media Tracking", "Video Analytics", "Audio Analytics", "Media Events", "Video Engagement", "Media Performance"
+
+docs/sources/trackers/web-trackers/tracking-events/session/index.md
+"Session Tracking", "User Sessions", "Session Analytics", "Session Management", "User Activity", "Session Events"
+
+docs/sources/trackers/web-trackers/testing-debugging/index.md
+"Web Testing", "Debug Tools", "Testing Framework", "Debugging Guide", "Analytics Testing", "Tracker Testing"
+
+docs/sources/trackers/web-trackers/browsers/index.md
+"Browser Support", "Browser Compatibility", "Web Browsers", "Cross Browser", "Browser Analytics", "Browser Testing"
+
+docs/sources/trackers/web-trackers/tracker-setup/managing-multiple-trackers/index.md
+"Multiple Trackers", "Multi Tracker", "Tracker Management", "Multi Instance", "Tracker Config", "Multiple Apps"
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/self-hosting-the-javascript-tracker-aws/index.md
+"Self Hosting AWS", "AWS Hosting", "JavaScript Hosting", "CDN Hosting", "AWS CDN", "Self Hosted"
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/self-hosting-the-javascript-tracker-on-google-cloud/index.md
+"GCP Hosting", "Google Cloud", "Self Hosting", "JavaScript Hosting", "Cloud Hosting", "GCP CDN"
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/index.md
+"JavaScript Hosting", "Self Hosting", "CDN Hosting", "Tracker Hosting", "Web Hosting", "Asset Hosting"
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/third-party-cdn-hosting/index.md
+"Third Party CDN", "CDN Hosting", "External CDN", "CDN Services", "Third Party", "CDN Setup"
+
+docs/sources/trackers/web-trackers/tracker-setup/hosting-the-javascript-tracker/creating-a-whitelabel-build/index.md
+"White Label", "Custom Build", "Branded Tracker", "Custom Tracker", "White Label Build", "Custom Branding"
+
+docs/sources/trackers/web-trackers/tracker-setup/initialization-options/index.md
+"Initialization Options", "Tracker Config", "Setup Options", "Web Configuration", "Tracker Settings", "Init Configuration"
+
+docs/sources/trackers/web-trackers/tracker-setup/index.md
+"Web Tracker Setup", "JavaScript Setup", "Tracker Installation", "Web Analytics", "Getting Started", "Tracker Config"
+
+docs/sources/trackers/web-trackers/tracker-setup/snowplow-plugin-for-analytics-npm-package/index.md
+"NPM Analytics", "Analytics Package", "NPM Plugin", "Package Manager", "JavaScript Package", "Analytics NPM"
+
+docs/sources/trackers/web-trackers/cookies-and-local-storage/configuring-cookies/index.md
+"Cookie Configuration", "Cookie Settings", "Web Cookies", "Cookie Management", "Browser Storage", "Cookie Options"
+
+docs/sources/trackers/web-trackers/cookies-and-local-storage/index.md
+"Cookies Storage", "Local Storage", "Browser Storage", "Web Storage", "Client Storage", "Storage Management"
+
+docs/sources/trackers/web-trackers/cookies-and-local-storage/getting-cookie-values/index.md
+"Cookie Values", "Cookie Data", "Reading Cookies", "Cookie Access", "Cookie Retrieval", "Cookie Information"
+
+docs/sources/trackers/web-trackers/index.md
+"Web Tracker", "JavaScript Tracker", "Web Analytics", "Browser Tracking", "Client Analytics", "Frontend Tracking"
+
+docs/sources/trackers/web-trackers/cross-domain-tracking/index.md
+"Cross Domain", "Domain Tracking", "Multi Domain", "Cross Site", "Domain Analytics", "Cross Origin"
+
+docs/sources/trackers/web-trackers/quick-start-guide/index.md
+"Web Quick Start", "JavaScript Guide", "Web Setup", "Getting Started", "Tracker Guide", "Web Analytics"
+
+docs/sources/trackers/webview-tracker/index.md
+"WebView Tracker", "Hybrid Analytics", "Mobile WebView", "WebView Integration", "Cross Platform", "Hybrid Apps"
+
+docs/sources/trackers/php-tracker/setup/index.md
+"PHP Setup", "PHP Configuration", "PHP Analytics", "Server PHP", "PHP Integration", "Backend PHP"
+
+docs/sources/trackers/php-tracker/initialization/index.md
+"PHP Initialization", "PHP Init", "PHP Setup", "PHP Configuration", "PHP Analytics", "Server Init"
+
+docs/sources/trackers/php-tracker/index.md
+"PHP Tracker", "PHP Analytics", "Server Tracking", "Backend Analytics", "PHP SDK", "Server Analytics"
+
+docs/sources/trackers/php-tracker/subjects/index.md
+"PHP Subjects", "User Context", "PHP Context", "Subject Class", "PHP Analytics", "User Data"
+
+docs/sources/trackers/php-tracker/emitters/index.md
+"PHP Emitters", "Event Sending", "PHP Configuration", "Transport Layer", "PHP Analytics", "Event Delivery"
+
+docs/sources/trackers/php-tracker/tracking-an-event/index.md
+"PHP Events", "Event Tracking", "PHP Analytics", "Server Events", "Backend Events", "PHP Tracking"
+
+docs/sources/trackers/mobile-trackers/configuring-how-events-are-sent/index.md
+"Mobile Configuration", "Event Sending", "Mobile Setup", "Transport Config", "Mobile Analytics", "Event Delivery"
+
+docs/sources/trackers/mobile-trackers/anonymous-tracking/index.md
+"Anonymous Mobile", "Mobile Privacy", "Anonymous Analytics", "Privacy Protection", "Mobile Privacy", "GDPR Mobile"
+
+docs/sources/trackers/mobile-trackers/plugins/focal-meter/index.md
+"FocalMeter Mobile", "Attention Analytics", "Mobile Attention", "Eye Tracking", "Engagement Metrics", "Mobile Focus"
+
+docs/sources/trackers/mobile-trackers/plugins/index.md
+"Mobile Plugins", "Tracker Plugins", "Mobile Extensions", "Analytics Plugins", "Mobile Features", "Plugin System"
+
+docs/sources/trackers/mobile-trackers/custom-tracking-using-schemas/index.md
+"Mobile Custom Tracking", "Custom Events", "Mobile Events", "Schema Tracking", "Mobile Analytics", "Custom Mobile"
+
+docs/sources/trackers/mobile-trackers/custom-tracking-using-schemas/global-context/index.md
+"Mobile Context", "Global Context", "Event Context", "Mobile Data", "Context Tracking", "Mobile Entities"
+
+docs/sources/trackers/mobile-trackers/tracking-events/platform-and-application-context/index.md
+"Mobile Platform", "App Context", "Platform Context", "Device Context", "Mobile Data", "App Information"
+
+docs/sources/trackers/mobile-trackers/tracking-events/exception-tracking/index.md
+"Exception Tracking", "Error Tracking", "Mobile Errors", "App Crashes", "Exception Analytics", "Error Monitoring"
+
+docs/sources/trackers/mobile-trackers/tracking-events/lifecycle-tracking/index.md
+"App Lifecycle", "Mobile Lifecycle", "App Events", "Lifecycle Events", "App State", "Mobile Sessions"
+
+docs/sources/trackers/mobile-trackers/tracking-events/installation-tracking/index.md
+"App Installation", "Install Tracking", "First Launch", "Mobile Install", "App Install", "Installation Events"
+
+docs/sources/trackers/mobile-trackers/tracking-events/gdpr-tracking/index.md
+"GDPR Mobile", "Mobile Consent", "Privacy Tracking", "Consent Management", "Mobile Privacy", "GDPR Compliance"
+
+docs/sources/trackers/mobile-trackers/tracking-events/visionos/index.md
+"VisionOS Tracking", "Apple Vision", "Spatial Computing", "VR Analytics", "Vision Pro", "Spatial Events"
+
+docs/sources/trackers/mobile-trackers/tracking-events/index.md
+"Mobile Events", "App Events", "Mobile Analytics", "Mobile Tracking", "App Analytics", "Mobile Behavior"
+
+docs/sources/trackers/mobile-trackers/tracking-events/screen-tracking/index.md
+"Screen Tracking", "Mobile Screens", "App Screens", "Screen Views", "Mobile Navigation", "Screen Analytics"
+
+docs/sources/trackers/mobile-trackers/tracking-events/ecommerce-tracking/index.md
+"Mobile Ecommerce", "App Commerce", "Mobile Shopping", "M-commerce", "Mobile Retail", "App Purchases"
+
+docs/sources/trackers/mobile-trackers/tracking-events/session-tracking/index.md
+"Mobile Sessions", "App Sessions", "Session Tracking", "Mobile Analytics", "User Sessions", "App Usage"
+
+docs/sources/trackers/mobile-trackers/tracking-events/media-tracking/index.md
+"Mobile Media", "App Media", "Mobile Video", "Media Analytics", "Video Tracking", "Audio Tracking"
+
+docs/sources/trackers/mobile-trackers/client-side-properties/index.md
+"Mobile Properties", "Device Properties", "Client Data", "Mobile Context", "Device Information", "App Properties"
+
+docs/sources/trackers/mobile-trackers/android-google-play-data-safety/index.md
+"Android Safety", "Play Store", "Data Safety", "Privacy Labels", "Google Play", "Android Privacy"
+
+docs/sources/trackers/mobile-trackers/hybrid-apps/index.md
+"Hybrid Mobile", "Mobile WebView", "Cross Platform", "Hybrid Analytics", "WebView Integration", "Mobile Hybrid"
+
+docs/sources/trackers/mobile-trackers/index.md
+"Mobile Tracker", "Mobile Analytics", "App Tracking", "iOS Android", "Mobile SDK", "App Analytics"
+
+docs/sources/trackers/mobile-trackers/remote-configuration/index.md
+"Remote Configuration", "Mobile Config", "Dynamic Config", "Remote Setup", "App Configuration", "Mobile Management"
+
+docs/sources/trackers/mobile-trackers/installation-and-set-up/index.md
+"Mobile Installation", "Mobile Setup", "App Setup", "Mobile Configuration", "Getting Started", "Mobile Guide"
+
+docs/sources/trackers/pixel-tracker/index.md
+"Pixel Tracker", "Image Tracking", "Pixel Analytics", "Email Tracking", "Pixel Beacon", "Tracking Pixel"
+
+docs/sources/trackers/unity-tracker/emitter/index.md
+"Unity Emitter", "Game Analytics", "Unity Configuration", "Event Sending", "Unity Events", "Game Events"
+
+docs/sources/trackers/unity-tracker/subject/index.md
+"Unity Subject", "Player Context", "Game Context", "Unity Analytics", "Player Data", "Game Data"
+
+docs/sources/trackers/unity-tracker/setup/index.md
+"Unity Setup", "Game Setup", "Unity Configuration", "Unity Analytics", "Game Analytics", "Unity Integration"
+
+docs/sources/trackers/unity-tracker/tracker/index.md
+"Unity Tracker", "Game Tracker", "Unity Analytics", "Game Analytics", "Unity SDK", "Game Development"
+
+docs/sources/trackers/unity-tracker/initialization/index.md
+"Unity Initialization", "Game Init", "Unity Setup", "Unity Configuration", "Game Analytics", "Unity Init"
+
+docs/sources/trackers/unity-tracker/utilities/index.md
+"Unity Utilities", "Game Utilities", "Helper Functions", "Unity Tools", "Game Tools", "Unity Helpers"
+
+docs/sources/trackers/unity-tracker/index.md
+"Unity Tracker", "Game Analytics", "Unity Analytics", "Game Development", "Unity SDK", "Gaming Analytics"
+
+docs/sources/trackers/unity-tracker/event-tracking/index.md
+"Unity Events", "Game Events", "Unity Analytics", "Game Analytics", "Player Events", "Gaming Events"
+
+docs/sources/trackers/unity-tracker/session/index.md
+"Unity Sessions", "Game Sessions", "Player Sessions", "Game Analytics", "Unity Analytics", "Gaming Sessions"
+
+docs/sources/trackers/google-amp-tracker/index.md
+"AMP Tracker", "AMP Analytics", "Google AMP", "Mobile Pages", "AMP Integration", "Accelerated Pages"
+
+docs/sources/trackers/flutter-tracker/initialization-and-configuration/index.md
+"Flutter Configuration", "Flutter Setup", "Mobile Flutter", "Cross Platform", "Flutter Analytics", "Flutter Config"
+
+docs/sources/trackers/flutter-tracker/adding-data/index.md
+"Flutter Data", "Flutter Events", "Custom Data", "Flutter Analytics", "Event Data", "Flutter Tracking"
+
+docs/sources/trackers/flutter-tracker/anonymous-tracking/index.md
+"Flutter Anonymous", "Flutter Privacy", "Anonymous Analytics", "Privacy Protection", "Flutter GDPR", "Mobile Privacy"
+
+docs/sources/trackers/flutter-tracker/tracking-events/index.md
+"Flutter Events", "Flutter Analytics", "Mobile Events", "Cross Platform", "Flutter Tracking", "App Events"
+
+docs/sources/trackers/flutter-tracker/tracking-events/media-tracking/index.md
+"Flutter Media", "Media Tracking", "Flutter Video", "Video Analytics", "Flutter Audio", "Media Events"
+
+docs/sources/trackers/flutter-tracker/sessions-and-data-model/index.md
+"Flutter Sessions", "Data Model", "Flutter Analytics", "Session Management", "Flutter Data", "App Sessions"
+
+docs/sources/trackers/flutter-tracker/getting-started/index.md
+"Flutter Tracker", "Getting Started", "Flutter Setup", "Flutter Guide", "Mobile Flutter", "Cross Platform"
+
+docs/sources/trackers/flutter-tracker/hybrid-apps/index.md
+"Flutter Hybrid", "Hybrid Apps", "WebView Flutter", "Cross Platform", "Flutter WebView", "Hybrid Analytics"
+
+docs/sources/trackers/flutter-tracker/index.md
+"Flutter Tracker", "Flutter Analytics", "Cross Platform", "Mobile Flutter", "Flutter SDK", "Dart Analytics"
+
+docs/sources/trackers/roku-tracker/adding-data/index.md
+"Roku Data", "Roku Events", "TV Analytics", "Roku Tracking", "OTT Analytics", "Connected TV"
+
+docs/sources/trackers/roku-tracker/configuration/index.md
+"Roku Configuration", "Roku Setup", "TV Configuration", "Roku Analytics", "OTT Setup", "Connected TV"
+
+docs/sources/trackers/roku-tracker/tracking-events/index.md
+"Roku Events", "TV Events", "Roku Analytics", "OTT Analytics", "Connected TV", "Streaming Events"
+
+docs/sources/trackers/roku-tracker/device-context/index.md
+"Roku Context", "Device Context", "TV Context", "Roku Data", "Device Information", "TV Analytics"
+
+docs/sources/trackers/roku-tracker/index.md
+"Roku Tracker", "Roku Analytics", "Connected TV", "OTT Analytics", "TV Analytics", "Streaming Analytics"
+
+docs/sources/trackers/roku-tracker/media-tracking/v1/index.md
+"Roku Media V1", "TV Media", "Video Analytics", "Roku Video", "Media Tracking", "Streaming Media"
+
+docs/sources/trackers/roku-tracker/media-tracking/v2/index.md
+"Roku Media V2", "TV Media", "Video Analytics", "Roku Video", "Media Tracking", "Streaming Media"
+
+docs/sources/trackers/roku-tracker/media-tracking/index.md
+"Roku Media", "TV Media", "Video Analytics", "Roku Video", "OTT Media", "Connected TV"
+
+docs/sources/trackers/snowplow-tracking-cli/additional-information/index.md
+"CLI Information", "Tracking CLI", "Command Line", "CLI Tools", "Terminal Tracking", "CLI Analytics"
+
+docs/sources/trackers/snowplow-tracking-cli/usage/index.md
+"CLI Usage", "Command Usage", "CLI Guide", "Terminal Usage", "CLI Commands", "Tracking CLI"
+
+docs/sources/trackers/snowplow-tracking-cli/installation/index.md
+"CLI Installation", "CLI Setup", "Command Line", "CLI Tools", "Terminal Setup", "CLI Guide"
+
+docs/sources/trackers/snowplow-tracking-cli/index.md
+"Snowplow CLI", "Tracking CLI", "Command Line", "CLI Tools", "Terminal Tracking", "CLI Analytics"
+
+docs/sources/trackers/python-tracker/contracts/index.md
+"Python Contracts", "Type Contracts", "Python Types", "Data Contracts", "Python Analytics", "Type Safety"
+
+docs/sources/trackers/python-tracker/subject/index.md
+"Python Subject", "User Context", "Subject Class", "Python Analytics", "User Data", "Python Context"
+
+docs/sources/trackers/python-tracker/setup/index.md
+"Python Setup", "Python Configuration", "Python Analytics", "Server Python", "Python Integration", "Backend Python"
+
+docs/sources/trackers/python-tracker/intialization/index.md
+"Python Initialization", "Python Init", "Python Setup", "Python Configuration", "Python Analytics", "Server Init"
+
+docs/sources/trackers/python-tracker/index.md
+"Python Tracker", "Python Analytics", "Server Tracking", "Backend Analytics", "Python SDK", "Data Science"
+
+docs/sources/trackers/python-tracker/tracking-specific-events/index.md
+"Python Events", "Event Tracking", "Python Analytics", "Server Events", "Backend Events", "Python Tracking"
+
+docs/sources/trackers/python-tracker/emitters/index.md
+"Python Emitters", "Event Sending", "Python Configuration", "Transport Layer", "Python Analytics", "Event Delivery"
+
+docs/sources/trackers/python-tracker/logging/index.md
+"Python Logging", "Debug Logging", "Python Analytics", "Log Management", "Error Logging", "Debug Tools"
+
+docs/sources/trackers/scala-tracker/sending-events/index.md
+"Scala Events", "Event Sending", "Scala Analytics", "Functional Programming", "Scala Tracking", "JVM Analytics"
+
+docs/sources/trackers/scala-tracker/subject-methods/index.md
+"Scala Subject", "Subject Methods", "User Context", "Scala Analytics", "Functional Analytics", "Subject Class"
+
+docs/sources/trackers/scala-tracker/setup/index.md
+"Scala Setup", "Scala Configuration", "Scala Analytics", "JVM Analytics", "Functional Programming", "Scala Integration"
+
+docs/sources/trackers/scala-tracker/initialization/index.md
+"Scala Initialization", "Scala Init", "Scala Setup", "Scala Configuration", "JVM Analytics", "Functional Programming"
+
+docs/sources/trackers/scala-tracker/index.md
+"Scala Tracker", "Scala Analytics", "JVM Analytics", "Functional Programming", "Server Tracking", "Backend Analytics"
+
+docs/sources/first-party-tracking/index.md
+"First Party Tracking", "Cookie Less", "Server Side", "Privacy First", "Direct Tracking", "First Party Data"
+
+docs/sources/index.md
+"Data Sources", "Event Sources", "Tracking Sources", "Data Collection", "Analytics Sources", "Event Collection"
+
+docs/sources/webhooks/iterable/index.md
+"Iterable Webhook", "Email Marketing", "Marketing Automation", "Campaign Data", "Customer Engagement", "Marketing Events"
+
+docs/sources/webhooks/iglu-webhook/index.md
+"Iglu Webhook", "Schema Webhook", "Schema Events", "Registry Webhook", "Schema Management", "Iglu Integration"
+
+docs/sources/webhooks/adjust-webhook/index.md
+"Adjust Webhook", "Mobile Attribution", "App Attribution", "Marketing Attribution", "Install Attribution", "Performance Marketing"
+
+docs/sources/webhooks/sendgrid/index.md
+"SendGrid Webhook", "Email Events", "Email Analytics", "Transactional Email", "Email Delivery", "Email Marketing"
+
+docs/sources/webhooks/mandrill/index.md
+"Mandrill Webhook", "Email Events", "Email Analytics", "Transactional Email", "Email Delivery", "Email Service"
+
+docs/sources/webhooks/index.md
+"Webhook Sources", "Event Webhooks", "API Integration", "Third Party", "External Events", "Webhook Analytics"
+
+docs/sources/webhooks/zendesk/index.md
+"Zendesk Webhook", "Support Events", "Customer Service", "Ticket Analytics", "Support Analytics", "Help Desk"
+
+docs/sources/webhooks/mailgun/index.md
+"Mailgun Webhook", "Email Events", "Email Analytics", "Email Service", "Email Delivery", "Transactional Email"
+
+docs/events/timestamps/index.md
+"Event Timestamps", "Time Data", "Event Time", "Temporal Data", "Time Analytics", "Event Timing"
+
+docs/events/going-deeper/example-requests/index.md
+"Request Examples", "HTTP Examples", "Event Examples", "API Examples", "Request Format", "Event Format"
+
+docs/events/going-deeper/http-headers/index.md
+"HTTP Headers", "Request Headers", "Header Data", "HTTP Analytics", "Header Information", "Web Headers"
+
+docs/events/going-deeper/index.md
+"Event Deep Dive", "Advanced Events", "Event Details", "Event Structure", "Event Analysis", "Event Internals"
+
+docs/events/going-deeper/event-parameters/index.md
+"Event Parameters", "Event Properties", "Event Data", "Parameter Mapping", "Event Attributes", "Data Properties"
+
+docs/events/ootb-data/links-and-referrers/index.md
+"Referrer Data", "Link Tracking", "Traffic Sources", "Referrer Analytics", "Source Attribution", "Link Analytics"
+
+docs/events/ootb-data/page-activity-tracking/index.md
+"Page Activity", "Engagement Tracking", "Activity Analytics", "User Engagement", "Page Engagement", "Activity Events"
+
+docs/events/ootb-data/mobile-lifecycle-events/index.md
+"Mobile Lifecycle", "App Lifecycle", "Mobile Events", "App State", "Lifecycle Analytics", "Mobile Sessions"
+
+docs/events/ootb-data/page-and-screen-view-events/index.md
+"Page Views", "Screen Views", "View Events", "Navigation Analytics", "View Tracking", "Page Analytics"
+
+docs/events/ootb-data/ecommerce-events/index.md
+"Ecommerce Events", "Shopping Events", "Purchase Events", "Retail Analytics", "Commerce Analytics", "Transaction Events"
+
+docs/events/ootb-data/app-information/index.md
+"App Information", "Application Data", "App Context", "App Analytics", "Application Context", "App Properties"
+
+docs/events/ootb-data/media-events/index.md
+"Media Events", "Video Events", "Audio Events", "Media Analytics", "Video Analytics", "Media Tracking"
+
+docs/events/ootb-data/user-and-session-identification/index.md
+"User Identification", "Session ID", "User Analytics", "Identity Resolution", "User Tracking", "Session Management"
+
+docs/events/ootb-data/index.md
+"Out of Box", "Default Events", "Standard Events", "Built-in Events", "Core Events", "Base Analytics"
+
+docs/events/ootb-data/app-performance/index.md
+"App Performance", "Performance Analytics", "Mobile Performance", "Performance Metrics", "App Optimization", "Performance Tracking"
+
+docs/events/ootb-data/geolocation/index.md
+"Geolocation Data", "Location Analytics", "Geographic Data", "Location Tracking", "Geo Analytics", "Spatial Data"
+
+docs/events/ootb-data/visionos-swiftui/index.md
+"VisionOS Events", "SwiftUI Events", "Apple Vision", "Spatial Computing", "VR Events", "Vision Pro"
+
+docs/events/ootb-data/consent-events/index.md
+"Consent Events", "Privacy Events", "GDPR Events", "Consent Analytics", "Privacy Analytics", "Consent Management"
+
+docs/events/ootb-data/device-and-browser/index.md
+"Device Data", "Browser Data", "Device Analytics", "Browser Analytics", "Device Information", "Browser Intelligence"
+
+docs/events/ootb-data/app-error-events/index.md
+"App Errors", "Error Events", "Exception Events", "Error Analytics", "Crash Analytics", "Error Tracking"
+
+docs/events/cookie-extension/index.md
+"Cookie Extension", "Cookie Analytics", "Cookie Data", "Browser Cookies", "Cookie Tracking", "Web Cookies"
+
+docs/events/index.md
+"Event Tracking", "Analytics Events", "Behavioral Events", "Event Data", "Event Analytics", "Data Events"
+
+docs/events/custom-events/structured-events/index.md
+"Structured Events", "Event Structure", "Event Schema", "Structured Data", "Event Format", "Standard Events"
+
+docs/events/custom-events/index.md
+"Custom Events", "Custom Analytics", "Bespoke Events", "Event Creation", "Custom Tracking", "Tailored Events"
+
+docs/events/custom-events/context-entities/index.md
+"Context Entities", "Event Context", "Entity Data", "Context Data", "Event Entities", "Contextual Data"
+
+docs/events/custom-events/self-describing-events/index.md
+"Self Describing Events", "Schema Events", "Custom Events", "Event Schema", "Flexible Events", "JSON Events"
+
+docs/modeling-your-data/visualization/funnel-builder/index.md
+"Funnel Builder", "Conversion Funnel", "Funnel Analytics", "Conversion Analysis", "User Journey", "Funnel Visualization"
+
+docs/modeling-your-data/visualization/ecommerce-analytics/index.md
+"Ecommerce Analytics", "Retail Analytics", "Shopping Analytics", "Commerce Insights", "Revenue Analytics", "Sales Analytics"
+
+docs/modeling-your-data/visualization/video-media/index.md
+"Video Analytics", "Media Analytics", "Video Insights", "Media Visualization", "Video Metrics", "Content Analytics"
+
+docs/modeling-your-data/visualization/attribution-modeling/index.md
+"Attribution Modeling", "Marketing Attribution", "Attribution Analytics", "Touch Attribution", "Attribution Analysis", "Marketing ROI"
+
+docs/modeling-your-data/visualization/index.md
+"Data Visualization", "Analytics Dashboard", "Data Charts", "Visual Analytics", "BI Tools", "Data Insights"
+
+docs/modeling-your-data/visualization/marketing-dashboards/index.md
+"Marketing Dashboards", "Marketing Analytics", "Campaign Analytics", "Marketing Insights", "Marketing ROI", "Campaign Performance"
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/dbt/index.md
+"DBT Models", "Data Transformation", "SQL Models", "Analytics Engineering", "Data Modeling", "DBT Pipeline"
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/dbt/resolving-data-model-failures/index.md
+"DBT Troubleshooting", "Model Failures", "DBT Debugging", "Model Errors", "Data Issues", "DBT Resolution"
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/retrieving-job-execution-data-via-the-api/index.md
+"Job Execution", "API Data", "Execution Analytics", "Job Monitoring", "Pipeline API", "Execution Metrics"
+
+docs/modeling-your-data/running-data-models-via-snowplow-bdp/index.md
+"Snowplow BDP", "Managed Models", "BDP Pipeline", "Managed Analytics", "Cloud Pipeline", "Enterprise Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/sql-runner-mobile-data-model/index.md
+"SQL Runner Mobile", "Mobile SQL", "Mobile Analytics", "SQL Models", "Mobile Data", "App Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/migrating-to-dbt/index.md
+"SQL to DBT", "Migration Guide", "DBT Migration", "SQL Migration", "Model Migration", "Analytics Migration"
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/index.md
+"SQL Runner", "SQL Models", "Data Transformation", "SQL Analytics", "Legacy Models", "SQL Pipeline"
+
+docs/modeling-your-data/modeling-your-data-with-sql-runner/sql-runner-web-data-model/index.md
+"SQL Runner Web", "Web SQL", "Web Analytics", "SQL Models", "Web Data", "Website Analytics"
+
+docs/modeling-your-data/index.md
+"Data Modeling", "Analytics Models", "Data Transformation", "Data Engineering", "Analytics Engineering", "Data Pipeline"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/ecommerce/index.md
+"Ecommerce Migration", "DBT Migration", "Commerce Models", "Retail Migration", "Shopping Analytics", "DBT Upgrade"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/web/index.md
+"Web Migration", "DBT Migration", "Web Models", "Website Migration", "Web Analytics", "DBT Upgrade"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/web_to_unified/index.md
+"Web to Unified", "Model Migration", "Unified Models", "Analytics Migration", "DBT Migration", "Model Upgrade"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/media-player/index.md
+"Media Migration", "Video Migration", "Media Models", "Video Analytics", "DBT Migration", "Media DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/unified/index.md
+"Unified Migration", "Model Migration", "DBT Migration", "Unified Analytics", "Cross Platform", "DBT Upgrade"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/utils/index.md
+"Utils Migration", "DBT Utils", "Utility Migration", "Helper Migration", "DBT Utilities", "Support Migration"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/normalize/index.md
+"Normalize Migration", "Data Normalization", "DBT Migration", "Schema Migration", "Data Structure", "DBT Upgrade"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/index.md
+"DBT Migration", "Model Migration", "Version Migration", "Upgrade Guide", "Breaking Changes", "Migration Guide"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/mobile/index.md
+"Mobile Migration", "App Migration", "Mobile Models", "Mobile Analytics", "DBT Migration", "App DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/attribution/index.md
+"Attribution Migration", "Marketing Migration", "Attribution Models", "Marketing Analytics", "DBT Migration", "Attribution DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/migration-guides/fractribution/index.md
+"Fractribution Migration", "Attribution Migration", "Marketing Migration", "Fractional Attribution", "DBT Migration", "Attribution DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/index.md
+"DBT Models", "Data Transformation", "SQL Models", "Analytics Engineering", "DBT Package", "Data Modeling"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-normalize-data-model/index.md
+"DBT Normalize", "Data Normalization", "Schema Normalization", "Data Structure", "DBT Package", "Data Organization"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-media-player-data-model/index.md
+"DBT Media", "Video DBT", "Media Analytics", "Video Models", "Media Transformation", "Content Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-attribution-data-model/keeping-cohesion-with-unified/index.md
+"Attribution Unified", "Model Cohesion", "Unified Attribution", "Cross Platform", "Attribution Analytics", "Model Integration"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-attribution-data-model/index.md
+"DBT Attribution", "Marketing Attribution", "Attribution Analytics", "Marketing Models", "Attribution DBT", "Marketing DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-attribution-data-model/custom-implementations/index.md
+"Custom Attribution", "Attribution Custom", "Bespoke Attribution", "Marketing Custom", "Attribution Logic", "Custom Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-mobile-data-model/app-errors-module/index.md
+"Mobile Errors", "App Errors", "Error Analytics", "Mobile DBT", "App Analytics", "Error Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-mobile-data-model/index.md
+"DBT Mobile", "Mobile Analytics", "App Analytics", "Mobile Models", "Mobile DBT", "App DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/core-web-vitals-module/index.md
+"Web Vitals DBT", "Performance DBT", "Core Vitals", "Web Performance", "Performance Analytics", "UX Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/conversions/index.md
+"Web Conversions", "Conversion Analytics", "Web DBT", "Conversion Models", "Goal Analytics", "Conversion Tracking"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/consent-module/index.md
+"Consent DBT", "Privacy DBT", "GDPR DBT", "Consent Analytics", "Privacy Models", "Consent Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-web-data-model/index.md
+"DBT Web", "Web Analytics", "Website Analytics", "Web Models", "Web DBT", "Website DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/index.md
+"Legacy DBT", "Legacy Models", "Deprecated Models", "Old Models", "Previous Versions", "Legacy Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/legacy/dbt-fractribution-data-model/index.md
+"DBT Fractribution", "Fractional Attribution", "Attribution Analytics", "Marketing DBT", "Attribution Models", "Marketing Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-ecommerce-data-model/index.md
+"DBT Ecommerce", "Commerce Analytics", "Retail DBT", "Shopping Analytics", "Ecommerce Models", "Sales Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-utils-data-model/index.md
+"DBT Utils", "DBT Utilities", "Helper Functions", "DBT Tools", "Utility Models", "Support Functions"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/index.md
+"DBT Models", "Data Models", "Analytics Models", "DBT Package", "Data Transformation", "SQL Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/app-errors-module/index.md
+"Unified Errors", "App Errors", "Error Analytics", "Unified DBT", "Error Models", "Cross Platform"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/core-web-vitals-module/index.md
+"Unified Vitals", "Web Vitals", "Performance DBT", "Core Vitals", "UX Analytics", "Performance Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/overridable-macros/index.md
+"DBT Macros", "Custom Macros", "Overridable Functions", "DBT Customization", "Macro Overrides", "Custom Logic"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/conversions/index.md
+"Unified Conversions", "Conversion Analytics", "Cross Platform", "Unified DBT", "Conversion Models", "Goal Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/consent-module/index.md
+"Unified Consent", "Privacy DBT", "GDPR Models", "Consent Analytics", "Privacy Models", "Cross Platform"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-models/dbt-unified-data-model/index.md
+"DBT Unified", "Unified Analytics", "Cross Platform", "Unified Models", "Multi Platform", "Unified DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/dbt-tests/index.md
+"DBT Tests", "Data Testing", "Quality Tests", "DBT Validation", "Test Framework", "Data Quality"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/debugging/index.md
+"DBT Debugging", "Model Debugging", "DBT Troubleshooting", "Debug Tools", "Model Issues", "DBT Errors"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/backfilling/index.md
+"DBT Backfill", "Historical Data", "Data Backfill", "Model Backfill", "DBT History", "Data Recovery"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/full-or-partial-refreshes/index.md
+"DBT Refresh", "Model Refresh", "Full Refresh", "Partial Refresh", "DBT Operations", "Model Updates"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/disabling-models/index.md
+"Disable Models", "DBT Control", "Model Management", "DBT Configuration", "Model Toggle", "DBT Settings"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/async-runs/index.md
+"Async DBT", "Parallel Processing", "DBT Performance", "Concurrent Runs", "Async Models", "Performance Optimization"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/index.md
+"DBT Operations", "Model Operations", "DBT Management", "Pipeline Operations", "DBT Workflow", "Data Operations"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/lakes/index.md
+"DBT Lakes", "Data Lakes", "Lake Models", "Big Data", "Lake Analytics", "Data Lake"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-operation/model-selection/index.md
+"Model Selection", "DBT Selection", "Model Targeting", "DBT Filter", "Model Scope", "DBT Targeting"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/this-run-tables/index.md
+"This Run", "DBT Tables", "Run Tables", "DBT Mechanics", "Incremental Processing", "DBT Internals"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/overridable-macros/index.md
+"Macro Override", "DBT Macros", "Custom Macros", "Macro Customization", "DBT Functions", "Custom Logic"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/dispatch/index.md
+"DBT Dispatch", "Macro Dispatch", "Function Dispatch", "DBT Routing", "Macro Selection", "DBT Framework"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/late-arriving-data/index.md
+"Late Data", "Delayed Data", "Data Arrival", "Late Events", "DBT Handling", "Data Timeliness"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/deduplication/index.md
+"Data Deduplication", "Duplicate Removal", "DBT Dedup", "Data Cleaning", "Unique Records", "Data Quality"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/optimized-upserts/index.md
+"DBT Upserts", "Data Upserts", "Optimized Updates", "Merge Operations", "Data Sync", "Incremental Updates"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/incremental-processing/full-run-calculation/index.md
+"Full Run", "Complete Processing", "DBT Calculation", "Full Refresh", "Complete Analysis", "Full Processing"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/incremental-processing/index.md
+"Incremental Processing", "DBT Incremental", "Incremental Models", "Delta Processing", "Incremental Updates", "Stream Processing"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/index.md
+"Package Mechanics", "DBT Internals", "Package Architecture", "DBT Framework", "Package Design", "DBT Structure"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-mechanics/manifest-tables/index.md
+"Manifest Tables", "DBT Manifest", "Model Registry", "Table Registry", "DBT Metadata", "Model Tracking"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/index.md
+"Custom Models", "Bespoke Models", "Custom DBT", "Model Development", "Custom Analytics", "Tailored Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/new-derived-model/index.md
+"Derived Model", "Custom Model", "Model Creation", "New Model", "Model Development", "DBT Examples"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/additional-sql-on-events-this-run/index.md
+"Custom SQL", "Additional SQL", "SQL Enhancement", "Event SQL", "Custom Logic", "SQL Extension"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/daily-aggregate-table/index.md
+"Daily Aggregates", "Aggregate Tables", "Daily Reports", "Aggregation Models", "Daily Analytics", "Aggregate Data"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/index.md
+"Model Examples", "DBT Examples", "Custom Examples", "Model Samples", "Implementation Examples", "Code Examples"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/using-mulit-valued-entities/index.md
+"Multi Entities", "Multiple Values", "Entity Arrays", "Complex Entities", "Entity Processing", "Multi Value"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/adding-fields-to-derived-table/index.md
+"Custom Fields", "Additional Fields", "Field Extension", "Table Enhancement", "Custom Columns", "Field Addition"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/using-different-sessionisation/index.md
+"Custom Sessionization", "Session Logic", "Session Rules", "Custom Sessions", "Session Definition", "Session Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/examples/incorporating-non-snowplow-data/index.md
+"External Data", "Third Party", "Non Snowplow", "Data Integration", "External Sources", "Data Blending"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/high-volume-optimizations/index.md
+"High Volume", "Performance Optimization", "Scale Optimization", "Big Data", "Volume Handling", "Performance Tuning"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/custom-identifiers/index.md
+"Custom Identifiers", "Custom IDs", "Identifier Logic", "ID Management", "Custom Keys", "Identity Features"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/modeling-entities/index.md
+"Entity Modeling", "Entity Processing", "Entity Analytics", "Entity Models", "Context Modeling", "Entity Data"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/custom-aggregations/index.md
+"Custom Aggregations", "Custom Metrics", "Aggregation Logic", "Custom Calculations", "Metric Creation", "Custom Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/identity-stitching/index.md
+"Identity Stitching", "User Stitching", "Identity Resolution", "User Matching", "Cross Device", "Identity Linking"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/index.md
+"Package Features", "DBT Features", "Model Features", "Package Capabilities", "Advanced Features", "DBT Tools"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/passthrough-fields/index.md
+"Passthrough Fields", "Custom Fields", "Field Passthrough", "Additional Columns", "Field Extension", "Custom Data"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/package-features/table-grants/index.md
+"Table Grants", "Access Control", "Permissions", "DBT Security", "Table Access", "Data Permissions"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/ecommerce/index.md
+"Ecommerce Quickstart", "Commerce Setup", "Retail Analytics", "Shopping Analytics", "Ecommerce DBT", "Commerce Guide"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/media-player/index.md
+"Media Quickstart", "Video Setup", "Media Analytics", "Video DBT", "Media Guide", "Content Analytics"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/unified/index.md
+"Unified Quickstart", "Unified Setup", "Cross Platform", "Unified Analytics", "Multi Platform", "Unified Guide"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/web/index.md
+"Web Quickstart", "Website Setup", "Web Analytics", "Web DBT", "Website Guide", "Web Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/index.md
+"Legacy Quickstart", "Legacy Setup", "Old Models", "Deprecated Setup", "Legacy Guide", "Previous Versions"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/mobile/index.md
+"Mobile Quickstart", "App Setup", "Mobile Analytics", "Mobile DBT", "App Guide", "Mobile Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/legacy/fractribution/index.md
+"Fractribution Quickstart", "Attribution Setup", "Marketing Attribution", "Attribution Guide", "Marketing DBT", "Attribution Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/utils/index.md
+"Utils Quickstart", "Utilities Setup", "Helper Setup", "Utils Guide", "DBT Utilities", "Support Tools"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/normalize/index.md
+"Normalize Quickstart", "Normalization Setup", "Data Structure", "Schema Setup", "Normalize Guide", "Data Organization"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/index.md
+"DBT Quickstart", "DBT Setup", "Getting Started", "DBT Guide", "Quick Setup", "DBT Installation"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/attribution/index.md
+"Attribution Quickstart", "Marketing Setup", "Attribution Analytics", "Marketing Attribution", "Attribution Guide", "Marketing DBT"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/ecommerce/index.mdx
+"Ecommerce Config", "Commerce Configuration", "Retail Config", "Shopping Setup", "Ecommerce DBT", "Commerce Settings"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/media-player/index.mdx
+"Media Config", "Video Configuration", "Media Setup", "Video DBT", "Media Settings", "Content Config"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/unified/index.mdx
+"Unified Config", "Unified Configuration", "Cross Platform", "Unified Setup", "Multi Platform", "Unified Settings"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/web/index.mdx
+"Web Config", "Website Configuration", "Web Setup", "Web DBT", "Website Settings", "Web Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/index.md
+"Legacy Config", "Legacy Configuration", "Old Settings", "Deprecated Config", "Legacy Setup", "Previous Config"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/mobile/index.mdx
+"Mobile Config", "App Configuration", "Mobile Setup", "Mobile DBT", "App Settings", "Mobile Models"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/legacy/fractribution/index.mdx
+"Fractribution Config", "Attribution Configuration", "Marketing Config", "Attribution Setup", "Marketing DBT", "Attribution Settings"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/utils/index.mdx
+"Utils Config", "Utilities Configuration", "Helper Config", "Utils Setup", "DBT Utilities", "Support Config"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/normalize/index.mdx
+"Normalize Config", "Normalization Configuration", "Data Structure", "Schema Config", "Normalize Setup", "Data Organization"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/index.md
+"DBT Configuration", "DBT Config", "Model Configuration", "DBT Settings", "Package Config", "DBT Setup"
+
+docs/modeling-your-data/modeling-your-data-with-dbt/dbt-configuration/attribution/index.mdx
+"Attribution Config", "Marketing Configuration", "Attribution Setup", "Marketing DBT", "Attribution Settings", "Marketing Config"
+
+docs/get-started/tooling/index.md
+"Snowplow Tooling", "Analytics Tools", "Development Tools", "Platform Tools", "Getting Started", "Tool Overview"
+
+docs/get-started/feature-comparison/index.md
+"Feature Comparison", "Edition Comparison", "Platform Features", "Feature Matrix", "Product Comparison", "Feature Overview"
+
+docs/get-started/modeling/index.md
+"Data Modeling", "Getting Started", "Model Introduction", "Analytics Modeling", "Data Transformation", "Model Basics"
+
+docs/get-started/failed-events/index.md
+"Failed Events", "Error Handling", "Getting Started", "Event Errors", "Data Quality", "Error Management"
+
+docs/get-started/index.md
+"Getting Started", "Snowplow Introduction", "Quick Start", "Platform Overview", "Analytics Platform", "First Steps"
+
+docs/get-started/custom-events/index.md
+"Custom Events", "Event Creation", "Getting Started", "Custom Analytics", "Event Design", "Bespoke Events"
+
+docs/get-started/tracking/cookies-and-ad-blockers/index.md
+"Cookie Blockers", "Ad Blockers", "Privacy Tracking", "Tracking Challenges", "Analytics Blocking", "Privacy Issues"
+
+docs/get-started/tracking/index.md
+"Event Tracking", "Analytics Tracking", "Getting Started", "Data Collection", "Tracking Setup", "Behavioral Tracking"
+
+docs/get-started/snowplow-bdp/setup-guide-gcp/index.md
+"BDP GCP", "Google Cloud", "BDP Setup", "Cloud Setup", "GCP Guide", "Enterprise Setup"
+
+docs/get-started/snowplow-bdp/index.md
+"Snowplow BDP", "Behavioral Data Platform", "Enterprise Analytics", "Managed Platform", "Cloud Analytics", "BDP Overview"
+
+docs/get-started/snowplow-bdp/setup-guide-azure/index.md
+"BDP Azure", "Azure Setup", "BDP Setup", "Cloud Setup", "Azure Guide", "Enterprise Setup"
+
+docs/get-started/snowplow-bdp/setup-guide-aws/index.md
+"BDP AWS", "AWS Setup", "BDP Setup", "Cloud Setup", "AWS Guide", "Enterprise Setup"
+
+docs/get-started/querying/index.md
+"Data Querying", "SQL Queries", "Getting Started", "Data Analysis", "Query Guide", "Analytics Queries"
+
+docs/get-started/snowplow-community-edition/faq/index.md
+"Community FAQ", "Community Edition", "Open Source", "FAQ Guide", "Common Questions", "Community Help"
+
+docs/get-started/snowplow-community-edition/what-is-deployed/index.md
+"Community Deployment", "What Deployed", "Infrastructure Overview", "Deployment Guide", "Community Setup", "Architecture Overview"
+
+docs/get-started/snowplow-community-edition/index.md
+"Community Edition", "Open Source", "Free Version", "Community Platform", "OSS Analytics", "Community Setup"
+
+docs/get-started/snowplow-community-edition/quick-start/index.md
+"Community Quickstart", "Open Source", "Community Setup", "Quick Start", "Free Setup", "Community Guide"
+
+docs/get-started/snowplow-community-edition/telemetry/index.md
+"Community Telemetry", "Usage Telemetry", "Anonymous Metrics", "Community Analytics", "Platform Telemetry", "Usage Data"
+
+docs/get-started/snowplow-community-edition/upgrade-guide/index.md
+"Community Upgrade", "Version Upgrade", "Migration Guide", "Upgrade Process", "Community Migration", "Version Update"
+
+docs/get-started/snowplow-community-edition/what-is-quick-start/index.md
+"Quick Start", "Community Quick Start", "Rapid Setup", "Fast Deployment", "Quick Setup", "Instant Setup"
+
+tutorials/unified-digital/setting-up-locally.md
+"Unified Local", "Local Setup", "Development Setup", "Local Analytics", "Unified Tutorial", "Local Development"
+
+tutorials/unified-digital/setting-up-via-console.md
+"Console Setup", "Unified Console", "Web Console", "Console Tutorial", "Unified Setup", "Console Guide"
+
+tutorials/unified-digital/intro.md
+"Unified Tutorial", "Unified Analytics", "Cross Platform", "Tutorial Introduction", "Multi Platform", "Unified Guide"
+
+tutorials/unified-digital/viewing-output-data.md
+"Output Data", "Data Viewing", "Results Analysis", "Data Output", "Analytics Results", "Data Visualization"
+
+tutorials/kafka-live-viewer-profiles/conclusion.md
+"Kafka Conclusion", "Tutorial Conclusion", "Kafka Tutorial", "Real Time", "Stream Processing", "Live Data"
+
+tutorials/kafka-live-viewer-profiles/quickstart-localstack.md
+"Kafka Localstack", "Local Kafka", "Localstack Setup", "Development Kafka", "Local Stream", "Kafka Development"
+
+tutorials/kafka-live-viewer-profiles/introduction.md
+"Kafka Tutorial", "Real Time", "Stream Processing", "Kafka Introduction", "Live Analytics", "Stream Analytics"
+
+tutorials/kafka-live-viewer-profiles/deploy-aws-terraform.md
+"Kafka AWS", "Terraform Kafka", "AWS Deployment", "Infrastructure Code", "Kafka Terraform", "Cloud Kafka"
+
+tutorials/enrichments/enabling-via-terraform.md
+"Terraform Enrichments", "Infrastructure Code", "Enrichment Deployment", "Terraform Setup", "IaC Enrichments", "Automated Enrichments"
+
+tutorials/enrichments/intro.md
+"Enrichment Tutorial", "Data Enrichment", "Event Enhancement", "Enrichment Guide", "Tutorial Introduction", "Processing Tutorial"
+
+tutorials/enrichments/configurable-enrichment-list.md
+"Enrichment List", "Available Enrichments", "Enrichment Catalog", "Enhancement Options", "Enrichment Types", "Processing Options"
+
+tutorials/android-event-tracking/examining-events.md
+"Android Events", "Event Examination", "Mobile Events", "Android Analytics", "Event Analysis", "Mobile Tutorial"
+
+tutorials/android-event-tracking/screen-views.md
+"Android Screens", "Screen Views", "Mobile Screens", "Android Navigation", "Screen Analytics", "Mobile Tracking"
+
+tutorials/android-event-tracking/installation.md
+"Android Installation", "Mobile Setup", "Android SDK", "App Installation", "Mobile Integration", "Android Guide"
+
+tutorials/data-structures-in-git/conclusion.md
+"Git Conclusion", "Schema Git", "Version Control", "Git Tutorial", "Schema Management", "Git Workflow"
+
+tutorials/data-structures-in-git/verify-github-setup.md
+"GitHub Verification", "Git Setup", "GitHub Config", "Repository Setup", "Git Verification", "GitHub Tutorial"
+
+tutorials/data-structures-in-git/follow-up-with-data-products.md
+"Data Products", "Schema Products", "Product Follow-up", "Data Management", "Schema Integration", "Product Tutorial"
+
+tutorials/data-structures-in-git/introduction.md
+"Git Tutorial", "Schema Git", "Version Control", "Git Introduction", "Schema Management", "Git Workflow"
+
+tutorials/data-structures-in-git/validation-and-publishing.md
+"Schema Validation", "Schema Publishing", "Git Validation", "Schema CI", "Schema Deployment", "Git Publishing"
+
+tutorials/data-structures-in-git/automate-with-github-actions.md
+"GitHub Actions", "Schema Automation", "CI/CD", "Git Automation", "Schema CI", "Automated Workflows"
+
+tutorials/data-structures-in-git/local-setup.md
+"Git Local", "Local Git", "Git Setup", "Local Development", "Git Configuration", "Development Setup"
+
+tutorials/snowplow-cli-mcp/setup.md
+"CLI MCP", "MCP Setup", "CLI Configuration", "MCP Integration", "Command Line", "MCP Tutorial"
+
+tutorials/snowplow-cli-mcp/introduction.md
+"CLI MCP", "MCP Introduction", "Command Line", "MCP Tutorial", "CLI Integration", "Model Context"
+
+tutorials/snowplow-cli-mcp/next-steps.md
+"MCP Next Steps", "CLI Advanced", "Next Steps", "MCP Progression", "CLI Development", "Advanced Tutorial"
+
+tutorials/snowplow-cli-mcp/basic-workflow.md
+"MCP Workflow", "CLI Workflow", "Basic Workflow", "MCP Process", "Command Workflow", "CLI Process"
+
+tutorials/index.md
+"Snowplow Tutorials", "Tutorial Index", "Learning Guides", "Step-by-Step", "Tutorial Overview", "Learning Resources"
+
+tutorials/attribution/setting-up-locally.md
+"Attribution Local", "Local Attribution", "Attribution Setup", "Marketing Local", "Local Analytics", "Attribution Development"
+
+tutorials/attribution/setting-up-via-console.md
+"Attribution Console", "Console Setup", "Attribution Tutorial", "Marketing Console", "Attribution Guide", "Console Attribution"
+
+tutorials/attribution/intro.md
+"Attribution Tutorial", "Marketing Attribution", "Attribution Introduction", "Attribution Guide", "Marketing Analytics", "Attribution Overview"
+
+tutorials/attribution/optional-configuring-channel-group-classification.md
+"Channel Classification", "Marketing Channels", "Channel Groups", "Attribution Channels", "Marketing Categories", "Channel Mapping"
+
+tutorials/attribution/before-you-start.md
+"Attribution Prerequisites", "Before Start", "Attribution Setup", "Prerequisites", "Getting Ready", "Attribution Prep"
+
+tutorials/attribution/enabling-unified-conversions.md
+"Unified Conversions", "Attribution Conversions", "Cross Platform", "Conversion Attribution", "Unified Attribution", "Marketing Conversions"
+
+tutorials/attribution/optional-adding-marketing-spend-source.md
+"Marketing Spend", "Spend Attribution", "Marketing Costs", "ROI Attribution", "Campaign Spend", "Marketing Investment"
+
+tutorials/abandoned-browse-ccdp/reverse-etl.md
+"Reverse ETL", "Data Activation", "Customer Data", "CCDP Tutorial", "Data Sync", "Operational Analytics"
+
+tutorials/abandoned-browse-ccdp/conclusion.md
+"CCDP Conclusion", "Tutorial Conclusion", "Customer Data", "CCDP Complete", "Tutorial Summary", "Project Wrap-up"
+
+tutorials/abandoned-browse-ccdp/data-modeling.md
+"CCDP Modeling", "Data Modeling", "Customer Analytics", "Behavioral Modeling", "CCDP Analytics", "Customer Insights"
+
+tutorials/abandoned-browse-ccdp/braze-campaign.md
+"Braze Campaign", "Marketing Campaign", "Customer Engagement", "Braze Integration", "Marketing Automation", "Campaign Tutorial"
+
+tutorials/abandoned-browse-ccdp/introduction.md
+"CCDP Tutorial", "Customer Data", "CCDP Introduction", "Behavioral Analytics", "Customer Analytics", "Data Platform"
+
+tutorials/abandoned-browse-ccdp/tracking-setup.md
+"CCDP Tracking", "Tracking Setup", "Behavioral Tracking", "Customer Tracking", "Event Setup", "CCDP Events"
+
+tutorials/data-products-base-tracking/create-custom-dp.md
+"Custom Data Product", "Product Creation", "Custom Analytics", "Data Product", "Product Development", "Custom DP"
+
+tutorials/data-products-base-tracking/create-base-dp.md
+"Base Data Product", "Product Creation", "Data Product", "Base Analytics", "Product Foundation", "Core DP"
+
+tutorials/data-products-base-tracking/setup-custom-ds.md
+"Custom Data Structure", "Schema Setup", "Custom Schema", "Data Structure", "Schema Creation", "Custom DS"
+
+tutorials/data-products-base-tracking/create-source-application.md
+"Source Application", "App Creation", "Application Setup", "Source App", "App Configuration", "Application Source"
+
+tutorials/data-products-base-tracking/add-event-specs.md
+"Event Specifications", "Event Specs", "Specification Setup", "Event Definition", "Spec Creation", "Event Documentation"
+
+tutorials/data-products-base-tracking/snowtype.md
+"Snowtype Tutorial", "TypeScript Types", "Type Generation", "Type Safety", "Code Generation", "TypeScript Tutorial"
+
+tutorials/data-products-base-tracking/verify-dp-events.md
+"Verify Events", "Event Verification", "Data Validation", "Event Testing", "Product Validation", "Event Checking"
+
+tutorials/data-products-base-tracking/start.md
+"Tutorial Start", "Getting Started", "Data Products", "Product Tutorial", "Tutorial Beginning", "Start Guide"
+
+tutorials/data-products-base-tracking/generate-tracking-code.md
+"Code Generation", "Tracking Code", "Generated Code", "Code Tutorial", "SDK Generation", "Code Creation"
+
+tutorials/data-products-base-tracking/setup-basic-tracking.md
+"Basic Tracking", "Tracking Setup", "Event Setup", "Basic Analytics", "Tracking Tutorial", "Event Tracking"
+
+tutorials/flink-live-shopper-features/conclusion.md
+"Flink Conclusion", "Real Time", "Stream Processing", "Flink Tutorial", "Live Analytics", "Stream Analytics"
+
+tutorials/flink-live-shopper-features/add-calculation.md
+"Flink Calculations", "Stream Calculations", "Real Time", "Live Calculations", "Stream Processing", "Flink Analytics"
+
+tutorials/flink-live-shopper-features/introduction.md
+"Flink Tutorial", "Stream Processing", "Real Time", "Flink Introduction", "Live Analytics", "Stream Analytics"
+
+tutorials/flink-live-shopper-features/run.md
+"Flink Run", "Stream Execution", "Flink Execution", "Real Time", "Stream Run", "Live Processing"
+
+tutorials/flink-live-shopper-features/calculations.md
+"Flink Calculations", "Stream Calculations", "Real Time", "Live Calculations", "Stream Processing", "Analytics Calculations"
+
+docs/api-reference/versions/index.md
+"API Versions", "Version History", "API Documentation", "Version Control", "API Changes", "Version Guide"
+
+docs/api-reference/enrichment-components/enrich-kinesis/index.md
+"Enrich Kinesis", "Stream Enrichment", "AWS Kinesis", "Real Time", "Stream Processing", "Kinesis Enrichment"
+
+docs/api-reference/enrichment-components/enrich-nsq/index.md
+"Enrich NSQ", "NSQ Processing", "Message Queue", "NSQ Enrichment", "Queue Processing", "NSQ Integration"
+
+docs/api-reference/enrichment-components/enrich-pubsub/index.md
+"Enrich PubSub", "Google PubSub", "GCP Enrichment", "Stream Processing", "PubSub Integration", "Cloud Processing"
+
+docs/api-reference/enrichment-components/enrich-kafka/index.md
+"Enrich Kafka", "Kafka Processing", "Stream Processing", "Kafka Enrichment", "Real Time", "Message Processing"
+
+docs/api-reference/enrichment-components/monitoring/index.md
+"Enrichment Monitoring", "Component Monitoring", "Performance Monitoring", "Health Monitoring", "Enrichment Metrics", "System Monitoring"
+
+docs/api-reference/enrichment-components/configuration-reference/index.md
+"Enrichment Configuration", "Component Config", "Enrichment Setup", "Config Reference", "Setup Guide", "Component Settings"
+
+docs/api-reference/enrichment-components/index.md
+"Enrichment Components", "Data Enrichment", "Processing Components", "Enrichment Pipeline", "Event Processing", "Component Reference"
+
+docs/api-reference/trackers/index.md
+"Tracker API", "SDK Reference", "Tracker Documentation", "API Documentation", "SDK API", "Tracker Reference"
+
+docs/api-reference/analytics-sdk/analytics-sdk-javascript/index.md
+"JavaScript SDK", "Analytics SDK", "JS Analytics", "JavaScript API", "Web SDK", "Client SDK"
+
+docs/api-reference/analytics-sdk/analytics-sdk-net/snowplow-event-extractor/index.md
+".NET Extractor", "Event Extractor", ".NET SDK", "Data Extraction", ".NET API", "Event Processing"
+
+docs/api-reference/analytics-sdk/analytics-sdk-net/index.md
+".NET SDK", "Analytics SDK", ".NET API", "C# SDK", "Desktop SDK", "Framework SDK"
+
+docs/api-reference/analytics-sdk/index.md
+"Analytics SDK", "SDK Reference", "Analytics API", "Data SDK", "SDK Documentation", "Analytics Library"
+
+docs/api-reference/analytics-sdk/analytics-sdk-go/index.md
+"Go SDK", "Golang SDK", "Go API", "Server SDK", "Backend SDK", "Go Analytics"
+
+docs/api-reference/analytics-sdk/analytics-sdk-python/index.md
+"Python SDK", "Analytics SDK", "Python API", "Data Science", "Python Analytics", "Server SDK"
+
+docs/api-reference/analytics-sdk/analytics-sdk-scala/index.md
+"Scala SDK", "Analytics SDK", "Scala API", "JVM SDK", "Functional SDK", "Scala Analytics"
+
+docs/api-reference/failed-events/index.md
+"Failed Events API", "Error API", "Event Errors", "API Reference", "Error Handling", "Failed Event API"
+
+docs/api-reference/console-api.md
+"Console API", "Management API", "Admin API", "Platform API", "Console Reference", "Administrative API"
+
+docs/api-reference/index.md
+"API Reference", "API Documentation", "Developer API", "Platform API", "API Guide", "Reference Documentation"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/index.md
+"BigQuery Loader", "Google BigQuery", "Data Warehouse", "BigQuery Integration", "Cloud Warehouse", "GCP Loader"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/configuration-reference/index.md
+"BigQuery Configuration", "Loader Config", "BigQuery Setup", "Warehouse Config", "GCP Configuration", "BigQuery Settings"
+
+docs/api-reference/loaders-storage-targets/google-cloud-storage-loader/index.md
+"GCS Loader", "Cloud Storage", "Google Storage", "GCP Storage", "Cloud Loader", "Storage Loader"
+
+docs/api-reference/loaders-storage-targets/s3-loader/index.md
+"S3 Loader", "Amazon S3", "AWS Storage", "S3 Integration", "Cloud Storage", "AWS Loader"
+
+docs/api-reference/loaders-storage-targets/s3-loader/monitoring/index.md
+"S3 Monitoring", "Loader Monitoring", "Storage Monitoring", "AWS Monitoring", "Performance Monitoring", "S3 Metrics"
+
+docs/api-reference/loaders-storage-targets/s3-loader/configuration-reference/index.md
+"S3 Configuration", "Loader Config", "S3 Setup", "Storage Config", "AWS Configuration", "S3 Settings"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/databricks-loader/index.md
+"Databricks Loader", "Databricks Integration", "Data Lakehouse", "Spark Warehouse", "Analytics Platform", "Databricks Analytics"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/index.md
+"Data Loading", "Transformed Data", "RDB Loading", "Warehouse Loading", "Data Pipeline", "ETL Loading"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/redshift-loader/index.md
+"Redshift Loader", "Amazon Redshift", "Data Warehouse", "AWS Analytics", "Redshift Integration", "Cloud Warehouse"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/monitoring/index.md
+"RDB Monitoring", "Loader Monitoring", "Pipeline Monitoring", "ETL Monitoring", "Data Monitoring", "Loading Metrics"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/snowflake-loader/index.md
+"Snowflake Loader", "Snowflake Integration", "Cloud Warehouse", "Data Cloud", "Snowflake Analytics", "Modern Warehouse"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/index.md
+"RDB Loader", "Relational Database", "Database Loader", "SQL Warehouse", "Data Pipeline", "ETL Component"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/deduplication/index.md
+"Data Deduplication", "Duplicate Removal", "Data Quality", "Event Dedup", "Unique Events", "Data Cleaning"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/index.md
+"Data Transformation", "ETL Transform", "Data Processing", "Enriched Data", "Data Pipeline", "Transform Stage"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/spark-transformer/index.md
+"Spark Transformer", "Apache Spark", "Big Data", "Batch Processing", "Data Transformation", "Spark Processing"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/spark-transformer/configuration-reference/index.md
+"Spark Configuration", "Transformer Config", "Spark Setup", "Big Data Config", "Spark Settings", "Transform Config"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kinesis/index.md
+"Kinesis Transformer", "Stream Transform", "AWS Kinesis", "Real Time", "Stream Processing", "Kinesis Processing"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kinesis/configuration-reference/index.md
+"Kinesis Config", "Stream Config", "Transformer Config", "AWS Config", "Kinesis Settings", "Stream Settings"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-pubsub/index.md
+"PubSub Transformer", "Google PubSub", "Stream Transform", "GCP Processing", "Real Time", "Cloud Processing"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-pubsub/configuration-reference/index.md
+"PubSub Config", "GCP Config", "Stream Config", "Transformer Config", "PubSub Settings", "Cloud Settings"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/index.md
+"Stream Transformer", "Real Time Transform", "Stream Processing", "Data Transformation", "Real Time ETL", "Stream Pipeline"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kafka/index.md
+"Kafka Transformer", "Stream Transform", "Kafka Processing", "Real Time", "Message Processing", "Stream Processing"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/transforming-enriched-data/stream-transformer/transformer-kafka/configuration-reference/index.md
+"Kafka Config", "Stream Config", "Transformer Config", "Kafka Settings", "Message Config", "Stream Settings"
+
+docs/api-reference/loaders-storage-targets/index.md
+"Storage Targets", "Data Loaders", "Warehouse Loaders", "Storage Solutions", "Data Destinations", "ETL Components"
+
+docs/api-reference/loaders-storage-targets/lake-loader/partitions/index.md
+"Lake Partitions", "Data Partitioning", "Partition Strategy", "Data Lake", "Partition Optimization", "Data Organization"
+
+docs/api-reference/loaders-storage-targets/lake-loader/index.md
+"Lake Loader", "Data Lake", "Big Data Storage", "Lake Storage", "Analytics Lake", "Data Lake Loader"
+
+docs/api-reference/loaders-storage-targets/lake-loader/maintenance/index.md
+"Lake Maintenance", "Data Maintenance", "Lake Operations", "Storage Maintenance", "Data Management", "Lake Optimization"
+
+docs/api-reference/loaders-storage-targets/lake-loader/configuration-reference/index.md
+"Lake Configuration", "Loader Config", "Lake Setup", "Storage Config", "Lake Settings", "Data Lake Config"
+
+docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/index.md
+"Snowflake Streaming", "Real Time Snowflake", "Stream Loading", "Continuous Loading", "Streaming Warehouse", "Real Time Warehouse"
+
+docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/configuration-reference/index.md
+"Snowflake Stream Config", "Streaming Config", "Real Time Config", "Snowflake Settings", "Stream Settings", "Warehouse Config"
+
+docs/api-reference/loaders-storage-targets/snowplow-postgres-loader/postgres-loader-configuration-reference/index.md
+"Postgres Configuration", "PostgreSQL Config", "Database Config", "Postgres Settings", "SQL Config", "Database Settings"
+
+docs/api-reference/loaders-storage-targets/snowplow-postgres-loader/index.md
+"Postgres Loader", "PostgreSQL Loader", "Database Loader", "SQL Loader", "Relational Database", "Postgres Integration"
+
+docs/api-reference/snowplow-mini/setup-guide-for-gcp/index.md
+"Mini GCP", "Mini Setup", "Google Cloud", "Testing Environment", "Development Platform", "GCP Mini"
+
+docs/api-reference/snowplow-mini/control-plane-api/index.md
+"Mini API", "Control Plane", "Mini Management", "API Interface", "Mini Control", "Management API"
+
+docs/api-reference/snowplow-mini/setup-guide-for-aws/index.md
+"Mini AWS", "Mini Setup", "AWS Setup", "Testing Environment", "Development Platform", "AWS Mini"
+
+docs/api-reference/snowplow-mini/index.md
+"Snowplow Mini", "Testing Platform", "Development Environment", "Mini Pipeline", "Testing Framework", "Development Tool"
+
+docs/api-reference/snowplow-mini/usage-guide/index.md
+"Mini Usage", "Testing Guide", "Mini Guide", "Development Guide", "Testing Framework", "Mini Tutorial"
+
+docs/api-reference/snowplow-micro/index.md
+"Snowplow Micro", "Local Testing", "Testing Tool", "Development Environment", "Micro Pipeline", "Local Analytics"
+
+docs/api-reference/snowplow-micro/api/index.md
+"Micro API", "Testing API", "Local API", "Development API", "Micro Interface", "Testing Interface"
+
+docs/api-reference/stream-collector/configure/index.md
+"Collector Configuration", "Stream Collector", "Event Collection", "Collector Setup", "Data Ingestion", "Collection Config"
+
+docs/api-reference/stream-collector/setup/index.md
+"Collector Setup", "Stream Collector", "Collection Setup", "Event Ingestion", "Data Collection", "Collector Installation"
+
+docs/api-reference/stream-collector/index.md
+"Stream Collector", "Event Collection", "Data Ingestion", "Collection Pipeline", "Event Ingestion", "Collector Component"
+
+docs/api-reference/iglu/iglu-repositories/iglu-server/setup/index.md
+"Iglu Server Setup", "Schema Registry", "Iglu Installation", "Registry Setup", "Schema Management", "Iglu Configuration"
+
+docs/api-reference/iglu/iglu-repositories/iglu-server/index.md
+"Iglu Server", "Schema Registry", "Schema Repository", "Schema Management", "Registry Server", "Schema Server"
+
+docs/api-reference/iglu/iglu-repositories/iglu-server/reference/index.md
+"Iglu Reference", "Server Reference", "Schema Registry", "API Reference", "Iglu API", "Registry API"
+
+docs/api-reference/iglu/iglu-repositories/static-repo/index.md
+"Static Repository", "Static Repo", "Schema Repository", "File Repository", "Static Registry", "Local Registry"
+
+docs/api-reference/iglu/iglu-repositories/index.md
+"Iglu Repositories", "Schema Repositories", "Schema Registry", "Registry Types", "Schema Storage", "Repository Management"
+
+docs/api-reference/iglu/iglu-repositories/jvm-embedded-repo/index.md
+"JVM Repository", "Embedded Repository", "JVM Registry", "Java Registry", "Embedded Schema", "JVM Schema"
+
+docs/api-reference/iglu/iglu-repositories/iglu-central/index.md
+"Iglu Central", "Central Registry", "Public Registry", "Schema Hub", "Central Repository", "Public Schemas"
+
+docs/api-reference/iglu/iglu-resolver/index.md
+"Iglu Resolver", "Schema Resolution", "Registry Resolution", "Schema Lookup", "Registry Client", "Schema Client"
+
+docs/api-reference/iglu/iglu-clients/scala-client-setup/index.md
+"Scala Client", "Iglu Scala", "Scala Integration", "JVM Client", "Scala Registry", "Scala Schema"
+
+docs/api-reference/iglu/iglu-clients/ruby-client/index.md
+"Ruby Client", "Iglu Ruby", "Ruby Integration", "Ruby Registry", "Ruby Schema", "Ruby Validation"
+
+docs/api-reference/iglu/iglu-clients/index.md
+"Iglu Clients", "Registry Clients", "Schema Clients", "Client Libraries", "SDK Clients", "Integration Clients"
+
+docs/api-reference/iglu/iglu-clients/objc-client/index.md
+"Objective-C Client", "iOS Client", "Iglu iOS", "Mobile Registry", "iOS Schema", "Objective-C Registry"
+
+docs/api-reference/iglu/igluctl-2/index.md
+"Igluctl", "Schema CLI", "Registry CLI", "Command Line", "Schema Tools", "CLI Tool"
+
+docs/api-reference/iglu/common-architecture/schemaver/index.md
+"SchemaVer", "Schema Versioning", "Version Control", "Schema Evolution", "Version Management", "Schema Versions"
+
+docs/api-reference/iglu/common-architecture/index.md
+"Iglu Architecture", "Registry Architecture", "Schema Architecture", "System Architecture", "Component Architecture", "Design Principles"
+
+docs/api-reference/iglu/common-architecture/self-describing-json-schemas/index.md
+"Self Describing Schemas", "JSON Schema", "Schema Definition", "Self Describing", "Schema Format", "JSON Validation"
+
+docs/api-reference/iglu/common-architecture/schema-resolution/index.md
+"Schema Resolution", "Registry Resolution", "Schema Lookup", "Resolution Process", "Schema Discovery", "Registry Query"
+
+docs/api-reference/iglu/common-architecture/self-describing-jsons/index.md
+"Self Describing JSON", "JSON Format", "Self Describing", "JSON Structure", "Event Format", "Data Format"
+
+docs/api-reference/iglu/common-architecture/iglu-core/index.md
+"Iglu Core", "Core Components", "Registry Core", "Core Architecture", "Iglu Foundation", "Core System"
+
+docs/api-reference/iglu/index.md
+"Iglu Registry", "Schema Registry", "Schema Management", "Registry System", "Schema Repository", "Data Schemas"
+
+docs/api-reference/iglu/iglu-central-setup/index.md
+"Iglu Central Setup", "Central Registry", "Public Registry", "Registry Setup", "Central Repository", "Registry Installation"
+
+docs/api-reference/elasticsearch/index.md
+"Elasticsearch Integration", "Search Analytics", "Elasticsearch Loader", "Search Engine", "Data Search", "Analytics Search"
+
+docs/api-reference/dataflow-runner/index.md
+"Dataflow Runner", "Batch Processing", "Job Runner", "Pipeline Runner", "Batch Jobs", "Processing Engine"
+
+docs/introduction.md
+"Snowplow Introduction", "Platform Overview", "Analytics Platform", "Behavioral Analytics", "Customer Data", "Data Infrastructure"
+
+docs/glossary/index.md
+"Snowplow Glossary", "Analytics Terms", "Platform Terms", "Terminology", "Definitions", "Analytics Glossary"
+
+docs/resources/discourse.md
+"Community Forum", "Discourse Forum", "Community Support", "User Forum", "Community Discussion", "Support Forum"
+
+docs/resources/limited-use-license-faq/index.md
+"Limited Use License", "License FAQ", "Usage License", "License Terms", "Software License", "License Agreement"
+
+docs/resources/copyright-license/index.md
+"Copyright License", "Intellectual Property", "License Terms", "Copyright FAQ", "Legal Terms", "License Information"
+
+docs/resources/community-license-faq/index.md
+"Community License", "Open Source License", "Community FAQ", "OSS License", "Free License", "Community Terms"
+
+docs/resources/index.md
+"Snowplow Resources", "Documentation Resources", "Learning Resources", "Support Resources", "Community Resources", "Help Resources"
+
+docs/resources/personal-and-academic-license-faq/index.md
+"Academic License", "Personal License", "Educational License", "Research License", "Academic Use", "Personal Use"
+
+docs/resources/contributor-license-agreement/index.md
+"Contributor License", "CLA Agreement", "Contribution Terms", "Developer Agreement", "Open Source", "Contributor Agreement"
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/testing/index.md
+"JavaScript Testing", "Enrichment Testing", "Custom Logic", "JS Validation", "Test Framework", "Code Testing"
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/examples/index.md
+"JS Examples", "Enrichment Examples", "JavaScript Code", "Custom Logic", "Code Samples", "Implementation Guide"
+
+docs/pipeline/enrichments/available-enrichments/custom-javascript-enrichment/writing/index.md
+"Writing JavaScript", "JS Development", "Enrichment Code", "Custom Functions", "JavaScript Guide", "Code Writing"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/flink/index.md
+"Flink Recovery", "Stream Processing", "Event Recovery", "Flink Jobs", "Real Time", "Stream Recovery"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/gcp-beam/index.md
+"Beam Recovery", "Google Cloud", "Dataflow Recovery", "Beam Processing", "GCP Pipeline", "Cloud Recovery"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/running/spark/index.md
+"Spark Recovery", "Batch Processing", "Spark Jobs", "Event Recovery", "Big Data", "Spark Processing"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/configuration/configuration-examples/index.md
+"Config Examples", "Recovery Examples", "Configuration Samples", "Setup Examples", "Config Templates", "Example Configs"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/troubleshooting/index.md
+"Recovery Troubleshooting", "Error Resolution", "Debug Guide", "Problem Solving", "Issue Resolution", "Recovery Issues"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/testing/index.md
+"Recovery Testing", "Test Recovery", "Validation Testing", "Recovery Verification", "Test Process", "Quality Testing"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/getting-started/index.md
+"Recovery Guide", "Getting Started", "Recovery Setup", "Initial Setup", "Recovery Basics", "Start Guide"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/extending/index.md
+"Recovery Extension", "Custom Recovery", "Extended Recovery", "Advanced Recovery", "Recovery Enhancement", "Custom Logic"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/monitoring/index.md
+"Recovery Monitoring", "Process Monitoring", "Recovery Metrics", "Performance Monitoring", "Recovery Tracking", "Monitoring Tools"
+
+docs/data-product-studio/data-quality/failed-events/recovering-failed-events/manual/hints-workflows/index.md
+"Recovery Workflows", "Process Hints", "Recovery Tips", "Workflow Guide", "Best Practices", "Process Optimization"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/troubleshooting/index.md
+"Monitoring Troubleshooting", "Alert Issues", "Monitor Problems", "Debug Monitoring", "Alert Debugging", "Monitor Troubleshooting"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/classic-alerts/index.md
+"Classic Alerts", "Legacy Alerts", "Traditional Alerts", "Alert System", "Notification System", "Alert Management"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/creating-alerts/index.md
+"Creating Alerts", "Alert Setup", "Alert Configuration", "Alert Creation", "Notification Setup", "Alert Builder"
+
+docs/data-product-studio/data-quality/failed-events/monitoring-failed-events/alerts/failed-event-alerts/managing-alerts/index.md
+"Alert Management", "Managing Alerts", "Alert Administration", "Alert Control", "Notification Management", "Alert Operations"
+
+docs/data-product-studio/data-quality/failed-events/exploring-failed-events/file-storage/index.md
+"File Storage", "Event Storage", "Failed Events", "Storage Analysis", "File Analysis", "Storage Explorer"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/anonymous-tracking/index.md
+"React Native Anonymous", "Anonymous Tracking", "Privacy Protection", "React Native Privacy", "Anonymous Analytics", "Privacy Mode"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/custom-tracking-using-schemas/index.md
+"React Native Custom", "Custom Tracking", "Schema Tracking", "Custom Events", "Event Schemas", "Custom Analytics"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/introduction/index.md
+"React Native Introduction", "Mobile Introduction", "React Native Guide", "Mobile Setup", "Cross Platform", "Getting Started"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/platform-and-application-context/index.md
+"React Native Platform", "App Context", "Platform Context", "Device Context", "Mobile Platform", "Application Data"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/exception-tracking/index.md
+"React Native Exceptions", "Exception Tracking", "Error Tracking", "Mobile Errors", "App Crashes", "Error Analytics"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/lifecycle-tracking/index.md
+"React Native Lifecycle", "App Lifecycle", "Mobile Lifecycle", "App Events", "Lifecycle Events", "App State"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/installation-tracking/index.md
+"React Native Installation", "App Installation", "Install Tracking", "First Launch", "Mobile Install", "Installation Events"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/screen-tracking/index.md
+"React Native Screens", "Screen Tracking", "Screen Views", "Mobile Screens", "Navigation Tracking", "Screen Analytics"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/tracking-events/session-tracking/index.md
+"React Native Sessions", "Session Tracking", "User Sessions", "Mobile Sessions", "Session Analytics", "Session Management"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/expo/index.md
+"React Native Expo", "Expo Integration", "Expo Setup", "Cross Platform", "Mobile Development", "Expo Analytics"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/client-side-properties/index.md
+"React Native Properties", "Client Properties", "Device Properties", "Mobile Properties", "Client Data", "Device Information"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/advanced-usage/index.md
+"React Native Advanced", "Advanced Usage", "Advanced Features", "Expert Guide", "Advanced Analytics", "Power Features"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/hybrid-apps/index.md
+"React Native Hybrid", "Hybrid Apps", "WebView Tracking", "Cross Platform", "Hybrid Analytics", "WebView Integration"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v2-reference/quick-start-guide/index.md
+"React Native Quick Start", "Mobile Quick Start", "Getting Started", "Setup Guide", "Installation Guide", "Mobile Setup"
+
+docs/sources/trackers/react-native-tracker/previous-version/react-native-tracker-v0-reference/index.md
+"React Native V0", "Legacy Version", "Previous Version", "Old Version", "Version Zero", "Deprecated Version"
+
+docs/sources/trackers/react-native-tracker/migration-guides/migrating-from-v1-x-to-v2/index.md
+"React Native Migration", "V1 to V2", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/react-native-tracker/migration-guides/migrating-from-v2-x-to-v4/index.md
+"React Native Migration", "V2 to V4", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/react-native-tracker/migration-guides/migrating-from-v0-x-to-v1/index.md
+"React Native Migration", "V0 to V1", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-settings-variable/index.md
+"GTM V3 Settings", "Legacy GTM", "Previous Version", "Tag Manager", "GTM Configuration", "Settings Variable"
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/tag-template-guide/index.md
+"GTM V3 Tags", "Tag Template", "Legacy GTM", "Tag Guide", "Tag Manager", "Template Guide"
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/tag-template-guide/plugins.md
+"GTM V3 Plugins", "Tag Plugins", "Legacy GTM", "GTM Extensions", "Tag Features", "Plugin Guide"
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/ecommerce-tag-template/ecommerce-tag-configuration/index.md
+"GTM V3 Ecommerce", "Ecommerce Configuration", "Legacy GTM", "Shopping Tags", "Ecommerce Setup", "Commerce Configuration"
+
+docs/sources/trackers/google-tag-manager/previous-versions/v3/v3-tags/ecommerce-tag-template/index.md
+"GTM V3 Ecommerce", "Ecommerce Template", "Legacy GTM", "Shopping Template", "Commerce Tags", "Retail Template"
+
+docs/sources/trackers/google-tag-manager/previous-versions/template-for-javascript-tracker-v2/index.md
+"GTM JavaScript V2", "Legacy JavaScript", "JS Tracker V2", "Previous Version", "Old Template", "Deprecated Template"
+
+docs/sources/trackers/node-js-tracker/migration-guides/v3-to-v4-migration-guide/index.md
+"Node.js Migration", "V3 to V4", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/configuration/index.md
+"Node.js V0.3.0", "Legacy Version", "Previous Configuration", "Old Version", "Deprecated Version", "Legacy Config"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/setup/index.md
+"Node.js V0.3.0", "Legacy Setup", "Previous Version", "Old Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/initialization/index.md
+"Node.js V0.3.0", "Legacy Initialization", "Previous Version", "Old Init", "Deprecated Init", "Legacy Setup"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-3-0/configuration-2/index.md
+"Node.js V0.3.0", "Legacy Configuration", "Previous Config", "Old Configuration", "Deprecated Config", "Legacy Settings"
+
+docs/sources/trackers/node-js-tracker/previous-versions/javascript-tracker-core/index.md
+"JavaScript Core", "Tracker Core", "Core Library", "Core Components", "Base Library", "Foundation Library"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/configuration/index.md
+"Node.js V0.4.0", "Legacy Version", "Previous Configuration", "Old Version", "Deprecated Version", "Legacy Config"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/setup/index.md
+"Node.js V0.4.0", "Legacy Setup", "Previous Version", "Old Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/tracking-events/index.md
+"Node.js V0.4.0", "Legacy Events", "Previous Version", "Old Events", "Deprecated Events", "Legacy Tracking"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-0-4-0/initialization/index.md
+"Node.js V0.4.0", "Legacy Initialization", "Previous Version", "Old Init", "Deprecated Init", "Legacy Setup"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/configuration/index.md
+"Node.js V3", "Legacy Version", "Previous Configuration", "V3 Configuration", "Deprecated Version", "Legacy Config"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/setup/index.md
+"Node.js V3", "Legacy Setup", "Previous Version", "V3 Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/tracking-events/index.md
+"Node.js V3", "Legacy Events", "Previous Version", "V3 Events", "Deprecated Events", "Legacy Tracking"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/initialization/index.md
+"Node.js V3", "Legacy Initialization", "Previous Version", "V3 Init", "Deprecated Init", "Legacy Setup"
+
+docs/sources/trackers/node-js-tracker/previous-versions/node-js-tracker-v3/api-reference.md
+"Node.js V3 API", "Legacy API", "Previous API", "V3 Reference", "Deprecated API", "API Documentation"
+
+docs/sources/trackers/java-tracker/migration-guides/migration-guide-v0-12/index.md
+"Java Migration", "V0.12 Migration", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/java-tracker/migration-guides/migration-guide-v1/index.md
+"Java Migration", "V1 Migration", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/configuring-how-events-are-sent/index.md
+"Java V0.12", "Legacy Configuration", "Previous Version", "Event Sending", "Deprecated Version", "Legacy Setup"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/custom-tracking-using-schemas/index.md
+"Java V0.12", "Legacy Custom", "Previous Version", "Custom Tracking", "Deprecated Version", "Legacy Events"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/tracking-events/index.md
+"Java V0.12", "Legacy Events", "Previous Version", "Event Tracking", "Deprecated Version", "Legacy Tracking"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/tracking-specific-client-side-properties/index.md
+"Java V0.12", "Legacy Properties", "Previous Version", "Client Properties", "Deprecated Version", "Legacy Context"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/what-do-java-tracker-events-look-like/index.md
+"Java V0.12", "Event Format", "Previous Version", "Event Structure", "Deprecated Version", "Legacy Format"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-12/installation-and-set-up/index.md
+"Java V0.12", "Legacy Installation", "Previous Version", "Setup Guide", "Deprecated Version", "Legacy Setup"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/emitter/index.md
+"Java V0.11", "Legacy Emitter", "Previous Version", "Event Sending", "Deprecated Version", "Legacy Transport"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/setup/index.md
+"Java V0.11", "Legacy Setup", "Previous Version", "Installation Guide", "Deprecated Version", "Legacy Installation"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/initialization/index.md
+"Java V0.11", "Legacy Initialization", "Previous Version", "Setup Guide", "Deprecated Version", "Legacy Init"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/payload-and-logging/index.md
+"Java V0.11", "Legacy Payload", "Previous Version", "Logging", "Deprecated Version", "Legacy Data"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/tracking-specific-events/index.md
+"Java V0.11", "Legacy Events", "Previous Version", "Event Tracking", "Deprecated Version", "Legacy Tracking"
+
+docs/sources/trackers/java-tracker/previous-versions/java-tracker-v0-11/adding-extra-data-the-subject-class/index.md
+"Java V0.11", "Legacy Subject", "Previous Version", "Subject Class", "Deprecated Version", "Legacy Context"
+
+docs/sources/trackers/java-tracker/demos/index.md
+"Java Demos", "Java Examples", "Sample Applications", "Demo Apps", "Java Samples", "Example Code"
+
+docs/sources/trackers/c-tracker/upgrading-to-newer-versions/index.md
+"C Tracker Upgrade", "Version Upgrade", "Migration Guide", "C Migration", "Upgrade Guide", "Breaking Changes"
+
+docs/sources/trackers/web-trackers/migration-guides/v2-to-v3-migration-guide/index.md
+"Web Tracker Migration", "V2 to V3", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/web-trackers/migration-guides/v3-to-v4-migration-guide/index.md
+"Web Tracker Migration", "V3 to V4", "Version Migration", "Upgrade Guide", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/web-trackers/example-app.md
+"Web Example App", "Sample Application", "Demo App", "Example Code", "Web Demo", "JavaScript Example"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-ios-tracker-sdk-from-version-1-x-to-2-0/index.md
+"iOS Migration", "V1 to V2", "iOS Upgrade", "Mobile Migration", "Version Migration", "Breaking Changes"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-from-version-3-x-to-4-0/index.md
+"Mobile Migration", "V3 to V4", "Mobile Upgrade", "Version Migration", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-ios-tracker-sdk-from-version-2-x-to-3-0/index.md
+"iOS Migration", "V2 to V3", "iOS Upgrade", "Mobile Migration", "Version Migration", "Breaking Changes"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-to-new-ecommerce/index.md
+"Mobile Ecommerce Migration", "Ecommerce Upgrade", "Commerce Migration", "Mobile Commerce", "Ecommerce Guide", "Shopping Migration"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-android-tracker-sdk-from-version-1-x-to-2-0/index.md
+"Android Migration", "V1 to V2", "Android Upgrade", "Mobile Migration", "Version Migration", "Breaking Changes"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-from-version-4-x-to-5-0/index.md
+"Mobile Migration", "V4 to V5", "Mobile Upgrade", "Version Migration", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-for-snowplow-android-tracker-sdk-from-version-2-x-to-3-0/index.md
+"Android Migration", "V2 to V3", "Android Upgrade", "Mobile Migration", "Version Migration", "Breaking Changes"
+
+docs/sources/trackers/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/index.md
+"Mobile Migration", "V5 to V6", "Mobile Upgrade", "Version Migration", "Migration Guide", "Breaking Changes"
+
+docs/sources/trackers/mobile-trackers/demos/index.md
+"Mobile Demos", "Mobile Examples", "Sample Apps", "Demo Applications", "Mobile Samples", "Example Code"
+
+docs/sources/trackers/unity-tracker/example-app.md
+"Unity Example App", "Game Example", "Unity Demo", "Game Demo", "Unity Sample", "Game Development"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/the-redisworker-class/index.md
+"Python Redis", "RedisWorker Class", "Python V0.15", "Legacy Redis", "Previous Version", "Deprecated Redis"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/contracts/index.md
+"Python Contracts", "Python V0.15", "Type Contracts", "Legacy Contracts", "Previous Version", "Deprecated Contracts"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/setup/index.md
+"Python V0.15", "Legacy Setup", "Previous Version", "Python Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/intialization/index.md
+"Python V0.15", "Legacy Initialization", "Previous Version", "Python Init", "Deprecated Init", "Legacy Setup"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/tracking-specific-events/index.md
+"Python V0.15", "Legacy Events", "Previous Version", "Event Tracking", "Deprecated Events", "Legacy Tracking"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/upgrading/index.md
+"Python V0.15", "Legacy Upgrade", "Previous Version", "Version Upgrade", "Deprecated Upgrade", "Legacy Migration"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/emitters/index.md
+"Python V0.15", "Legacy Emitters", "Previous Version", "Event Sending", "Deprecated Emitters", "Legacy Transport"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/logging/index.md
+"Python V0.15", "Legacy Logging", "Previous Version", "Debug Logging", "Deprecated Logging", "Legacy Debug"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/api-reference.md
+"Python V0.15 API", "Legacy API", "Previous API", "API Reference", "Deprecated API", "Legacy Documentation"
+
+docs/sources/trackers/python-tracker/previous_versions/python-v0-15/adding-extra-data-the-subject-class/index.md
+"Python V0.15", "Legacy Subject", "Previous Version", "Subject Class", "Deprecated Subject", "Legacy Context"
+
+docs/sources/trackers/python-tracker/demos/index.md
+"Python Demos", "Python Examples", "Sample Applications", "Demo Scripts", "Python Samples", "Example Code"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/sending-events/index.md
+"Scala V0.6.0", "Legacy Events", "Previous Version", "Event Sending", "Deprecated Events", "Legacy Tracking"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/subject-methods/index.md
+"Scala V0.6.0", "Legacy Subject", "Previous Version", "Subject Methods", "Deprecated Subject", "Legacy Context"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/setup/index.md
+"Scala V0.6.0", "Legacy Setup", "Previous Version", "Scala Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-6-0/initialization/index.md
+"Scala V0.6.0", "Legacy Initialization", "Previous Version", "Scala Init", "Deprecated Init", "Legacy Setup"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/sending-events/index.md
+"Scala V0.5.0", "Legacy Events", "Previous Version", "Event Sending", "Deprecated Events", "Legacy Tracking"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/subject-methods/index.md
+"Scala V0.5.0", "Legacy Subject", "Previous Version", "Subject Methods", "Deprecated Subject", "Legacy Context"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/setup/index.md
+"Scala V0.5.0", "Legacy Setup", "Previous Version", "Scala Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-5-0/initialization/index.md
+"Scala V0.5.0", "Legacy Initialization", "Previous Version", "Scala Init", "Deprecated Init", "Legacy Setup"
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/sending-events/index.md
+"Scala V1.0.0", "Legacy Events", "Previous Version", "Event Sending", "Deprecated Events", "Legacy Tracking"
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/subject-methods/index.md
+"Scala V1.0.0", "Legacy Subject", "Previous Version", "Subject Methods", "Deprecated Subject", "Legacy Context"
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/setup/index.md
+"Scala V1.0.0", "Legacy Setup", "Previous Version", "Scala Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/scala-tracker/previous-versions/1-0-0/initialization/index.md
+"Scala V1.0.0", "Legacy Initialization", "Previous Version", "Scala Init", "Deprecated Init", "Legacy Setup"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/sending-events/index.md
+"Scala V0.7.0", "Legacy Events", "Previous Version", "Event Sending", "Deprecated Events", "Legacy Tracking"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/subject-methods/index.md
+"Scala V0.7.0", "Legacy Subject", "Previous Version", "Subject Methods", "Deprecated Subject", "Legacy Context"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/setup/index.md
+"Scala V0.7.0", "Legacy Setup", "Previous Version", "Scala Setup", "Deprecated Setup", "Legacy Installation"
+
+docs/sources/trackers/scala-tracker/previous-versions/0-7-0/initialization/index.md
+"Scala V0.7.0", "Legacy Initialization", "Previous Version", "Scala Init", "Deprecated Init", "Legacy Setup"
+
+docs/ruby-tracker/example-rails-app.md
+"Ruby Rails Example", "Rails Application", "Ruby Demo", "Rails Demo", "Ruby Sample", "Rails Integration"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/upgrade-guides/1-0-x-upgrade-guide/index.md
+"BigQuery Upgrade", "V1.0.x Upgrade", "Loader Migration", "BigQuery Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/upgrade-guides/2-0-0-upgrade-guide/index.md
+"BigQuery Upgrade", "V2.0.0 Upgrade", "Loader Migration", "BigQuery Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-5-0/index.md
+"BigQuery V0.5.0", "Legacy Loader", "Previous Version", "Deprecated Loader", "Legacy BigQuery", "Old Version"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-1.x/index.md
+"BigQuery V1.x", "Legacy Loader", "Previous Version", "Deprecated Loader", "Legacy BigQuery", "Old Version"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-1.x/configuration-reference/index.md
+"BigQuery V1.x Config", "Legacy Configuration", "Previous Config", "Deprecated Config", "Legacy Settings", "Old Configuration"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-6-0/index.md
+"BigQuery V0.6.0", "Legacy Loader", "Previous Version", "Deprecated Loader", "Legacy BigQuery", "Old Version"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-3-0/index.md
+"BigQuery V0.3.0", "Legacy Loader", "Previous Version", "Deprecated Loader", "Legacy BigQuery", "Old Version"
+
+docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-0-4-0/index.md
+"BigQuery V0.4.0", "Legacy Loader", "Previous Version", "Deprecated Loader", "Legacy BigQuery", "Old Version"
+
+docs/api-reference/loaders-storage-targets/s3-loader/upgrade-guides/1-0-0-configuration/index.md
+"S3 Upgrade", "V1.0.0 Configuration", "Loader Migration", "S3 Migration", "Configuration Upgrade", "Config Changes"
+
+docs/api-reference/loaders-storage-targets/s3-loader/upgrade-guides/2-2-0-upgrade-guide/index.md
+"S3 Upgrade", "V2.2.0 Upgrade", "Loader Migration", "S3 Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/s3-loader/upgrade-guides/2-0-0-upgrade-guide/index.md
+"S3 Upgrade", "V2.0.0 Upgrade", "Loader Migration", "S3 Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/rdb-loader-configuration-reference/rdb-loader-previous-versions/rdb-loader-3-0-x/index.md
+"RDB Loader V3.0.x", "Legacy RDB", "Previous Version", "Deprecated Loader", "Legacy Configuration", "Old Version"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/rdb-loader-configuration-reference/rdb-loader-previous-versions/rdb-loader-4-0-x/index.md
+"RDB Loader V4.0.x", "Legacy RDB", "Previous Version", "Deprecated Loader", "Legacy Configuration", "Old Version"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/loading-transformed-data/rdb-loader-configuration-reference/index.md
+"RDB Configuration", "Loader Configuration", "RDB Config", "Database Config", "Loader Settings", "RDB Settings"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/1-2-0-upgrade-guide/index.md
+"RDB Upgrade", "V1.2.0 Upgrade", "Loader Migration", "RDB Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/r33-upgrade-guide/index.md
+"RDB Upgrade", "R33 Upgrade", "Loader Migration", "RDB Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/r32-upgrade-guide/index.md
+"RDB Upgrade", "R32 Upgrade", "Loader Migration", "RDB Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/6-0-0-upgrade-guide/index.md
+"RDB Upgrade", "V6.0.0 Upgrade", "Loader Migration", "RDB Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/2-0-0-upgrade-guide/index.md
+"RDB Upgrade", "V2.0.0 Upgrade", "Loader Migration", "RDB Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/r35-upgrade-guide/index.md
+"RDB Upgrade", "R35 Upgrade", "Loader Migration", "RDB Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/upgrade-guides/1-0-0-upgrade-guide/index.md
+"RDB Upgrade", "V1.0.0 Upgrade", "Loader Migration", "RDB Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-1-0-0/index.md
+"RDB Loader V1.0.0", "Legacy RDB", "Previous Version", "Deprecated Loader", "Legacy Version", "Old RDB"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/event-deduplication/index.md
+"RDB Deduplication", "Event Deduplication", "Legacy RDB", "Duplicate Removal", "Data Quality", "Event Dedup"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/shredding-overview/index.md
+"RDB Shredding", "Data Shredding", "Legacy RDB", "Data Processing", "Event Processing", "Data Transformation"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/rdb-shredder-configuration-reference/index.md
+"RDB Shredder Config", "Shredder Configuration", "Legacy Configuration", "RDB Config", "Shredder Settings", "Processing Config"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/dynamodb-table/index.md
+"RDB DynamoDB", "DynamoDB Table", "Legacy RDB", "Database Table", "DynamoDB Config", "NoSQL Integration"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/run-the-rdb-loader/index.md
+"Run RDB Loader", "Loader Execution", "Legacy RDB", "Running Loader", "Loader Operation", "RDB Execution"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/run-the-rdb-shredder/index.md
+"Run RDB Shredder", "Shredder Execution", "Legacy RDB", "Running Shredder", "Shredder Operation", "RDB Processing"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/monitoring/index.md
+"RDB Monitoring", "Legacy Monitoring", "Loader Monitoring", "RDB Metrics", "Performance Monitoring", "Legacy RDB"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/snowplow-rdb-loader/configuration-reference/index.md
+"RDB Legacy Config", "Legacy Configuration", "RDB Configuration", "Previous Config", "Deprecated Config", "Old Settings"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-1-1-0/index.md
+"RDB Loader V1.1.0", "Legacy RDB", "Previous Version", "Deprecated Loader", "Legacy Version", "Old RDB"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-r35-earlier/load-event-and-entity-types-that-you-have-defined/index.md
+"RDB R35 Events", "Custom Events", "Entity Types", "Legacy RDB", "Event Types", "Custom Entities"
+
+docs/api-reference/loaders-storage-targets/snowplow-rdb-loader/previous-versions/rdb-loader-r35-earlier/index.md
+"RDB R35 Earlier", "Legacy RDB", "Previous Version", "Deprecated Loader", "Legacy Version", "Old RDB"
+
+docs/api-reference/loaders-storage-targets/snowflake-streaming-loader/migrating.md
+"Snowflake Migration", "Streaming Migration", "Loader Migration", "Snowflake Upgrade", "Migration Guide", "Breaking Changes"
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/setup-guide-for-gcp/index.md
+"Mini V0.14 GCP", "Legacy Mini", "Previous Version", "GCP Setup", "Deprecated Mini", "Old Version"
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/control-plane-api/index.md
+"Mini V0.14 API", "Legacy API", "Previous Version", "Control Plane", "Deprecated API", "Old API"
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/setup-guide-for-aws/index.md
+"Mini V0.14 AWS", "Legacy Mini", "Previous Version", "AWS Setup", "Deprecated Mini", "Old Version"
+
+docs/api-reference/snowplow-mini/previous-releases/snowplow-mini-0-14/usage-guide/index.md
+"Mini V0.14 Usage", "Legacy Usage", "Previous Version", "Usage Guide", "Deprecated Mini", "Old Guide"
+
+docs/api-reference/stream-collector/3-0-x-upgrade-guide/index.md
+"Collector Upgrade", "V3.0.x Upgrade", "Collector Migration", "Stream Collector", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/enrichment-components/upgrade-guides/4-0-x-upgrade-guide/index.md
+"Enrichment Upgrade", "V4.0.x Upgrade", "Component Migration", "Enrichment Migration", "Version Upgrade", "Breaking Changes"
+
+docs/api-reference/enrichment-components/upgrade-guides/6-0-x-upgrade-guide/index.md
+"Enrichment Upgrade", "V6.0.x Upgrade", "Component Migration", "Enrichment Migration", "Version Upgrade", "Breaking Changes"
+
+Additional Previous Versions & Legacy Documentation
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/performance-timing/index.md
+"Browser V3 Performance", "Performance Timing", "Legacy Performance", "Web Performance", "Timing Metrics", "Browser Metrics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/vimeo-tracking/index.md
+"Browser V3 Vimeo", "Vimeo Tracking", "Legacy Vimeo", "Video Analytics", "Media Tracking", "Video Events"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/web-vitals/index.md
+"Browser V3 Vitals", "Web Vitals", "Legacy Vitals", "Performance Metrics", "UX Metrics", "Core Vitals"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/privacy-sandbox/index.md
+"Browser V3 Privacy", "Privacy Sandbox", "Legacy Privacy", "Chrome Privacy", "Privacy API", "Attribution API"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/creating-your-own-plugins/index.md
+"Browser V3 Plugins", "Custom Plugins", "Legacy Plugins", "Plugin Development", "Web Extensions", "JavaScript Plugins"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/timezone/index.md
+"Browser V3 Timezone", "Timezone Detection", "Legacy Timezone", "Geographic Data", "Time Analytics", "Location Data"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/ecommerce/index.md
+"Browser V3 Ecommerce", "Legacy Ecommerce", "Shopping Analytics", "Commerce Events", "Retail Analytics", "Transaction Events"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/client-hints/index.md
+"Browser V3 Hints", "Client Hints", "Legacy Hints", "Browser Intelligence", "Device Detection", "User Agent"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/enhanced-ecommerce/index.md
+"Browser V3 Enhanced", "Enhanced Ecommerce", "Legacy Enhanced", "Advanced Commerce", "Shopping Funnel", "Product Analytics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/form-tracking/index.md
+"Browser V3 Forms", "Form Tracking", "Legacy Forms", "Form Analytics", "User Input", "Form Behavior"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/youtube-tracking/index.md
+"Browser V3 YouTube", "YouTube Tracking", "Legacy YouTube", "Video Analytics", "YouTube Events", "Video Engagement"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/optimizely-classic/index.md
+"Browser V3 Optimizely", "Optimizely Classic", "Legacy Optimizely", "A/B Testing", "Experimentation", "Test Analytics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/adding-plugins-to-your-tracker/index.md
+"Browser V3 Setup", "Plugin Setup", "Legacy Plugins", "Plugin Configuration", "Web Features", "Plugin Management"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/site-tracking/index.md
+"Browser V3 Site", "Site Tracking", "Legacy Site", "Site Analytics", "Website Analytics", "Site Events"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/browser-features/index.md
+"Browser V3 Features", "Browser Features", "Legacy Features", "Browser Intelligence", "Feature Detection", "Capability Detection"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/ga-cookies/index.md
+"Browser V3 GA", "Google Analytics", "Legacy GA", "GA Cookies", "Analytics Migration", "Cookie Data"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/error-tracking/index.md
+"Browser V3 Errors", "Error Tracking", "Legacy Errors", "JavaScript Errors", "Error Analytics", "Bug Tracking"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/consent/index.md
+"Browser V3 Consent", "Consent Tracking", "Legacy Consent", "GDPR Compliance", "Privacy Consent", "Cookie Consent"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/geolocation/index.md
+"Browser V3 Location", "Geolocation", "Legacy Location", "Location Analytics", "Geographic Data", "Location Tracking"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/debugger/index.md
+"Browser V3 Debug", "Debug Tools", "Legacy Debug", "Development Tools", "Testing Tools", "Debug Analytics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/optimizely-x/index.md
+"Browser V3 OptimizelyX", "Optimizely X", "Legacy OptimizelyX", "A/B Testing", "Experimentation", "Test Analytics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/snowplow-ecommerce/index.md
+"Browser V3 Snowplow Commerce", "Snowplow Ecommerce", "Legacy Commerce", "Native Ecommerce", "Commerce Analytics", "Shopping Events"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/enhanced-consent/index.md
+"Browser V3 Enhanced Consent", "Enhanced Consent", "Legacy Consent", "Advanced Consent", "Privacy Management", "Consent Analytics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/performance-navigation-timing/index.md
+"Browser V3 Navigation", "Navigation Timing", "Legacy Navigation", "Performance Timing", "Page Performance", "Load Metrics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/link-click-tracking/index.md
+"Browser V3 Links", "Link Tracking", "Legacy Links", "Click Events", "Link Analytics", "Click Tracking"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/ad-tracking/index.md
+"Browser V3 Ads", "Ad Tracking", "Legacy Ads", "Advertisement Analytics", "Ad Events", "Marketing Analytics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/media-tracking/index.md
+"Browser V3 Media", "Media Tracking", "Legacy Media", "Video Analytics", "Audio Analytics", "Media Events"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/plugins/media/index.md
+"Browser V3 Media", "Media Plugin", "Legacy Media", "Media Analytics", "Video Tracking", "Audio Tracking"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracking-events/index.md
+"Browser V3 Events", "Legacy Events", "Event Tracking", "Web Events", "Browser Events", "Analytics Events"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/index.md
+"Browser V3 Advanced", "Advanced Usage", "Legacy Advanced", "Expert Features", "Power Features", "Advanced Analytics"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/tracker-information/index.md
+"Browser V3 Info", "Tracker Information", "Legacy Info", "Tracker Details", "System Information", "Analytics Info"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/using-an-id-service/index.md
+"Browser V3 ID", "ID Service", "Legacy ID", "Identity Service", "User Identification", "ID Management"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/advanced-usage/optional-timestamp-argument/index.md
+"Browser V3 Timestamp", "Optional Timestamp", "Legacy Timestamp", "Event Timing", "Time Data", "Custom Timing"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/additional-options/index.md
+"Browser V3 Options", "Additional Options", "Legacy Options", "Setup Options", "Configuration Options", "Advanced Config"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/managing-multiple-trackers/index.md
+"Browser V3 Multiple", "Multiple Trackers", "Legacy Multiple", "Multi Tracker", "Tracker Management", "Multi Instance"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/installing-the-tracker-from-npm/index.md
+"Browser V3 NPM", "NPM Installation", "Legacy NPM", "Package Manager", "JavaScript Package", "NPM Setup"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/tracker-setup/initialization-options/index.md
+"Browser V3 Init", "Initialization Options", "Legacy Init", "Setup Options", "Configuration Options", "Init Config"
+
+docs/sources/trackers/web-trackers/previous-versions/browser-tracker-v3-reference/api-reference.md
+"Browser V3 API", "Legacy API", "API Reference", "Browser API", "Tracker API", "JavaScript API"
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/ecommerce/original/index.md
+"Web V3 Original", "Original Ecommerce", "Legacy Ecommerce", "Traditional Commerce", "Old Commerce", "Classic Ecommerce"
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracking-events/consent-gdpr/original/index.md
+"Web V3 Original Consent", "Original Consent", "Legacy Consent", "Traditional Consent", "Old Consent", "Classic GDPR"
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-settings-variable/index.md
+"Web V3 GTM Settings", "GTM V3 Settings", "Legacy GTM", "Tag Manager", "GTM Configuration", "Settings Variable"
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/tag-template-guide/index.md
+"Web V3 GTM Tags", "GTM V3 Tags", "Legacy GTM", "Tag Template", "Tag Guide", "Tag Manager"
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/tag-template-guide/plugins.md
+"Web V3 GTM Plugins", "GTM V3 Plugins", "Legacy GTM", "Tag Plugins", "GTM Extensions", "Plugin Guide"
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/ecommerce-tag-template/ecommerce-tag-configuration/index.md
+"Web V3 GTM Commerce", "GTM V3 Ecommerce", "Legacy GTM", "Ecommerce Configuration", "Shopping Tags", "Commerce Setup"
+
+docs/sources/trackers/web-trackers/previous-versions/web-trackers-v3/tracker-setup/google-tag-manager-custom-template/v3-tags/ecommerce-tag-template/index.md
+"Web V3 GTM Ecommerce", "GTM V3 Ecommerce", "Legacy GTM", "Ecommerce Template", "Shopping Template", "Commerce Tags"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/advanced-usage/callbacks/index.md
+"JavaScript V2 Callbacks", "Legacy Callbacks", "Event Callbacks", "Callback Functions", "JavaScript Events", "Async Handling"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/advanced-usage/getting-the-most-out-of-performance-timing/index.md
+"JavaScript V2 Performance", "Performance Timing", "Legacy Performance", "Performance Optimization", "Timing Analytics", "Web Performance"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/advanced-usage/optional-timestamp-argument/index.md
+"JavaScript V2 Timestamp", "Optional Timestamp", "Legacy Timestamp", "Event Timing", "Custom Timing", "Time Data"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/loading/index.md
+"JavaScript V2 Loading", "Script Loading", "Legacy Loading", "Tracker Loading", "JavaScript Loading", "Async Loading"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/managing-multiple-trackers/index.md
+"JavaScript V2 Multiple", "Multiple Trackers", "Legacy Multiple", "Multi Tracker", "Tracker Management", "Multi Instance"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/initializing-a-tracker-2/index.md
+"JavaScript V2 Init", "Tracker Initialization", "Legacy Init", "Setup Process", "Configuration", "JavaScript Setup"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracker-setup/other-parameters-2/index.md
+"JavaScript V2 Parameters", "Other Parameters", "Legacy Parameters", "Configuration Parameters", "Setup Options", "Additional Config"
+
+docs/sources/trackers/web-trackers/previous-versions/javascript-tracker-v2/tracking-specific-events/index.md
+"JavaScript V2 Events", "Legacy Events", "Event Tracking", "Specific Events", "JavaScript Analytics", "Web Events"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/introduction/index.md
+"Mobile V2.x Introduction", "Legacy Mobile", "Mobile Introduction", "Previous Version", "Deprecated Mobile", "Old Mobile"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/tracking-events/index.md
+"Mobile V2.x Events", "Legacy Events", "Mobile Events", "Previous Version", "Deprecated Events", "Old Events"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/remote-configuration/index.md
+"Mobile V2.x Config", "Remote Configuration", "Legacy Config", "Previous Version", "Deprecated Config", "Old Config"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v2-x/quick-start-guide/index.md
+"Mobile V2.x Guide", "Legacy Guide", "Quick Start", "Previous Version", "Deprecated Guide", "Old Guide"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/introduction/index.md
+"Mobile V3.x Introduction", "Legacy Mobile", "Mobile Introduction", "Previous Version", "Deprecated Mobile", "Old Mobile"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/tracking-events/index.md
+"Mobile V3.x Events", "Legacy Events", "Mobile Events", "Previous Version", "Deprecated Events", "Old Events"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/remote-configuration/index.md
+"Mobile V3.x Config", "Remote Configuration", "Legacy Config", "Previous Version", "Deprecated Config", "Old Config"
+
+docs/sources/trackers/mobile-trackers/previous-versions/mobile-trackers-v3-x/quick-start-guide/index.md
+"Mobile V3.x Guide", "Legacy Guide", "Quick Start", "Previous Version", "Deprecated Guide", "Old Guide"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-0-0/index.md
+"Objective-C V1.0.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-4-0/index.md
+"Objective-C V0.4.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-4-0/index.md
+"iOS Tracker V1.4.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-3-0/index.md
+"Objective-C V0.3.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-9-0/index.md
+"Objective-C V0.9.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-3/index.md
+"Objective-C V1.1.3", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-4/index.md
+"Objective-C V1.1.4", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-5/index.md
+"Objective-C V1.1.5", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-2/index.md
+"Objective-C V1.1.2", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-7-0/index.md
+"Objective-C V0.7.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-7-0/index.md
+"iOS Tracker V1.7.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-8-0/index.md
+"Objective-C V0.8.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-2-0/index.md
+"Objective-C V0.2.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-2-0/index.md
+"Objective-C V1.2.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-6-0/index.md
+"Objective-C V0.6.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-6-0/index.md
+"iOS Tracker V1.6.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-0/index.md
+"Objective-C V1.1.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-1-0/index.md
+"Objective-C V0.1.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-0-5-0/index.md
+"Objective-C V0.5.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker/index.md
+"iOS Tracker Legacy", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/objective-c-1-1-1/index.md
+"Objective-C V1.1.1", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/objective-c-tracker/ios-tracker-1-5-0/index.md
+"iOS Tracker V1.5.0", "iOS Legacy", "Legacy iOS", "Previous Version", "Deprecated iOS", "Old iOS"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-4-0/index.md
+"Android V1.4.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-4-0/index.md
+"Android V0.4.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-0-0/index.md
+"Android V1.0.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-2-0-java-0-6-0/index.md
+"Android V0.2.0", "Java V0.6.0", "Android Legacy", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-7-0/index.md
+"Android V0.7.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-7-0/index.md
+"Android V1.7.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-3-0/index.md
+"Android V1.3.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-3-0/index.md
+"Android V0.3.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-2-1/index.md
+"Android V1.2.1", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-6-0/index.md
+"Android V0.6.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-6-0/index.md
+"Android V1.6.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-2-0/index.md
+"Android V1.2.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-8-0/index.md
+"Android V0.8.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-1-0-java-0-5-0/index.md
+"Android V0.1.0", "Java V0.5.0", "Android Legacy", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-5-0/index.md
+"Android V1.5.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-0-5-0/index.md
+"Android V0.5.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/mobile-trackers/previous-versions/android-tracker/android-1-1-0/index.md
+"Android V1.1.0", "Android Legacy", "Legacy Android", "Previous Version", "Deprecated Android", "Old Android"
+
+docs/sources/trackers/roku-tracker/quick-start-guide/index.md
+"Roku Quick Start", "Roku Setup", "TV Setup", "OTT Setup", "Connected TV", "Roku Guide"
+
+docs/api-reference/trackers/api-documentation-rust.md
+"Rust API", "Rust Documentation", "Rust Reference", "API Documentation", "Rust SDK", "Rust Tracker"
+
+docs/api-reference/trackers/api-reference-golang.md
+"Golang API", "Go Reference", "Go Documentation", "API Documentation", "Go SDK", "Go Tracker"
+
+docs/api-reference/trackers/api-reference-python.md
+"Python API", "Python Reference", "Python Documentation", "API Documentation", "Python SDK", "Python Tracker"
+
+docs/api-reference/trackers/api-reference-nodejs.md
+"Node.js API", "NodeJS Reference", "Node Documentation", "API Documentation", "NodeJS SDK", "Node Tracker"
+
+docs/api-reference/trackers/api-reference-lua.md
+"Lua API", "Lua Reference", "Lua Documentation", "API Documentation", "Lua SDK", "Lua Tracker"
+
+docs/api-reference/trackers/api-reference-ios.md
+"iOS API", "iOS Reference", "iOS Documentation", "API Documentation", "iOS SDK", "iOS Tracker"
+
+docs/api-reference/trackers/api-reference-ruby.md
+"Ruby API", "Ruby Reference", "Ruby Documentation", "API Documentation", "Ruby SDK", "Ruby Tracker"
+
+docs/api-reference/trackers/api-reference-java.md
+"Java API", "Java Reference", "Java Documentation", "API Documentation", "Java SDK", "Java Tracker"
+
+docs/api-reference/trackers/api-reference-cpp.md
+"C++ API", "C++ Reference", "C++ Documentation", "API Documentation", "C++ SDK", "C++ Tracker"
+
+docs/api-reference/trackers/api-reference-android.md
+"Android API", "Android Reference", "Android Documentation", "API Documentation", "Android SDK", "Android Tracker"
+
+docs/sources/trackers/roku-tracker/example-app/index.md
+"Roku Example", "TV Example", "Roku Demo", "OTT Demo", "Connected TV", "Roku Sample"
+
+docs/api-reference/iglu/iglu-central-setup/index.md
+"Iglu Central Setup", "Central Registry", "Public Registry", "Registry Setup", "Central Repository", "Registry Installation"
+
+tutorials/unified-digital/setting-up-locally.md
+"Unified Local", "Local Setup", "Development Setup", "Local Analytics", "Unified Tutorial", "Local Development"
+
+tutorials/unified-digital/setting-up-via-console.md
+"Console Setup", "Unified Console", "Web Console", "Console Tutorial", "Unified Setup", "Console Guide"
+
+tutorials/unified-digital/intro.md
+"Unified Tutorial", "Unified Analytics", "Cross Platform", "Tutorial Introduction", "Multi Platform", "Unified Guide"
+
+tutorials/unified-digital/viewing-output-data.md
+"Output Data", "Data Viewing", "Results Analysis", "Data Output", "Analytics Results", "Data Visualization"
+
+tutorials/kafka-live-viewer-profiles/conclusion.md
+"Kafka Conclusion", "Tutorial Conclusion", "Kafka Tutorial", "Real Time", "Stream Processing", "Live Data"
+
+tutorials/kafka-live-viewer-profiles/quickstart-localstack.md
+"Kafka Localstack", "Local Kafka", "Localstack Setup", "Development Kafka", "Local Stream", "Kafka Development"
+
+tutorials/kafka-live-viewer-profiles/introduction.md
+"Kafka Tutorial", "Real Time", "Stream Processing", "Kafka Introduction", "Live Analytics", "Stream Analytics"
+
+tutorials/kafka-live-viewer-profiles/deploy-aws-terraform.md
+"Kafka AWS", "Terraform Kafka", "AWS Deployment", "Infrastructure Code", "Kafka Terraform", "Cloud Kafka"
+
+tutorials/enrichments/enabling-via-terraform.md
+"Terraform Enrichments", "Infrastructure Code", "Enrichment Deployment", "Terraform Setup", "IaC Enrichments", "Automated Enrichments"
+
+tutorials/enrichments/intro.md
+"Enrichment Tutorial", "Data Enrichment", "Event Enhancement", "Enrichment Guide", "Tutorial Introduction", "Processing Tutorial"
+
+tutorials/enrichments/configurable-enrichment-list.md
+"Enrichment List", "Available Enrichments", "Enrichment Catalog", "Enhancement Options", "Enrichment Types", "Processing Options"
+
+tutorials/android-event-tracking/examining-events.md
+"Android Events", "Event Examination", "Mobile Events", "Android Analytics", "Event Analysis", "Mobile Tutorial"
+
+tutorials/android-event-tracking/screen-views.md
+"Android Screens", "Screen Views", "Mobile Screens", "Android Navigation", "Screen Analytics", "Mobile Tracking"
+
+tutorials/android-event-tracking/installation.md
+"Android Installation", "Mobile Setup", "Android SDK", "App Installation", "Mobile Integration", "Android Guide"
+
+tutorials/data-structures-in-git/conclusion.md
+"Git Conclusion", "Schema Git", "Version Control", "Git Tutorial", "Schema Management", "Git Workflow"
+
+tutorials/data-structures-in-git/verify-github-setup.md
+"GitHub Verification", "Git Setup", "GitHub Config", "Repository Setup", "Git Verification", "GitHub Tutorial"
+
+tutorials/data-structures-in-git/follow-up-with-data-products.md
+"Data Products", "Schema Products", "Product Follow-up", "Data Management", "Schema Integration", "Product Tutorial"
+
+tutorials/data-structures-in-git/introduction.md
+"Git Tutorial", "Schema Git", "Version Control", "Git Introduction", "Schema Management", "Git Workflow"
+
+tutorials/data-structures-in-git/validation-and-publishing.md
+"Schema Validation", "Schema Publishing", "Git Validation", "Schema CI", "Schema Deployment", "Git Publishing"
+
+tutorials/data-structures-in-git/automate-with-github-actions.md
+"GitHub Actions", "Schema Automation", "CI/CD", "Git Automation", "Schema CI", "Automated Workflows"
+
+tutorials/data-structures-in-git/local-setup.md
+"Git Local", "Local Git", "Git Setup", "Local Development", "Git Configuration", "Development Setup"
+
+tutorials/snowplow-cli-mcp/setup.md
+"CLI MCP", "MCP Setup", "CLI Configuration", "MCP Integration", "Command Line", "MCP Tutorial"
+
+tutorials/snowplow-cli-mcp/introduction.md
+"CLI MCP", "MCP Introduction", "Command Line", "MCP Tutorial", "CLI Integration", "Model Context"
+
+tutorials/snowplow-cli-mcp/next-steps.md
+"MCP Next Steps", "CLI Advanced", "Next Steps", "MCP Progression", "CLI Development", "Advanced Tutorial"
+
+tutorials/snowplow-cli-mcp/basic-workflow.md
+"MCP Workflow", "CLI Workflow", "Basic Workflow", "MCP Process", "Command Workflow", "CLI Process"
+
+tutorials/index.md
+"Snowplow Tutorials", "Tutorial Index", "Learning Guides", "Step-by-Step", "Tutorial Overview", "Learning Resources"
+
+tutorials/attribution/setting-up-locally.md
+"Attribution Local", "Local Attribution", "Attribution Setup", "Marketing Local", "Local Analytics", "Attribution Development"
+
+tutorials/attribution/setting-up-via-console.md
+"Attribution Console", "Console Setup", "Attribution Tutorial", "Marketing Console", "Attribution Guide", "Console Attribution"
+
+tutorials/attribution/intro.md
+"Attribution Tutorial", "Marketing Attribution", "Attribution Introduction", "Attribution Guide", "Marketing Analytics", "Attribution Overview"
+
+tutorials/attribution/optional-configuring-channel-group-classification.md
+"Channel Classification", "Marketing Channels", "Channel Groups", "Attribution Channels", "Marketing Categories", "Channel Mapping"
+
+tutorials/attribution/before-you-start.md
+"Attribution Prerequisites", "Before Start", "Attribution Setup", "Prerequisites", "Getting Ready", "Attribution Prep"
+
+tutorials/attribution/enabling-unified-conversions.md
+"Unified Conversions", "Attribution Conversions", "Cross Platform", "Conversion Attribution", "Unified Attribution", "Marketing Conversions"
+
+tutorials/attribution/optional-adding-marketing-spend-source.md
+"Marketing Spend", "Spend Attribution", "Marketing Costs", "ROI Attribution", "Campaign Spend", "Marketing Investment"
+
+tutorials/abandoned-browse-ccdp/reverse-etl.md
+"Reverse ETL", "Data Activation", "Customer Data", "CCDP Tutorial", "Data Sync", "Operational Analytics"
+
+tutorials/abandoned-browse-ccdp/conclusion.md
+"CCDP Conclusion", "Tutorial Conclusion", "Customer Data", "CCDP Complete", "Tutorial Summary", "Project Wrap-up"
+
+tutorials/abandoned-browse-ccdp/data-modeling.md
+"CCDP Modeling", "Data Modeling", "Customer Analytics", "Behavioral Modeling", "CCDP Analytics", "Customer Insights"
+
+tutorials/abandoned-browse-ccdp/braze-campaign.md
+"Braze Campaign", "Marketing Campaign", "Customer Engagement", "Braze Integration", "Marketing Automation", "Campaign Tutorial"
+
+tutorials/abandoned-browse-ccdp/introduction.md
+"CCDP Tutorial", "Customer Data", "CCDP Introduction", "Behavioral Analytics", "Customer Analytics", "Data Platform"
+
+tutorials/abandoned-browse-ccdp/tracking-setup.md
+"CCDP Tracking", "Tracking Setup", "Behavioral Tracking", "Customer Tracking", "Event Setup", "CCDP Events"
+
+tutorials/data-products-base-tracking/create-custom-dp.md
+"Custom Data Product", "Product Creation", "Custom Analytics", "Data Product", "Product Development", "Custom DP"
+
+tutorials/data-products-base-tracking/create-base-dp.md
+"Base Data Product", "Product Creation", "Data Product", "Base Analytics", "Product Foundation", "Core DP"
+
+tutorials/data-products-base-tracking/setup-custom-ds.md
+"Custom Data Structure", "Schema Setup", "Custom Schema", "Data Structure", "Schema Creation", "Custom DS"
+
+tutorials/data-products-base-tracking/create-source-application.md
+"Source Application", "App Creation", "Application Setup", "Source App", "App Configuration", "Application Source"
+
+tutorials/data-products-base-tracking/add-event-specs.md
+"Event Specifications", "Event Specs", "Specification Setup", "Event Definition", "Spec Creation", "Event Documentation"
+
+tutorials/data-products-base-tracking/snowtype.md
+"Snowtype Tutorial", "TypeScript Types", "Type Generation", "Type Safety", "Code Generation", "TypeScript Tutorial"
+
+tutorials/data-products-base-tracking/verify-dp-events.md
+"Verify Events", "Event Verification", "Data Validation", "Event Testing", "Product Validation", "Event Checking"
+
+tutorials/data-products-base-tracking/start.md
+"Tutorial Start", "Getting Started", "Data Products", "Product Tutorial", "Tutorial Beginning", "Start Guide"
+
+tutorials/data-products-base-tracking/generate-tracking-code.md
+"Code Generation", "Tracking Code", "Generated Code", "Code Tutorial", "SDK Generation", "Code Creation"
+
+tutorials/data-products-base-tracking/setup-basic-tracking.md
+"Basic Tracking", "Tracking Setup", "Event Setup", "Basic Analytics", "Tracking Tutorial", "Event Tracking"
+
+tutorials/flink-live-shopper-features/conclusion.md
+"Flink Conclusion", "Real Time", "Stream Processing", "Flink Tutorial", "Live Analytics", "Stream Analytics"
+
+tutorials/flink-live-shopper-features/add-calculation.md
+"Flink Calculations", "Stream Calculations", "Real Time", "Live Calculations", "Stream Processing", "Flink Analytics"
+
+tutorials/flink-live-shopper-features/introduction.md
+"Flink Tutorial", "Stream Processing", "Real Time", "Flink Introduction", "Live Analytics", "Stream Analytics"
+
+tutorials/flink-live-shopper-features/run.md
+"Flink Run", "Stream Execution", "Flink Execution", "Real Time", "Stream Run", "Live Processing"
+
+tutorials/flink-live-shopper-features/calculations.md
+"Flink Calculations", "Stream Calculations", "Real Time", "Live Calculations", "Stream Processing", "Analytics Calculations"

--- a/src/components/SchemaPlugin/index.tsx
+++ b/src/components/SchemaPlugin/index.tsx
@@ -35,7 +35,7 @@ export function generateSchema(frontMatter: BaseFrontMatter, pageMeta: any, site
     url: 'https://snowplow.io',
     logo: {
       '@type': 'ImageObject',
-      url: 'https://snowplow.io/images/logo.png',
+      url: `${site}/img/snowplow-logo.svg`,
     },
   }
 

--- a/src/components/SchemaPlugin/index.tsx
+++ b/src/components/SchemaPlugin/index.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { useDoc } from '@docusaurus/theme-common/internal'
+import { usePluginData } from '@docusaurus/useGlobalData'
+import Head from '@docusaurus/Head'
+
+type BaseFrontMatter = {
+  title?: string
+  slug?: string
+  image?: string
+  author?: string
+}
+
+function normalizeSlug(slug: string): string {
+  return slug.replace(/\/$/, '')
+}
+
+export function generateSchema(frontMatter: BaseFrontMatter, pageMeta: any) {
+  const { title, slug, image, author } = frontMatter
+
+  const safeTitle = title || 'Snowplow Documentation'
+  const description = pageMeta.description || 'Snowplow documentation'
+  const keywords = pageMeta.keywords || []
+  const fullUrl = `https://snowplow.io${slug || ''}`
+
+  const publisher = {
+    '@type': 'Organization',
+    name: 'Snowplow',
+    url: 'https://snowplow.io',
+    logo: {
+      '@type': 'ImageObject',
+      url: 'https://snowplow.io/images/logo.png',
+    },
+  }
+
+  const schemaData: Record<string, any> = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle', // always TechArticle
+    headline: safeTitle,
+    description,
+    keywords,
+    url: fullUrl,
+    inLanguage: 'en-US',
+    publisher,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': fullUrl,
+    },
+  }
+
+  if (image) schemaData.image = image
+  if (author) schemaData.author = { '@type': 'Person', name: author }
+
+  return [schemaData]
+}
+
+export default function HeadJSONLD() {
+  const { frontMatter, metadata } = useDoc()
+
+  const pluginData = usePluginData('docusaurus-plugin-page-schema') as {
+    siteUrl: string
+    siteName: string
+    allPagesMetadata: Record<string, any>
+  }
+
+  const allPagesMetadata = pluginData.allPagesMetadata || {}
+
+  const rawSlug =
+    frontMatter.slug ||
+    metadata.permalink ||
+    `/${frontMatter.title?.replace(/\s+/g, '-').toLowerCase()}`
+  const slug = normalizeSlug(rawSlug)
+
+  const pageMeta = allPagesMetadata[slug] || {}
+
+  const schemas = generateSchema(
+    {
+      title: frontMatter.title,
+      slug,
+      image: (frontMatter as any).image, // safe cast, optional
+      author: (frontMatter as any).author, // safe cast, optional
+    },
+    pageMeta
+  )
+
+  return (
+    <Head>
+      {schemas.map((schema, index) => (
+        <script key={index} type="application/ld+json">
+          {JSON.stringify(schema)}
+        </script>
+      ))}
+    </Head>
+  )
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -16,10 +16,10 @@ import styles from './styles.module.css'
 import { Paper } from '@mui/material'
 
 import { useTutorial, TutorialKind } from '@site/src/components/tutorials/hooks'
-import { AlignLeft } from 'lucide-react';
+import { AlignLeft } from 'lucide-react'
+import HeadJSONLD from '../../../components/SchemaPlugin'
 
-import Demo_Ad from '../../../components/ui/Demo_Ad';
-
+import Demo_Ad from '../../../components/ui/Demo_Ad'
 
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -50,38 +50,43 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
   const tutorial = useTutorial()
 
   return (
-    <div className="row">
-      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
-        <DocVersionBanner />
-        <div className={styles.docItemContainer}>
-          <article className="overflow-x-auto max-w-fit leading-relaxed prose prose-headings:font-bold prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-sm prose-img:mx-auto prose-img:block ">
-            <DocBreadcrumbs />
-            <DocVersionBadge />
-            {docTOC.mobile}
-            {tutorial === TutorialKind.Tutorial ? (
-              <Paper sx={{ p: 2, pt: 2 }}>
+    <>
+      <HeadJSONLD />
+      <div className="row">
+        <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+          <DocVersionBanner />
+          <div className={styles.docItemContainer}>
+            <article className="overflow-x-auto max-w-fit leading-relaxed prose prose-headings:font-bold prose-p:mt-0 prose-table:rounded-lg prose-td:ps-3 prose-td:pe-3 prose-th:ps-3 prose-th:pe-3 prose-ul:mt-0 prose-ol:mt-0 prose-code:before:content-none prose-code:after:content-none prose-code:font-normal prose-code:text-sm prose-img:mx-auto prose-img:block ">
+              <DocBreadcrumbs />
+              <DocVersionBadge />
+              {docTOC.mobile}
+              {tutorial === TutorialKind.Tutorial ? (
+                <Paper sx={{ p: 2, pt: 2 }}>
+                  <DocItemContent>{children}</DocItemContent>
+                </Paper>
+              ) : (
                 <DocItemContent>{children}</DocItemContent>
-              </Paper>
-            ) : (
-              <DocItemContent>{children}</DocItemContent>
-            )}
-            <DocItemFooter />
-          </article>
-          <DocItemPaginator />
+              )}
+              <DocItemFooter />
+            </article>
+            <DocItemPaginator />
+          </div>
         </div>
+        {docTOC.desktop && (
+          <div className="col col--3">
+            <div className="sticky top-16">
+              <div className="flex items-center gap-2 my-1">
+                <AlignLeft size={16} className="opacity-70 text-foreground" />
+                <p className="text-[0.825rem] font-normal opacity-70 text-foreground m-0 pl-1">
+                  On this page
+                </p>
+              </div>
+              {docTOC.desktop}
+              <Demo_Ad />
+            </div>
+          </div>
+        )}
       </div>
-      {docTOC.desktop && 
-      <div className="col col--3">
-        <div className="sticky top-16">
-        <div className='flex items-center gap-2 my-1'>
-          <AlignLeft size={16} className='opacity-70 text-foreground' />
-          <p className="text-[0.825rem] font-normal opacity-70 text-foreground m-0 pl-1">On this page</p>
-        </div>
-        {docTOC.desktop}
-        <Demo_Ad />
-        </div>
-      </div>
-      }
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
Adds a Docusaurus plugin to generate TechArticle JSON-LD schema for all documentation pages,  using a central mapping for SEO metadata.
