### PR TITLE
Add instructions on how to authenticate using Signals Sandbox through the SDK

### DIFF
--- a/docs/signals/define-attributes/using-python-sdk/index.md
+++ b/docs/signals/define-attributes/using-python-sdk/index.md
@@ -47,6 +47,21 @@ sp_signals = Signals(
 )
 ```
 
+:::info Using Signals Sandbox authentication
+
+In case you are trying out Signals using the Sandbox experience, you can authenticate using the sandbox token as follows:
+
+```py
+from snowplow_signals import SignalsSandbox
+
+sp_signals = SignalsSandbox(
+    api_url=SANDBOX_URL,
+    sandbox_token=SANDBOX_TOKEN,
+)
+```
+
+:::
+
 The created `Signals` object has the following methods:
 
 | Method                   | Description                                                                 |

--- a/docs/signals/interventions/index.md
+++ b/docs/signals/interventions/index.md
@@ -129,7 +129,7 @@ If the intervention is valid, it will immediately be published to any subscriber
 ```python
 from snowplow_signals import AttributeKeyIdentifiers, InterventionInstance, Signals
 
-# regular signals SDK authentication
+# regular signals SDK authentication (use the SignalsSandbox class instead of Signals if using the Sandbox experience)
 sp_signals = Signals(
     api_url=SIGNALS_DEPLOYED_URL,
     api_key=CONSOLE_API_KEY,
@@ -188,7 +188,7 @@ The Signals SDK allows subscribing to interventions for arbitrary attribute keys
 ```python
 from snowplow_signals import AttributeKeyIdentifiers, InterventionInstance, Signals
 
-# regular signals SDK authentication
+# regular signals SDK authentication (use the SignalsSandbox class instead of Signals if using the Sandbox experience)
 sp_signals = Signals(
     api_url=SIGNALS_DEPLOYED_URL,
     api_key=CONSOLE_API_KEY,

--- a/docs/signals/retrieve-attributes/index.md
+++ b/docs/signals/retrieve-attributes/index.md
@@ -49,6 +49,21 @@ sp_signals = Signals(
 )
 ```
 
+:::info Using Signals Sandbox authentication
+
+In case you are trying out Signals using the Sandbox experience, you can authenticate using the sandbox token as follows:
+
+```py
+from snowplow_signals import SignalsSandbox
+
+sp_signals = SignalsSandbox(
+    api_url=SANDBOX_URL,
+    sandbox_token=SANDBOX_TOKEN,
+)
+```
+
+:::
+
 </TabItem>
 <TabItem value="nodejs" label="Node.js">
 
@@ -70,6 +85,22 @@ const signals = new Signals({
   organizationId: ORG_ID,
 });
 ```
+
+:::info Using Signals Sandbox authentication
+
+In case you are trying out Signals using the Sandbox experience, you can authenticate using the sandbox token as follows:
+
+```typescript
+import { Signals } from '@snowplow/signals-node';
+
+const signals = new Signals({
+  baseUrl: SANDBOX_URL,
+  sandboxToken: SANDBOX_TOKEN,
+});
+```
+
+:::
+
 
 </TabItem>
 </Tabs>

--- a/tutorials/signals-ml-prospect-scoring/define-prospect-attributes.md
+++ b/tutorials/signals-ml-prospect-scoring/define-prospect-attributes.md
@@ -343,6 +343,7 @@ Apply the attribute group and service configurations to Signals.
 ```python
 from snowplow_signals import Signals
 
+# NOTE: Use the SignalsSandbox class instead of Signals if using the Sandbox experience
 sp_signals = Signals(
     api_url=ENV_SP_API_URL,
     api_key=ENV_SP_API_KEY,

--- a/tutorials/signals-quickstart/retrieve-attributes.md
+++ b/tutorials/signals-quickstart/retrieve-attributes.md
@@ -45,6 +45,19 @@ sp_signals = Signals(
 )
 ```
 
+:::info Using Signals Sandbox authentication
+
+In case you are trying out Signals using the Sandbox experience, you can authenticate using the sandbox token as follows:
+
+```py
+from snowplow_signals import SignalsSandbox
+
+sp_signals = SignalsSandbox(
+    api_url=SANDBOX_URL,
+    sandbox_token=SANDBOX_TOKEN,
+)
+```
+
 ## Retrieving your session attributes
 
 Use your current session ID to retrieve the attributes that Signals has just calculated about your session.


### PR DESCRIPTION
Adds snippets to explain how to authenticate using the Signals Sandbox token through the SDK.

Not sure if we need more context for explaining Signals Sandbox or that will be explained separately? cc @johnmicahreid 