### PR TITLE
Fix Mermaid diagram text alignment in production builds

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1527,6 +1527,12 @@ pre.mermaid {
   width: 100% !important;
 }
 
+/* Fix Infima paragraph margin leaking into Mermaid SVG node labels */
+[id^="mermaid-"] foreignObject .nodeLabel p:not(#\#):not(#\#),
+[id^="mermaid-"] foreignObject .edgeLabel p:not(#\#):not(#\#) {
+  margin-bottom: 0;
+}
+
 /* Mobile: FORCE diagrams to never exceed viewport - covers both real mobile and dev tools simulation */
 @media (max-width: 768px),
   screen and (max-device-width: 768px),


### PR DESCRIPTION
## What changed?

Currently prod builds get a margin-bottom stuck on markdown defined elements in flowcharts which leads to this.

<img width="396" height="279" alt="Screenshot 2026-04-16 at 14 39 02" src="https://github.com/user-attachments/assets/1afdb597-1b65-4502-9b9d-0b659fc3ac1b" />


The selector soup here drops the margin and makes things line up better.

<img width="399" height="243" alt="Screenshot 2026-04-16 at 14 41 46" src="https://github.com/user-attachments/assets/df09eb3c-ea11-4864-adc7-75f52e5f92f0" />

I attempted to find less horrible looking workarounds, but failed.

I think these are only pages with diagrams affected (they look fixed locally).

Identities:
  - docs/identities/concepts/merges/index.md
  - docs/identities/concepts/unique-identifiers/index.md
  - docs/identities/concepts/index.md
  - docs/identities/concepts/cross-domain-tracking/index.md

IAB enrichment:
  - docs/pipeline/enrichments/available-enrichments/iab-enrichment/index.md

BigQuery loader:
  - docs/api-reference/loaders-storage-targets/bigquery-loader/previous-versions/bigquery-loader-1.x/_diagram.md (has some \n in there, i wont muddy this pr with fixing those, i can do that after)

