### PR TITLE
Add global Open Graph image meta tag to all docs pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -244,6 +244,18 @@ module.exports = {
       },
     }),
 
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:image',
+        content:
+          'https://cdn.prod.website-files.com/661fd4aa0185c5022e931990/66714f936876397066d5fba7_thumbnail-post-category.avif',
+      },
+    },
+  ],
+
+
   customFields: {
     webpack: {
       configure: (config) => {


### PR DESCRIPTION
Added a global Open Graph image meta tag in docusaurus.config.js to ensure a thumbnail appears when docs pages are shared on social media.