### PR TITLE
Bump snowbridge version to 5.1.1

### DIFF
--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -25,7 +25,7 @@ export const versions = {
   enrich: '6.11.0',
   sqs2kinesis: '1.0.4',
   dataflowRunner: '0.7.6',
-  snowbridge: '5.1.0',
+  snowbridge: '5.1.1',
 
   // Loaders
   bqLoader: '2.2.0',


### PR DESCRIPTION
## What changed?

Snowbridge version: from 5.1.0 to 5.1.1

## Why?

Snowbridge 5.1.1 release

## AI reviews

Claude will automatically review this PR against the docs style guide.

If you have questions or want it to look again at something specific, tag `@claude` in a comment.
