### PR TITLE
Correct a contradiction in ASN Lookup docs

### DIFF
--- a/docs/pipeline/enrichments/available-enrichments/asn-lookup-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/asn-lookup-enrichment/index.md
@@ -156,7 +156,7 @@ This enrichment modifies the ASN entity (`iglu:com.snowplowanalytics.snowplow/as
 }
 ```
 
-If the ASN does not match any entry in the bot list, or the event's platform is in `bypassPlatforms`, the `likelyBot` field is not added to the entity.
+If the event's platform is in `bypassPlatforms`, the `likelyBot` field is not added to the entity.
 
 | Field | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION
## What changed?

The page incorrectly stated that the absence of the ASN in the list would cause `likelyBot` to be absent. The table below is correct though.