### PR TITLE
Add info about activity metrics

### DIFF
--- a/docs/events/ootb-data/page-activity-tracking/index.md
+++ b/docs/events/ootb-data/page-activity-tracking/index.md
@@ -39,6 +39,56 @@ This table shows the support for page ping tracking across the main client-side 
 
 We recommend using the [Base web tracking plan template](/docs/event-studio/tracking-plans/templates/index.md#base-web) for web tracking. It includes page pings.
 
+Since web tracker 4.8.0, it's also possible to attach [detailed activity metrics](/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md#activity-metrics) to each page ping. The detailed metrics show how much interaction happened on the page, including the number of clicks, touches, key presses, absolute scroll distance (in either direction) and distance traveled by the mouse.
+
+:::tip[Agentic browsers]
+
+This can be helpful, for example, for distinguishing human and agent actions in an agentic browser session. Agents typically produce very little activity, navigating to pages directly and not clicking on links.
+
+:::
+
+### Activity metrics entity
+
+<SchemaProperties
+  overview={{event: false}}
+  example={{ mouseDistance: 1234, scrollDistance: 567, keyPresses: 12, clicks: 3, touches: 0 }}
+  schema={{
+    "description": "Quantitative user interaction metrics accumulated between page pings",
+    "properties": {
+      "mouseDistance": {
+        "type": "integer",
+        "description": "Cumulative Euclidean mouse distance in pixels"
+      },
+      "scrollDistance": {
+        "type": "integer",
+        "description": "Cumulative absolute scroll distance in pixels (both directions)"
+      },
+      "keyPresses": {
+        "type": "integer",
+        "description": "Number of key presses"
+      },
+      "clicks": {
+        "type": "integer",
+        "description": "Number of clicks"
+      },
+      "touches": {
+        "type": "integer",
+        "description": "Number of touch events"
+      }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": ["mouseDistance", "scrollDistance", "keyPresses", "clicks", "touches"],
+    "self": {
+      "vendor": "com.snowplowanalytics.snowplow",
+      "name": "activity_metrics",
+      "format": "jsonschema",
+      "version": "1-0-0"
+    },
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+  }}
+/>
+
 ## Screen engagement
 
 Use screen engagement tracking to track a `screen_end` event when a user navigates away from a screen.

--- a/docs/events/ootb-data/page-activity-tracking/index.md
+++ b/docs/events/ootb-data/page-activity-tracking/index.md
@@ -39,7 +39,7 @@ This table shows the support for page ping tracking across the main client-side 
 
 We recommend using the [Base web tracking plan template](/docs/event-studio/tracking-plans/templates/index.md#base-web) for web tracking. It includes page pings.
 
-Since web tracker 4.8.0, it's also possible to attach [detailed activity metrics](/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md#activity-metrics) to each page ping. The detailed metrics show how much interaction happened on the page, including the number of clicks, touches, key presses, absolute scroll distance (in either direction) and distance traveled by the mouse.
+Since JavaScript tracker version 4.8.0, you can also attach [detailed activity metrics](/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md#activity-metrics) to each page ping. The detailed metrics show how much interaction happened on the page, including the number of clicks, touches, key presses, absolute scroll distance (in either direction), and distance traveled by the mouse.
 
 :::tip[Agentic browsers]
 

--- a/docs/events/ootb-data/page-activity-tracking/index.md
+++ b/docs/events/ootb-data/page-activity-tracking/index.md
@@ -39,6 +39,8 @@ This table shows the support for page ping tracking across the main client-side 
 
 We recommend using the [Base web tracking plan template](/docs/event-studio/tracking-plans/templates/index.md#base-web) for web tracking. It includes page pings.
 
+### Activity metrics entity
+
 Since JavaScript tracker version 4.8.0, you can also attach [detailed activity metrics](/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md#activity-metrics) to each page ping. The detailed metrics show how much interaction happened on the page, including the number of clicks, touches, key presses, absolute scroll distance (in either direction), and distance traveled by the mouse.
 
 :::tip[Agentic browsers]
@@ -46,8 +48,6 @@ Since JavaScript tracker version 4.8.0, you can also attach [detailed activity m
 This can be helpful, for example, for distinguishing human and agent actions in an agentic browser session. Agents typically produce very little activity, navigating to pages directly and not clicking on links.
 
 :::
-
-### Activity metrics entity
 
 <SchemaProperties
   overview={{event: false}}

--- a/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md
+++ b/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md
@@ -146,9 +146,48 @@ On the next interval after this call, a ping will be generated even if the user 
 
 This is particularly useful when a user is passively engaging with your content, e.g. watching a video.
 
+### Activity metrics
+
+Since web tracker 4.8.0, it's possible to track more detailed activity metrics. These metrics show how much interaction happened on the page, including the number of clicks, touches, key presses, absolute scroll distance (in either direction) and distance traveled by the mouse.
+
+To enable activity metrics, set `activityMetrics` to `true` when enabling activity tracking (the default is `false`):
+
+<Tabs groupId="platform" queryString>
+  <TabItem value="js" label="JavaScript (tag)" default>
+
+```javascript
+snowplow('enableActivityTracking', {
+  activityMetrics: true,
+  ...
+});
+```
+  </TabItem>
+  <TabItem value="browser" label="Browser (npm)">
+
+```javascript
+enableActivityTracking({
+  activityMetrics: true,
+  ...
+});
+```
+  </TabItem>
+</Tabs>
+
+With activity metrics enabled, each page ping includes an [`activity_metrics`](/docs/events/ootb-data/page-activity-tracking/index.md#activity-metrics-entity) entity.
+
+Metrics accumulate between page pings and reset after each one, so each ping reflects activity during that interval only. They also reset when a new page view is tracked (see [reset page pings on page view](#reset-page-pings-on-page-view)).
+
+:::note[Manual updates]
+
+Calling `updatePageActivity` triggers a ping but does not add to the activity metrics. Only real user interactions (mouse movement, scrolling, clicks, key presses, touches) contribute to the metrics.
+
+:::
+
+Activity metrics also work with [activity tracking callbacks](#activity-tracking-callback). Set `activityMetrics: true` in the `enableActivityTrackingCallback` configuration, and the `activityMetrics` field will be available on the callback data.
+
 ## Activity tracking callback
 
-You can now perform edge analytics in the browser to reduce the number of events sent to your Collector whilst still tracking user activity. The Snowplow JavaScript Tracker enables this by allowing a callback to be specified in place of a page ping being sent.
+You can perform edge analytics in the browser to reduce the number of events sent to your Collector whilst still tracking user activity. The Snowplow JavaScript Tracker enables this by allowing a callback to be specified in place of a page ping being sent.
 
 ### Enable callback
 
@@ -200,6 +239,8 @@ type ActivityCallbackData = {
     maxXOffset: number;
     /** The maximum Y scroll position for the current page view */
     maxYOffset: number;
+    /** Since 4.8.0. Activity metrics accumulated since the last ping (only when activityMetrics is enabled) */
+    activityMetrics?: ActivityMetrics;
 };
 ```
 

--- a/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md
+++ b/docs/sources/web-trackers/tracking-events/activity-page-pings/index.md
@@ -148,7 +148,7 @@ This is particularly useful when a user is passively engaging with your content,
 
 ### Activity metrics
 
-Since web tracker 4.8.0, it's possible to track more detailed activity metrics. These metrics show how much interaction happened on the page, including the number of clicks, touches, key presses, absolute scroll distance (in either direction) and distance traveled by the mouse.
+Since JavaScript tracker version 4.8.0, you can track more detailed activity metrics. These metrics show how much interaction happened on the page, including the number of clicks, touches, key presses, absolute scroll distance (in either direction), and distance traveled by the mouse.
 
 To enable activity metrics, set `activityMetrics` to `true` when enabling activity tracking (the default is `false`):
 
@@ -187,7 +187,7 @@ Activity metrics also work with [activity tracking callbacks](#activity-tracking
 
 ## Activity tracking callback
 
-You can perform edge analytics in the browser to reduce the number of events sent to your Collector whilst still tracking user activity. The Snowplow JavaScript Tracker enables this by allowing a callback to be specified in place of a page ping being sent.
+You can perform edge analytics in the browser to reduce the number of events sent to your Collector while still tracking user activity. The Snowplow JavaScript Tracker enables this by allowing a callback to be specified in place of a page ping being sent.
 
 ### Enable callback
 
@@ -239,7 +239,7 @@ type ActivityCallbackData = {
     maxXOffset: number;
     /** The maximum Y scroll position for the current page view */
     maxYOffset: number;
-    /** Since 4.8.0. Activity metrics accumulated since the last ping (only when activityMetrics is enabled) */
+    /** Since version 4.8.0. Activity metrics accumulated since the last ping (only when activityMetrics is enabled) */
     activityMetrics?: ActivityMetrics;
 };
 ```

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -8,7 +8,7 @@ export const versions = {
   googleAmpTracker: '1.1.0',
   iosTracker: '6.2.1',
   javaTracker: '2.1.0',
-  javaScriptTracker: '4.6.8',
+  javaScriptTracker: '4.8.0',
   luaTracker: '0.2.0',
   phpTracker: '0.9.2',
   pixelTracker: '0.3.0',


### PR DESCRIPTION
## What changed?

Adding info about activity metrics, a new feature in the web tracker 4.8.0.