### PR TITLE
Add docs for Unity anonymous tracking

### DIFF
--- a/docs/events/anonymous-tracking/index.md
+++ b/docs/events/anonymous-tracking/index.md
@@ -211,7 +211,7 @@ This table shows the support for anonymous tracking across the main [Snowplow tr
 | Rust                                                                                               | ❌         |               |             |             |                                                               |
 | [PHP](/docs/sources/php-tracker/emitters/index.md)                                                 | ✅         | 0.9.0         | ❌           | ✅           |                                                               |
 | C++                                                                                                | ❌         |               |             |             |                                                               |
-| Unity                                                                                              | ❌         |               |             |             |                                                               |
+| Unity                                                                                              | ✅         | 0.9.0         | ✅          | ✅           |                                                               |
 | Lua                                                                                                | ❌         |               |             |             |                                                               |
 | [Google Tag Manager](/docs/sources/google-tag-manager/settings-template/index.md)                  | ✅         | v4            | ✅           | ✅           |                                                               |
 

--- a/docs/sources/unity-tracker/emitter/index.md
+++ b/docs/sources/unity-tracker/emitter/index.md
@@ -39,3 +39,16 @@ All except `eventStore` of these variables can be altered after creation with th
 
 Some load balancers limit the maximum URL length accepted for `GET` requests, often around 16KB.
 The default of 52000 bytes is considerably larger than these limits, but most single event payloads will not reach this size.
+
+
+### Functions
+
+The Emitter also provides functions to configure its behavior after construction.
+
+#### `SetServerAnonymisation(bool)`
+
+Enables or disables [server-side anonymization](/docs/events/anonymous-tracking/index.md#server-side-anonymization). When enabled, the `SP-Anonymous: *` header is added to all requests to the Collector, instructing it to anonymize the user's IP address and network user ID.
+
+```csharp
+emitter.SetServerAnonymisation(true);
+```

--- a/docs/sources/unity-tracker/subject/index.md
+++ b/docs/sources/unity-tracker/subject/index.md
@@ -9,6 +9,11 @@ keywords: ["unity subject configuration", "unity user context", "unity tracker u
 
 You may have additional information about your application's environment, current user and so on, which you want to send to Snowplow with each event.
 
+:::note[User anonymization]
+When [user anonymization](/docs/sources/unity-tracker/tracker/index.md#setuseranonymisationbool) is enabled on the tracker, the `userId`, `domainUserId`, `networkUserId`, and `ipAddress` fields are omitted from events regardless of
+what is set on the Subject.
+:::
+
 The Subject class has a set of `Set...()` methods to attach extra data relating to the user to all tracked events:
 
 - `SetUserId`

--- a/docs/sources/unity-tracker/tracker/index.md
+++ b/docs/sources/unity-tracker/tracker/index.md
@@ -20,6 +20,7 @@ The Tracker object is responsible for co-ordinating the saving and sending of ev
 | [`session`](/docs/sources/unity-tracker/session/index.md) | The Session object you create                                            | No            | Null        |
 | `platform`                                                | The device the Tracker is running on                                     | No            | Mobile      |
 | `base64Encoded`                                           | If we [base 64 encode](https://en.wikipedia.org/wiki/Base64) json values | No            | True        |
+| `userAnonymisation` | Enables [client-side user anonymization](/docs/events/anonymous-tracking/index.md#full-client-side-anonymization). Omits user identifiers (userId, domainUserId, networkUserId) and any explicitly-set ipAddress from all events. Note: this does not affect the IP address captured by the collector from the network connection, use server anonymisation for that. | No | False |
 
 A full Tracker construction should look like the following:
 
@@ -58,4 +59,12 @@ This is the function used for Tracking all events.
 
 ```csharp
 tracker.Track(IEvent newEvent);
+```
+
+#### `SetUserAnonymisation(bool)`
+
+Enables or disables user anonymization. When enabled, the `userId`, `domainUserId`, `networkUserId`, and `ipAddress` fields are omitted from all events. This can also be set at construction time via the `userAnonymisation` parameter.
+
+```csharp
+tracker.SetUserAnonymisation(true);
 ```


### PR DESCRIPTION
## What changed?

- Add docs for Unity tracker anonymous tracking

## Why?

- Support for anonymous tracking was added to the Unity tracker

