### PR TITLE
Bump Micro to 4.2.1

### DIFF
--- a/docs/api-reference/snowplow-micro/api/index.md
+++ b/docs/api-reference/snowplow-micro/api/index.md
@@ -45,7 +45,7 @@ Each object in the `filters` array has the following fields:
 | Field | Type | Description |
 |---|---|---|
 | `column` | string | Column name to filter on (e.g., `app_id`, `event_name`). |
-| `value` | string | Filter value. In-memory mode uses case-insensitive substring matching. When persistent storage is enabled (including [Micro in Console](/docs/testing/snowplow-micro/console/index.md)), exact matching is used and only the following columns are supported: `event_id`, `app_id`, `event_name`, `platform`, `name_tracker`, `domain_userid`, `v_tracker`. |
+| `value` | string | Filter value. In-memory mode uses case-insensitive substring matching. When persistent storage is enabled (including [Micro in Console](/docs/testing/snowplow-micro/console/index.md)), exact matching is used and only the following columns are supported: `event_id`, `app_id`, `event_name`, `platform`, `name_tracker`, `user_id`, `domain_userid`, `v_tracker`. |
 
 The `timeRange` object has the following fields:
 
@@ -58,7 +58,7 @@ The `sorting` object has the following fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `column` | string | Column to sort by. When persistent storage is enabled (including [Micro in Console](/docs/testing/snowplow-micro/console/index.md)), only the following columns are supported: `event_id`, `app_id`, `event_name`, `platform`, `name_tracker`, `domain_userid`, `v_tracker`, `collector_tstamp`. |
+| `column` | string | Column to sort by. When persistent storage is enabled (including [Micro in Console](/docs/testing/snowplow-micro/console/index.md)), only the following columns are supported: `event_id`, `app_id`, `event_name`, `platform`, `name_tracker`, `user_id`, `domain_userid`, `v_tracker`, `collector_tstamp`. |
 | `desc` | boolean | `true` for descending, `false` for ascending. |
 
 Example request:

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -75,6 +75,6 @@ export const versions = {
   igluScalaClient: '4.0.3',
 
   // Testing & debugging
-  snowplowMicro: '4.2.0',
+  snowplowMicro: '4.2.1',
   snowplowMini: '0.25.1',
 }


### PR DESCRIPTION
## What changed?

Added Micro 4.2.1 which allows to filter by `user_id`.
