### PR TITLE
Fix identities quickstart to install dbt package from GitHub

### DIFF
--- a/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/identities/index.md
+++ b/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-quickstart/identities/index.md
@@ -17,12 +17,12 @@ This guide walks you through setting up the [Snowplow Identities dbt package](/d
 
 ## Installation
 
-Add the package to your `packages.yml`:
+Add the package from [GitHub](https://github.com/snowplow-incubator/dbt-snowplow-identities) to your `packages.yml`:
 
 ```yaml title="packages.yml"
 packages:
-  - package: snowplow/snowplow_identities
-    version: [">=0.1.0", "<0.2.0"]
+  - git: "https://github.com/snowplow-incubator/dbt-snowplow-identities.git"
+    revision: "main"
 ```
 
 Then run:


### PR DESCRIPTION
## Summary
- Fixed the identities quickstart installation instructions to source the dbt package from [GitHub](https://github.com/snowplow-incubator/dbt-snowplow-identities) instead of dbt Hub, where it is not published

## Test plan
- [ ] Verify the `packages.yml` snippet works with `dbt deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)