### PR TITLE
Enable Cloudflare Workers observability logging and traces

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,5 +7,14 @@
     "binding": "ASSETS",
     "run_worker_first": true,
     "not_found_handling": "404-page"
+  },
+  "observability": {
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Enable observability in `wrangler.jsonc` with logging (including invocation logs) and traces

## Test plan

- [ ] Deploy to Cloudflare Workers and confirm the site loads correctly
- [ ] Verify observability logs and traces appear in the Cloudflare dashboard