### PR TITLE
Add Bloomreach docs

### DIFF
--- a/docs/destinations/forwarding-events/integrations/bloomreach/index.md
+++ b/docs/destinations/forwarding-events/integrations/bloomreach/index.md
@@ -16,7 +16,12 @@ Send Snowplow events to Bloomreach Engagement for real-time customer analytics, 
 
 ## Prerequisites
 
-Before setting up the forwarder in Console, you'll need the following from your Bloomreach Engagement account:
+Before setting up the forwarder in Console, you'll need to configure an API key with 'Get' and 'Set' permission on all of the properties events that you intend to send to bloomreach. We recommend also permitting 'Get' and 'Set' permission on 'New Properties' and 'New Events', do avoid problems when new tracking is added.
+
+You can configure this in the Access Management section of Project settings.
+
+
+You'll also need the following from your Bloomreach Engagement account:
 
 - **API Endpoint Host**: the base URL for your Bloomreach API instance (e.g., `api-engagement.bloomreach.com`)
 - **Project Token**: a unique identifier for your Bloomreach project

--- a/docs/destinations/forwarding-events/integrations/bloomreach/index.md
+++ b/docs/destinations/forwarding-events/integrations/bloomreach/index.md
@@ -1,0 +1,68 @@
+---
+title: "Forward events to Bloomreach"
+sidebar_label: "Bloomreach"
+sidebar_position: 2
+description: "Send Snowplow events to Bloomreach Engagement for real-time customer analytics and personalization using the Batch Commands API."
+keywords: ["Bloomreach", "Bloomreach Engagement", "event forwarding", "customer data platform", "personalization"]
+date: "2026-05-05"
+---
+
+```mdx-code-block
+import EventForwardingSchemaTable from '@site/src/components/EventForwardingSchemaTable';
+import bloomreachSchema from '@site/src/components/EventForwardingSchemaTable/Schemas/bloomreach.json';
+```
+
+Send Snowplow events to Bloomreach Engagement for real-time customer analytics, segmentation, and personalization using the [Batch Commands API](https://documentation.bloomreach.com/engagement/reference/batch-commands-2).
+
+## Prerequisites
+
+Before setting up the forwarder in Console, you'll need the following from your Bloomreach Engagement account:
+
+- **API Endpoint Host**: the base URL for your Bloomreach API instance (e.g., `api-engagement.bloomreach.com`)
+- **Project Token**: a unique identifier for your Bloomreach project
+- **API Key ID**: the identifier for your API key
+- **API Secret**: the secret associated with your API key. Save the secret in a secure location, as you can only view it once after creation.
+
+You can find all of these values in Bloomreach under **Project settings** > **Access management** > **API**.
+
+:::tip[Test in a non-production project first]
+To avoid introducing test data in your production Bloomreach project, we recommend using a test or development project to test your transformations first. Then, create a new connection in Console with your production credentials, and a new forwarder that imports the configuration from your development forwarder.
+:::
+
+## Getting started
+
+### Configure the destination
+
+To create the connection and forwarder, follow the steps in [Creating forwarders](/docs/destinations/forwarding-events/creating-forwarders/index.md).
+
+When configuring the connection, select **Bloomreach** for the connection type and enter your API endpoint host, project token, API key ID, and API secret.
+
+### Validate the integration
+
+You can confirm events are reaching Bloomreach by checking the customer profiles in your Bloomreach Engagement project:
+
+1. In Bloomreach, navigate to **Data & Assets** > **Customers**
+2. Search for a customer whose events you have forwarded
+3. Open the customer profile and check the **Events** tab to verify that your Snowplow events appear
+
+## Identity management
+
+Bloomreach uses a combination of hard and soft customer IDs to identify and merge customer profiles. The Snowplow integration defaults to using `user_id` as the hard ID (`registered`) and `domain_userid` as the soft ID (`cookie`).
+
+When a user is anonymous, Bloomreach tracks their activity using the soft ID. When the user logs in and your event contains a `user_id` value, Bloomreach merges the anonymous profile with the identified profile, linking prior anonymous activity to the known customer.
+
+The ID type names (`registered`, `cookie`) must match the customer ID types configured in your Bloomreach project. You can customize these mappings in the forwarder configuration if your project uses different ID type names.
+
+## Sending custom properties
+
+You can send custom event properties beyond the standard fields defined in the schema reference below. Custom properties are nested under the `properties` object. When configuring your forwarder, add field mappings formatted as `properties.your_custom_field` (e.g., `properties.plan_type`, `properties.feature_flag`).
+
+For property names containing spaces, use bracket notation (e.g., `properties["referred by"]`).
+
+See Bloomreach's [Batch Commands API documentation](https://documentation.bloomreach.com/engagement/reference/batch-commands-2) for details on supported data types and property requirements. See [Creating forwarders](/docs/destinations/forwarding-events/creating-forwarders/index.md) for details on configuring field mappings.
+
+## Schema reference
+
+This section contains information on the fields you can send to Bloomreach, including field names, data types, required fields, and default Snowplow mapping expressions.
+
+<EventForwardingSchemaTable schema={bloomreachSchema}/>

--- a/docs/destinations/forwarding-events/integrations/bloomreach/index.md
+++ b/docs/destinations/forwarding-events/integrations/bloomreach/index.md
@@ -23,7 +23,7 @@ You can configure this in the Access Management section of Project settings.
 
 You'll also need the following from your Bloomreach Engagement account:
 
-- **API Endpoint Host**: the base URL for your Bloomreach API instance (e.g., `api-engagement.bloomreach.com`)
+- **API Endpoint Host**: the base URL for your Bloomreach API instance (e.g., `api.exponea.com`)
 - **Project Token**: a unique identifier for your Bloomreach project
 - **API Key ID**: the identifier for your API key
 - **API Secret**: the secret associated with your API key. Save the secret in a secure location, as you can only view it once after creation.

--- a/docs/destinations/forwarding-events/integrations/braze/index.md
+++ b/docs/destinations/forwarding-events/integrations/braze/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Forward events to Braze"
 sidebar_label: "Braze"
-sidebar_position: 2
+sidebar_position: 3
 description: "Send Snowplow events to Braze for real-time personalization and campaign automation using the Track Users API with support for user attributes, custom events, and purchases."
 keywords: ["Braze", "personalization", "campaign automation", "Track Users API", "marketing automation", "event forwarding"]
 ---

--- a/docs/destinations/forwarding-events/integrations/index.md
+++ b/docs/destinations/forwarding-events/integrations/index.md
@@ -13,5 +13,6 @@ Event forwarding supports third-party destinations through pre-built integration
 Snowplow event forwarding supports the following destinations:
 
 - [Amplitude](/docs/destinations/forwarding-events/integrations/amplitude/index.md)
+- [Bloomreach](/docs/destinations/forwarding-events/integrations/bloomreach/index.md)
 - [Braze](/docs/destinations/forwarding-events/integrations/braze/index.md)
 - [Mixpanel](/docs/destinations/forwarding-events/integrations/mixpanel/index.md)

--- a/docs/destinations/forwarding-events/integrations/mixpanel/index.md
+++ b/docs/destinations/forwarding-events/integrations/mixpanel/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Forward events to Mixpanel"
+sidebar_label: "Mixpanel"
 description: "Send Snowplow events to Mixpanel for product analytics and user behavior insights using the Import API with support for event tracking and custom properties."
 sidebar_position: 3
 keywords: ["mixpanel", "event forwarding", "product analytics", "user tracking"]

--- a/src/components/EventForwardingSchemaTable/Schemas/bloomreach.json
+++ b/src/components/EventForwardingSchemaTable/Schemas/bloomreach.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["customer_ids", "event_type"],
+  "properties": {
+    "customer_ids": {
+      "type": "object",
+      "description": "Object identifying the customer. Must contain at least one ID. Keys are ID type names configured in the Bloomreach project.",
+      "consoleRequired": true,
+      "minProperties": 1,
+      "properties": {
+        "registered": {
+          "type": "string",
+          "description": "Hard ID — the identified user ID. Used for cross-device identity resolution.",
+          "consoleDefault": "event.user_id"
+        },
+        "cookie": {
+          "type": "string",
+          "description": "Soft ID — anonymous visitor identifier, typically a browser cookie.",
+          "consoleDefault": "event.domain_userid"
+        }
+      }
+    },
+    "event_type": {
+      "type": "string",
+      "description": "The name of the event type in Bloomreach.",
+      "consoleDefault": "event.event_name",
+      "consoleRequired": true
+    },
+    "timestamp": {
+      "type": "integer",
+      "description": "When the event occurred, as UNIX epoch seconds. Defaults to current time if omitted.",
+      "consoleDefault": "Math.floor(spTstampToJSDate(event.derived_tstamp).getTime() / 1000)",
+      "consoleRequired": true
+    },
+    "properties": {
+      "type": "object",
+      "description": "Arbitrary key-value pairs for the event. Values can be strings, numbers, booleans, or nested objects.",
+      "additionalProperties": true,
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The full URL of the page where the event occurred.",
+          "consoleDefault": "event.page_url"
+        },
+        "title": {
+          "type": "string",
+          "description": "The page title.",
+          "consoleDefault": "event.page_title"
+        },
+        "referrer": {
+          "type": "string",
+          "description": "The referring URL.",
+          "consoleDefault": "event.page_referrer"
+        },
+        "ip": {
+          "type": "string",
+          "description": "The user's IP address.",
+          "consoleDefault": "event.user_ipaddress"
+        },
+        "city": {
+          "type": "string",
+          "description": "The city of the user.",
+          "consoleDefault": "event.geo_city"
+        },
+        "region": {
+          "type": "string",
+          "description": "The region (state or province) of the user.",
+          "consoleDefault": "event.geo_region_name || event.geo_region"
+        },
+        "country": {
+          "type": "string",
+          "description": "The country code of the user.",
+          "consoleDefault": "event.geo_country"
+        },
+        "latitude": {
+          "type": "number",
+          "description": "Latitude of the user's location.",
+          "consoleDefault": "event.geo_latitude"
+        },
+        "longitude": {
+          "type": "number",
+          "description": "Longitude of the user's location.",
+          "consoleDefault": "event.geo_longitude"
+        },
+        "browser": {
+          "type": "string",
+          "description": "Name of the browser.",
+          "consoleDefault": "event.contexts_nl_basjes_yauaa_context_1?.[0]?.agentName"
+        },
+        "browser_version": {
+          "type": "string",
+          "description": "Version of the browser.",
+          "consoleDefault": "event.contexts_nl_basjes_yauaa_context_1?.[0]?.agentVersion"
+        },
+        "os": {
+          "type": "string",
+          "description": "Operating system name.",
+          "consoleDefault": "event.contexts_nl_basjes_yauaa_context_1?.[0]?.operatingSystemName || event.contexts_com_snowplowanalytics_snowplow_mobile_context_1?.[0]?.osType"
+        },
+        "os_version": {
+          "type": "string",
+          "description": "Operating system version.",
+          "consoleDefault": "event.contexts_nl_basjes_yauaa_context_1?.[0]?.operatingSystemVersion || event.contexts_com_snowplowanalytics_snowplow_mobile_context_1?.[0]?.osVersion"
+        },
+        "device": {
+          "type": "string",
+          "description": "Device name or model.",
+          "consoleDefault": "event.contexts_nl_basjes_yauaa_context_1?.[0]?.deviceName || event.contexts_com_snowplowanalytics_snowplow_mobile_context_1?.[0]?.deviceModel"
+        },
+        "device_type": {
+          "type": "string",
+          "description": "The type/class of device (e.g. Desktop, Mobile, Tablet).",
+          "consoleDefault": "event.contexts_nl_basjes_yauaa_context_1?.[0]?.deviceClass"
+        },
+        "device_manufacturer": {
+          "type": "string",
+          "description": "Manufacturer of the device.",
+          "consoleDefault": "event.contexts_nl_basjes_yauaa_context_1?.[0]?.deviceBrand || event.contexts_com_snowplowanalytics_snowplow_mobile_context_1?.[0]?.deviceManufacturer"
+        },
+        "screen_height": {
+          "type": "integer",
+          "description": "Device screen height in pixels.",
+          "consoleDefault": "event.dvce_screenheight"
+        },
+        "screen_width": {
+          "type": "integer",
+          "description": "Device screen width in pixels.",
+          "consoleDefault": "event.dvce_screenwidth"
+        },
+        "language": {
+          "type": "string",
+          "description": "The user's language/locale.",
+          "consoleDefault": "event.contexts_com_snowplowanalytics_snowplow_browser_context_1?.[0]?.browserLanguage || event.contexts_com_snowplowanalytics_snowplow_mobile_context_1?.[0]?.language"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "The user's timezone.",
+          "consoleDefault": "event.os_timezone"
+        },
+        "platform": {
+          "type": "string",
+          "description": "The platform the event was tracked on (web, mob, etc.).",
+          "consoleDefault": "event.platform"
+        },
+        "tracker": {
+          "type": "string",
+          "description": "Tracker library that sent the event.",
+          "consoleDefault": "'Snowplow: ' + event.v_tracker"
+        },
+        "utm_source": {
+          "type": "string",
+          "description": "UTM source parameter.",
+          "consoleDefault": "event.mkt_source"
+        },
+        "utm_medium": {
+          "type": "string",
+          "description": "UTM medium parameter.",
+          "consoleDefault": "event.mkt_medium"
+        },
+        "utm_campaign": {
+          "type": "string",
+          "description": "UTM campaign parameter.",
+          "consoleDefault": "event.mkt_campaign"
+        },
+        "utm_content": {
+          "type": "string",
+          "description": "UTM content parameter.",
+          "consoleDefault": "event.mkt_content"
+        },
+        "utm_term": {
+          "type": "string",
+          "description": "UTM term parameter.",
+          "consoleDefault": "event.mkt_term"
+        },
+        "carrier": {
+          "type": "string",
+          "description": "Mobile carrier.",
+          "consoleDefault": "event.contexts_com_snowplowanalytics_snowplow_mobile_context_1?.[0]?.carrier"
+        },
+        "network_type": {
+          "type": "string",
+          "description": "Network connection type (wifi, mobile, etc.).",
+          "consoleDefault": "event.contexts_com_snowplowanalytics_snowplow_mobile_context_1?.[0]?.networkType"
+        },
+        "app_version": {
+          "type": "string",
+          "description": "Application version.",
+          "consoleDefault": "event.contexts_com_snowplowanalytics_mobile_application_1?.[0]?.version || event.contexts_com_snowplowanalytics_snowplow_application_1?.[0]?.version"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed?

Adding the Bloomreach integration. 100% Claude-generated based on the underlying metadata/config repo (https://github.com/snowplow-product/event-forwarding-metadata/tree/main/apis/bloomreach_batch_commands).