### PR TITLE
Add cross-domain tracking to stitch users across snowplow.io and console

### DIFF
--- a/snowplow.js
+++ b/snowplow.js
@@ -5,6 +5,7 @@ import {
   addGlobalContexts,
   enableActivityTracking,
   disableAnonymousTracking,
+  crossDomainLinker,
 } from '@snowplow/browser-tracker'
 import {
   LinkClickTrackingPlugin,
@@ -26,6 +27,14 @@ import { isEmpty, pickBy } from 'lodash'
 import { SnowplowMediaPlugin } from '@snowplow/browser-plugin-media'
 import { BotDetectionPlugin } from '@snowplow/browser-plugin-bot-detection'
 
+const CROSS_DOMAIN_TARGETS = ['snowplowanalytics.com']
+
+const crossDomainLinkerFn = (linkElement) => {
+  return CROSS_DOMAIN_TARGETS.some((domain) =>
+    linkElement.hostname.endsWith(domain)
+  )
+}
+
 const createTrackerConfig = (cookieName) => {
   const appId = DOCS_SITE_URLS.includes(window.location.hostname)
     ? 'docs2'
@@ -45,6 +54,8 @@ const createTrackerConfig = (cookieName) => {
     cookieDomain: `.${domain[1]}.${domain[0]}`,
     cookieName,
     cookieSameSite: 'Lax',
+    crossDomainLinker: crossDomainLinkerFn,
+    useExtendedCrossDomainLinker: true,
     contexts: {
       webPage: true,
       performanceTiming: true,
@@ -131,6 +142,7 @@ const module = {
       // see https://github.com/facebook/docusaurus/pull/7424 regarding setTimeout
       setTimeout(() => {
         trackPageView()
+        crossDomainLinker(crossDomainLinkerFn)
       })
     }
   },


### PR DESCRIPTION
## Summary
- Enables cross-domain tracking from the docs site (`snowplow.io`) to the console (`snowplowanalytics.com`) by decorating outgoing links with the `_sp` querystring parameter
- Uses the extended cross-domain linker format (`useExtendedCrossDomainLinker: true`) to include `sessionId` and `sourceId` for richer identity stitching via the [cross-navigation enrichment](https://docs.snowplow.io/docs/pipeline/enrichments/available-enrichments/cross-navigation-enrichment/)
- Re-applies link decoration on Docusaurus SPA route changes so dynamically rendered links are also covered

## How it works
A `crossDomainLinker` callback is added to the tracker configuration that returns `true` for any link whose hostname ends with `snowplowanalytics.com`. When a user clicks such a link, the tracker appends `_sp={domainUserId}.{timestamp}.{sessionId}.{sourceId}...` to the URL. The console's tracker then picks up the `refr_domain_userid` from the destination page's events, enabling [Identities](https://docs.snowplow.io/docs/identities/concepts/cross-domain-tracking/) to resolve both sites' activity to a single Snowplow ID.

## Test plan
- [ ] Verify the site builds cleanly (`yarn build` passes)
- [ ] On the docs site, inspect a link to `console.snowplowanalytics.com` — confirm it gets an `_sp` parameter appended on click
- [ ] Confirm links to non-target domains (e.g. GitHub, external docs) are **not** decorated
- [ ] Navigate between docs pages and verify links on the new page are also decorated (SPA re-decoration)
- [ ] Verify anonymous tracking mode still works correctly (no `_sp` decoration leaks PII when analytics cookies are declined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)