### PR TITLE
Add noindex flag to link pages again

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -155,12 +155,15 @@ const swapDocItemsToLinkItems = (generatedDocs, originalDocs) => {
       descriptions[docItem.id] = docItem.frontMatter.description
     }
     if (docItem.frontMatter.type === 'link') {
+      // Mutate the original frontMatter so useDoc() picks up noindex at render time.
+      // This is intentional — the spread into linkItems below copies the updated reference.
+      docItem.frontMatter.sidebar_custom_props = {
+        ...(docItem.frontMatter.sidebar_custom_props || {}),
+        noindex: true,
+      }
+
       linkItems[docItem.id] = {
         ...docItem.frontMatter,
-        sidebar_custom_props: {
-          ...(docItem.frontMatter.sidebar_custom_props || {}),
-          noindex: true,
-        },
       }
     }
   }

--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -47,6 +47,9 @@ export default function MDXContentWrapper(props) {
     )
   }
 
+  const frontMatter = docMetadata?.frontMatter ?? docMetadata?.metadata?.frontMatter
+  const isExternalLink = frontMatter?.type === 'link' && frontMatter?.href
+
   return (
     <>
       {(legacy || outdated || hidden || noindex) && (
@@ -55,7 +58,14 @@ export default function MDXContentWrapper(props) {
         </Head>
       )}
       {admonitions}
-      <MDXContent {...props} />
+      {isExternalLink ? (
+        <p>
+          This page links to an external resource. Visit it
+          at: <a href={frontMatter.href}>{frontMatter.href}</a>
+        </p>
+      ) : (
+        <MDXContent {...props} />
+      )}
     </>
   )
 }

--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -47,7 +47,8 @@ export default function MDXContentWrapper(props) {
     )
   }
 
-  const frontMatter = docMetadata?.frontMatter ?? docMetadata?.metadata?.frontMatter
+  const frontMatter =
+    docMetadata?.frontMatter ?? docMetadata?.metadata?.frontMatter
   const isExternalLink = frontMatter?.type === 'link' && frontMatter?.href
 
   return (
@@ -60,8 +61,8 @@ export default function MDXContentWrapper(props) {
       {admonitions}
       {isExternalLink ? (
         <p>
-          This page links to an external resource. Visit it
-          at: <a href={frontMatter.href}>{frontMatter.href}</a>
+          This page links to an external resource at{' '}
+          <a href={frontMatter.href}>{frontMatter.href}</a>
         </p>
       ) : (
         <MDXContent {...props} />


### PR DESCRIPTION
Link pages were showing up in Algolia search results again. They just looked like empty pages - confusing.

I added `noindex` in #1503, but there was a regression in #1629. This PR fixes the behaviour, plus a comment explaining what's happening.

Also adds content to the link pages in case anyone ends up there.