### PR TITLE
Remove misleading wording about sync engine

### DIFF
--- a/docs/signals/attributes/using-python-sdk/batch-calculations/index.md
+++ b/docs/signals/attributes/using-python-sdk/batch-calculations/index.md
@@ -27,7 +27,7 @@ The engine will be enabled when you either:
 * Apply an `ExternalBatchAttributeGroup` for an existing table
 * Run the batch engine `sync` command after creating new attribute tables
 
-Once enabled, syncs begin at a fixed interval. By default, this is every 1 hour. Only the records that have changed since the last sync are sent to the Profiles Store.
+Once enabled, syncs begin at a fixed interval: every hour. Only the records that have changed since the last sync are sent to the Profiles Store.
 
 ## Using existing attributes
 

--- a/docs/signals/concepts/index.md
+++ b/docs/signals/concepts/index.md
@@ -106,7 +106,7 @@ Real-time stream flow:
 ### Batch source
 
 The batch data source uses dbt to generate and calculate new tables of attributes from your
-Snowplow atomic events table. Signals then syncs them to the Profiles Store periodically using the sync engine.
+Snowplow atomic events table. Signals then syncs them to the Profiles Store every hour using the sync engine.
 
 Batch flow:
 1. Behavioral data events arrive in the warehouse


### PR DESCRIPTION
The Signals docs implied that the sync engine job runs could be configured. Right now they can't.
