### PR TITLE
Remove mermaid droop

### DIFF
--- a/docs/fundamentals/schemas/versioning/index.md
+++ b/docs/fundamentals/schemas/versioning/index.md
@@ -49,7 +49,7 @@ flowchart LR
   style v102 fill:orange
   %% ~~~ is not working for some reason
   linkStyle default stroke:none,fill:none
-  v100("1-0-0") --- v101("1-0-1") --- v102("1-0-2\n(incorrect)")
+  v100("1-0-0") --- v101("1-0-1") --- v102("1-0-2<br/>(incorrect)")
 ```
 
 After:
@@ -58,7 +58,7 @@ After:
 flowchart LR
   style v102 fill:teal
   linkStyle default stroke:none,fill:none
-  v100("1-0-0") --- v101("1-0-1") --- v102("1-0-2\n(corrected)")
+  v100("1-0-0") --- v101("1-0-1") --- v102("1-0-2<br/>(corrected)")
 ```
 
 Follow these [instructions](/docs/event-studio/data-structures/versioning/index.md#patch-a-schema) to patch a schema.
@@ -79,7 +79,7 @@ Before:
 flowchart RL
   style v102 fill:orange
   linkStyle default stroke:none,fill:none
-  v102("1-0-2\n(incorrect)") --- v101("1-0-1") --- v100("1-0-0")
+  v102("1-0-2<br/>(incorrect)") --- v101("1-0-1") --- v100("1-0-0")
 ```
 
 After:
@@ -88,8 +88,8 @@ After:
 flowchart RL
   style v102 fill:orange
   style v103 fill:teal
-  v102("1-0-2\n(incorrect)") --- v101("1-0-1") --- v100("1-0-0")
-  v103("1-0-3\n(corrected)") -->|supersedes| v102
+  v102("1-0-2<br/>(incorrect)") --- v101("1-0-1") --- v100("1-0-0")
+  v103("1-0-3<br/>(corrected)") -->|supersedes| v102
   linkStyle 0,1 stroke:none,fill:none
 ```
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1517,6 +1517,11 @@ div[class*='buttonGroup'] {
 .theme-code-block div[class^='codeBlockContent'] {
   padding-top: 0 !important;
 }
+/* Reset paragraph margins inside Mermaid nodes (foreignObject renders <p> tags) */
+.mermaid p {
+  margin: 0;
+}
+
 /* Mermaid diagrams responsive styles - FORCE fit viewport */
 .mermaid,
 div.mermaid,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1517,11 +1517,16 @@ div[class*='buttonGroup'] {
 .theme-code-block div[class^='codeBlockContent'] {
   padding-top: 0 !important;
 }
-/* Reset paragraph margins inside Mermaid nodes (foreignObject renders <p> tags).
-   The container class is "docusaurus-mermaid-container", not ".mermaid".
-   Needs !important to beat Infima's boosted p margin specificity (Docusaurus 3). */
+/* Fix Mermaid node sizing: Infima's boosted p margins (Docusaurus 3) inflate
+   foreignObject dimensions at render time. In production builds, external CSS
+   loads after Mermaid measures nodes, so shapes are drawn too large. The margin
+   reset fixes the text; height: 100% shrinks foreignObject to fit its content
+   within the already-drawn shapes. */
 .docusaurus-mermaid-container p {
   margin: 0 !important;
+}
+.docusaurus-mermaid-container foreignObject {
+  height: 100% !important;
 }
 
 /* Mermaid diagrams responsive styles - FORCE fit viewport */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1517,9 +1517,10 @@ div[class*='buttonGroup'] {
 .theme-code-block div[class^='codeBlockContent'] {
   padding-top: 0 !important;
 }
-/* Reset paragraph margins inside Mermaid nodes (foreignObject renders <p> tags) */
+/* Reset paragraph margins inside Mermaid nodes (foreignObject renders <p> tags).
+   Needs !important to survive production CSS reordering (Tailwind important: true). */
 .mermaid p {
-  margin: 0;
+  margin: 0 !important;
 }
 
 /* Mermaid diagrams responsive styles - FORCE fit viewport */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1518,8 +1518,9 @@ div[class*='buttonGroup'] {
   padding-top: 0 !important;
 }
 /* Reset paragraph margins inside Mermaid nodes (foreignObject renders <p> tags).
-   Needs !important to survive production CSS reordering (Tailwind important: true). */
-.mermaid p {
+   The container class is "docusaurus-mermaid-container", not ".mermaid".
+   Needs !important to beat Infima's boosted p margin specificity (Docusaurus 3). */
+.docusaurus-mermaid-container p {
   margin: 0 !important;
 }
 


### PR DESCRIPTION
## What changed?

Removed extra line in Mermaid notes. This seems to have broken with a recent Mermaid upgrade.

Also fixed the `\n` showing up as `\n`.