### PR TITLE
Add architecture diagram to Signals + Vercel AI SDK tutorial

### DIFF
--- a/tutorials/signals-ai-agent-context/introduction.md
+++ b/tutorials/signals-ai-agent-context/introduction.md
@@ -32,6 +32,37 @@ Agent: "I can see you've been exploring our Enterprise plan — happy to help.
 
 The agent can tailor its response based on the user's actual behavior, making for a more engaging and personalized experience.
 
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph Browser["Browser"]
+        T["Snowplow tracker"]
+        W["ChatWidget<br/>(useChat hook)"]
+    end
+
+    subgraph Server["Next.js server"]
+        R["/api/chat route<br/>streamText + systemPrompt"]
+    end
+
+    subgraph Snowplow["Snowplow"]
+        CO["Collector<br/>(receives raw events)"]
+        SG["Signals<br/>(real-time session attributes)"]
+    end
+
+    subgraph AI["Model provider"]
+        G["Vercel AI Gateway<br/>(openai/gpt-4o-mini)"]
+    end
+
+    T -->|"page views, pings,<br/>link clicks"| CO
+    CO -->|"enriched events"| SG
+    W -->|"POST messages +<br/>snowplowDomainSessionId"| R
+    R -->|"GET attributes<br/>by session ID"| SG
+    R -->|"streaming chat completion"| G
+```
+
+Here's how the pieces fit together. The Snowplow Browser tracker streams behavioral [events](/docs/fundamentals/events/) (page views, page pings, link clicks) to your Collector, and Signals computes live session attributes from that stream. On the frontend, the `ChatWidget` reads the Snowplow session ID from the tracker's cookie and sends it alongside every chat request as `pageContext.snowplowDomainSessionId`. The Next.js `/api/chat` route uses that session ID to fetch fresh attributes from Signals, appends them to the system prompt, and hands the combined prompt to `streamText`, which streams the model's response back through the Vercel AI Gateway to the browser.
+
 ## Prerequisites
 
 This tutorial requires:

--- a/tutorials/signals-ai-agent-context/introduction.md
+++ b/tutorials/signals-ai-agent-context/introduction.md
@@ -32,7 +32,7 @@ Agent: "I can see you've been exploring our Enterprise plan — happy to help.
 
 The agent can tailor its response based on the user's actual behavior, making for a more engaging and personalized experience.
 
-## Architecture
+## How the components fit together
 
 ```mermaid
 flowchart TB
@@ -61,7 +61,7 @@ flowchart TB
     R -->|"streaming chat completion"| G
 ```
 
-Here's how the pieces fit together. The Snowplow Browser tracker streams behavioral [events](/docs/fundamentals/events/) (page views, page pings, link clicks) to your Collector, and Signals computes live session attributes from that stream. On the frontend, the `ChatWidget` reads the Snowplow session ID from the tracker's cookie and sends it alongside every chat request as `pageContext.snowplowDomainSessionId`. The Next.js `/api/chat` route uses that session ID to fetch fresh attributes from Signals, appends them to the system prompt, and hands the combined prompt to `streamText`, which streams the model's response back through the Vercel AI Gateway to the browser.
+The Snowplow JavaScript tracker streams behavioral [events](/docs/fundamentals/events/) (page views, page pings, link clicks) to the Collector, and Signals computes live session attributes from that stream. On the front-end, the `ChatWidget` reads the Snowplow session ID from the tracker's cookie and sends it alongside every chat request as `pageContext.snowplowDomainSessionId`. The Next.js `/api/chat` route uses that session ID to fetch fresh attributes from Signals, appends them to the system prompt, and hands the combined prompt to `streamText`, which streams the model's response back through the Vercel AI Gateway to the browser.
 
 ## Prerequisites
 

--- a/tutorials/signals-ai-agent-context/introduction.md
+++ b/tutorials/signals-ai-agent-context/introduction.md
@@ -34,6 +34,13 @@ The agent can tailor its response based on the user's actual behavior, making fo
 
 ## How the components fit together
 
+The flow works like this:
+- The Snowplow Browser tracker streams behavioral [events](/docs/fundamentals/events/) to your Collector
+- Signals computes live session attributes from that stream
+- On the front-end, the `ChatWidget` reads the Snowplow session ID from the tracker's cookie and sends it alongside every chat request as `pageContext.snowplowDomainSessionId`
+- The Next.js `/api/chat` route uses that session ID to fetch fresh attributes from Signals and appends them to the system prompt
+- The model's response is streamed back through the Vercel AI Gateway to the browser
+
 ```mermaid
 flowchart TB
     subgraph Browser["Browser"]
@@ -60,8 +67,6 @@ flowchart TB
     R -->|"GET attributes<br/>by session ID"| SG
     R -->|"streaming chat completion"| G
 ```
-
-The Snowplow JavaScript tracker streams behavioral [events](/docs/fundamentals/events/) (page views, page pings, link clicks) to the Collector, and Signals computes live session attributes from that stream. On the front-end, the `ChatWidget` reads the Snowplow session ID from the tracker's cookie and sends it alongside every chat request as `pageContext.snowplowDomainSessionId`. The Next.js `/api/chat` route uses that session ID to fetch fresh attributes from Signals, appends them to the system prompt, and hands the combined prompt to `streamText`, which streams the model's response back through the Vercel AI Gateway to the browser.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Adds a Mermaid flowchart to the Signals + Vercel AI SDK tutorial `introduction.md`, mirroring the architecture section in the newer Google ADK tutorial
- Adds a short paragraph explaining how the browser, Next.js API route, Snowplow Collector/Signals, and Vercel AI Gateway fit together

## Test plan
- [ ] Netlify deploy preview renders the Mermaid diagram
- [ ] `yarn build` succeeds (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)