### PR TITLE
Remove the github edit link and timestamp

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,8 +45,7 @@ module.exports = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       {
         docs: {
-          showLastUpdateTime: true,
-          editUrl: 'https://github.com/snowplow/documentation/tree/main/',
+          showLastUpdateTime: false,
           remarkPlugins: [abbreviations, math],
           rehypePlugins: [katex],
           async sidebarItemsGenerator({


### PR DESCRIPTION
The edit link isn't relevant any more now that the repo is private.
And the timestamp was never very useful.