### PR TITLE
Test: trigger build notification

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,4 +1,5 @@
 {
+  // Test: trigger build notification
   "name": "documentation",
   "compatibility_date": "2026-02-27",
   "main": "worker/index.js",


### PR DESCRIPTION
## Summary

- No-op change to trigger a Cloudflare Workers build and verify the `builds-event-subscriptions` queue subscription fires `build.succeeded`/`build.failed` events

## Test plan

- [ ] Verify build is triggered
- [ ] Verify queue subscription receives the build event
- [ ] Close and delete branch after confirming