### PR TITLE
Add request logging to worker for observability

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -13,14 +13,24 @@ export default {
     const url = new URL(request.url);
 
     const forced = toResponse(findForcedRedirect(url.pathname), url);
-    if (forced) return forced;
+    if (forced) {
+      console.log(`${request.method} ${url.pathname} -> ${forced.status} (redirect)`);
+      return forced;
+    }
 
     const response = await env.ASSETS.fetch(request);
-    if (response.status !== 404) return response;
+    if (response.status !== 404) {
+      console.log(`${request.method} ${url.pathname} -> ${response.status}`);
+      return response;
+    }
 
     const fallback = toResponse(findFallbackRedirect(url.pathname), url);
-    if (fallback) return fallback;
+    if (fallback) {
+      console.log(`${request.method} ${url.pathname} -> ${fallback.status} (fallback redirect)`);
+      return fallback;
+    }
 
+    console.log(`${request.method} ${url.pathname} -> 404`);
     return response;
   },
 };

--- a/worker/index.js
+++ b/worker/index.js
@@ -20,7 +20,7 @@ export default {
 
     const response = await env.ASSETS.fetch(request);
     if (response.status !== 404) {
-      console.log(`${request.method} ${url.pathname} -> ${response.status}`);
+      console.log(`${request.method} ${url.pathname} -> ${response.status} (asset)`);
       return response;
     }
 


### PR DESCRIPTION
## Summary

- Log method, URL path, and response status for every request in the worker
- Distinguishes between forced redirects, fallback redirects, asset responses, and 404s
- Logs appear in Workers Logs (Observability tab) and via `wrangler tail`

## Test plan

- [x] Deploy and run `npx wrangler tail` to verify logs appear
- [x] Check the Observability tab in the Cloudflare dashboard for request detail