### PR TITLE
Update example to use schema version 1-0-1 not 1-2-0

### DIFF
--- a/docs/api-reference/loaders-storage-targets/schemas-in-warehouse/index.md
+++ b/docs/api-reference/loaders-storage-targets/schemas-in-warehouse/index.md
@@ -276,7 +276,7 @@ Because the table name for the self-describing event or entity includes the majo
 | Schema                                      | Resulting table              |
 | ------------------------------------------- | ---------------------------- |
 | `com.example/button_press/jsonschema/1-0-0` | `com_example_button_press_1` |
-| `com.example/button_press/jsonschema/1-2-0` | `com_example_button_press_1` |
+| `com.example/button_press/jsonschema/1-0-1` | `com_example_button_press_1` |
 | `com.example/button_press/jsonschema/2-0-0` | `com_example_button_press_2` |
 
 When you evolve your schema within the same major version, (non-destructive) changes are applied to the existing table automatically. For example, if you change the `maxLength` of a `string` field, the limit of the `VARCHAR` column would be updated accordingly.
@@ -313,7 +313,7 @@ Because the column name for the self-describing event or entity includes the maj
 | Schema                                      | Resulting column                            |
 | ------------------------------------------- | ------------------------------------------- |
 | `com.example/button_press/jsonschema/1-0-0` | `unstruct_event_com_example_button_press_1` |
-| `com.example/button_press/jsonschema/1-2-0` | `unstruct_event_com_example_button_press_1` |
+| `com.example/button_press/jsonschema/1-0-1` | `unstruct_event_com_example_button_press_1` |
 | `com.example/button_press/jsonschema/2-0-0` | `unstruct_event_com_example_button_press_2` |
 
 When you evolve your schema within the same major version, (non-destructive) changes are applied to the existing column automatically. For example, if you add a new optional field in the schema, a new optional field will be added to the `RECORD`.
@@ -328,7 +328,7 @@ Because the column name for the self-describing event or entity includes the ful
 | Schema                                      | Resulting column                                |
 | ------------------------------------------- | ----------------------------------------------- |
 | `com.example/button_press/jsonschema/1-0-0` | `unstruct_event_com_example_button_press_1_0_0` |
-| `com.example/button_press/jsonschema/1-2-0` | `unstruct_event_com_example_button_press_1_2_0` |
+| `com.example/button_press/jsonschema/1-0-1` | `unstruct_event_com_example_button_press_1_0_1` |
 | `com.example/button_press/jsonschema/2-0-0` | `unstruct_event_com_example_button_press_2_0_0` |
 
 If you are [modeling your data with dbt](/docs/modeling-your-data/modeling-your-data-with-dbt/index.md), you can use [this macro](https://github.com/snowplow/dbt-snowplow-utils#combine_column_versions-source) to aggregate the data across multiple columns.
@@ -351,7 +351,7 @@ Because the column name for the self-describing event or entity includes the maj
 | Schema                                      | Resulting column                            |
 | ------------------------------------------- | ------------------------------------------- |
 | `com.example/button_press/jsonschema/1-0-0` | `unstruct_event_com_example_button_press_1` |
-| `com.example/button_press/jsonschema/1-2-0` | `unstruct_event_com_example_button_press_1` |
+| `com.example/button_press/jsonschema/1-0-1` | `unstruct_event_com_example_button_press_1` |
 | `com.example/button_press/jsonschema/2-0-0` | `unstruct_event_com_example_button_press_2` |
 
 :::info[Breaking changes]
@@ -372,7 +372,7 @@ Because the column name for the self-describing event or entity includes the maj
 | Schema                                      | Resulting column                            |
 | ------------------------------------------- | ------------------------------------------- |
 | `com.example/button_press/jsonschema/1-0-0` | `unstruct_event_com_example_button_press_1` |
-| `com.example/button_press/jsonschema/1-2-0` | `unstruct_event_com_example_button_press_1` |
+| `com.example/button_press/jsonschema/1-0-1` | `unstruct_event_com_example_button_press_1` |
 | `com.example/button_press/jsonschema/2-0-0` | `unstruct_event_com_example_button_press_2` |
 
 When you evolve your schema within the same major version, (non-destructive) changes are applied to the existing column automatically. For example, if you add a new optional field in the schema, a new optional field will be added to the `STRUCT`.


### PR DESCRIPTION
We never increment the middle digit of a schema, so we shouldn't use the middle digit in examples. Updated the examples in this page to use correct schema versioning.

## What changed?

Fixes wrong versioning in examples

## Why?

Because I noticed that the examples showed the middle digit increase.

## Reviewer guidance

<!-- For larger PRs: what should reviewers focus on? Are there areas you're uncertain about? Any additional context that would help them? -->
<!-- Delete or ignore this section for small or obvious PRs. -->

## AI reviews

Claude will automatically review this PR against the docs style guide.

If you have questions or want it to look again at something specific, tag `@claude` in a comment.
