### PR TITLE
Add free trial docs and header CTA

### DIFF
--- a/docs/get-started/free-trial/index.md
+++ b/docs/get-started/free-trial/index.md
@@ -25,7 +25,7 @@ Some features are not configurable during the trial:
 
 * Collector configuration changes are not available.
 * First-party collector and custom domains are not available.
-* Advanced or non-self-serviceable infrastructure is not available during the trial. [Contact sales](https://console.snowplowanalytics.com/contact-us) to discuss your requirements.
+* Some destinations are not available during the trial. [Contact sales](https://console.snowplowanalytics.com/contact-us) to discuss your requirements.
 
 ## Capacity limits
 

--- a/docs/get-started/free-trial/index.md
+++ b/docs/get-started/free-trial/index.md
@@ -1,0 +1,43 @@
+---
+title: "Snowplow free trial"
+sidebar_position: 3
+sidebar_label: "Free trial"
+description: "Start a free 14-day trial of Snowplow CDI Cloud, and learn about the product and capacity limitations that apply during the trial."
+keywords: ["free trial", "Snowplow trial", "CDI Cloud", "14-day trial", "trial limitations", "getting started"]
+date: "2026-06-16"
+---
+
+The Snowplow free trial is a 14-day, fully managed trial of [Snowplow CDI Cloud](/docs/get-started/index.md#cdi-cloud). Snowplow hosts and manages the pipeline infrastructure, so you can collect, validate, and load behavioral data without setting up any cloud infrastructure yourself.
+
+Use the trial to evaluate Snowplow end to end: define your data, send events from your application, and load validated data into a warehouse or lake destination.
+
+## Start the trial
+
+Sign up for the free trial on the [Snowplow website](https://snowplow.io/get-started/snowplow-free-trial).
+
+After you sign up, your trial environment is provisioned automatically. Provisioning is not instant: trial access becomes available once provisioning completes, which takes around 20 minutes.
+
+The trial runs for 14 days. If you need more time, extensions are available on request.
+
+## Product limitations
+
+Some features are not configurable during the trial:
+
+* Collector configuration changes are not available.
+* First-party collector and custom domains are not available.
+* Advanced or non-self-serviceable infrastructure is not available during the trial. [Contact sales](https://console.snowplowanalytics.com/contact-us) to discuss your requirements.
+
+## Capacity limits
+
+The trial includes a limited set of resources that do not scale:
+
+* Destinations are limited to:
+  * one [Micro](/docs/api-reference/snowplow-micro/index.md) instance
+  * one [warehouse or lake destination](/docs/destinations/warehouses-lakes/index.md)
+  * one [event forwarding destination](/docs/destinations/forwarding-events/index.md)
+* Rate limiting is enforced at the collector.
+* Pipeline, [Signals](/docs/signals/index.md), and [Identities](/docs/identities/index.md) resources are limited and do not scale during the trial.
+
+:::note[Beyond the trial]
+For the full set of features available in Snowplow CDI, see the [feature comparison](/docs/get-started/feature-comparison/index.md).
+:::

--- a/docs/get-started/free-trial/index.md
+++ b/docs/get-started/free-trial/index.md
@@ -7,7 +7,7 @@ keywords: ["free trial", "Snowplow trial", "CDI Cloud", "14-day trial", "trial l
 date: "2026-06-16"
 ---
 
-The Snowplow free trial is a 14-day, fully managed trial of [Snowplow CDI Cloud](/docs/get-started/index.md#cdi-cloud). Snowplow hosts and manages the pipeline infrastructure, so you can collect, validate, and load behavioral data without setting up any cloud infrastructure yourself.
+The Snowplow free trial is a 14-day trial of [Snowplow CDI Cloud](/docs/get-started/index.md#cdi-cloud). Snowplow hosts and manages the pipeline infrastructure, so you can collect, validate, and load behavioral data without setting up any cloud infrastructure yourself.
 
 Use the trial to evaluate Snowplow end to end: define your data, send events from your application, and load validated data into a warehouse or lake destination.
 

--- a/docs/get-started/free-trial/index.md
+++ b/docs/get-started/free-trial/index.md
@@ -32,7 +32,7 @@ Some features are not configurable during the trial:
 The trial includes a limited set of resources that do not scale:
 
 * Destinations are limited to:
-  * one [Micro](/docs/api-reference/snowplow-micro/index.md) instance
+  * one [Micro](/docs/testing/snowplow-micro/index.md) instance
   * one [warehouse or lake destination](/docs/destinations/warehouses-lakes/index.md)
   * one [event forwarding destination](/docs/destinations/forwarding-events/index.md)
 * Rate limiting is enforced at the collector.

--- a/docs/get-started/free-trial/index.md
+++ b/docs/get-started/free-trial/index.md
@@ -17,14 +17,13 @@ Sign up for the free trial on the [Snowplow website](https://snowplow.io/get-sta
 
 After you sign up, your trial environment is provisioned automatically. You will receive access instructions within around 20 minutes.
 
-The trial runs for 14 days. If you need more time, extensions are available on request.
+The trial runs for 14 days. To request an extension, [contact sales](https://console.snowplowanalytics.com/contact-us).
 
 ## Product limitations
 
-Some features are not configurable during the trial:
+Some Snowplow features are not available during the trial:
 
-* Collector configuration changes are not available.
-* First-party collector and custom domains are not available.
+* First-party tracking using your own domain is not available.
 * Some destinations are not available during the trial. [Contact sales](https://console.snowplowanalytics.com/contact-us) to discuss your requirements.
 
 ## Capacity limits
@@ -35,7 +34,7 @@ The trial includes a limited set of resources that do not scale:
   * one [Micro](/docs/testing/snowplow-micro/index.md) instance
   * one [warehouse or lake destination](/docs/destinations/warehouses-lakes/index.md)
   * one [event forwarding destination](/docs/destinations/forwarding-events/index.md)
-* Rate limiting is enforced at the collector.
+* Collector-level rate limits apply.
 * Pipeline, [Signals](/docs/signals/index.md), and [Identities](/docs/identities/index.md) resources are limited and do not scale during the trial.
 
 :::note[Beyond the trial]

--- a/docs/get-started/free-trial/index.md
+++ b/docs/get-started/free-trial/index.md
@@ -34,7 +34,7 @@ The trial includes a limited set of resources that do not scale:
   * one [Micro](/docs/testing/snowplow-micro/index.md) instance
   * one [warehouse or lake destination](/docs/destinations/warehouses-lakes/index.md)
   * one [event forwarding destination](/docs/destinations/forwarding-events/index.md)
-* Collector-level rate limits apply.
+* Collector-level rate limits apply, capped at around 20 events per second.
 * Pipeline, [Signals](/docs/signals/index.md), and [Identities](/docs/identities/index.md) resources are limited and do not scale during the trial.
 
 :::note[Beyond the trial]

--- a/docs/get-started/free-trial/index.md
+++ b/docs/get-started/free-trial/index.md
@@ -15,7 +15,7 @@ Use the trial to evaluate Snowplow end to end: define your data, send events fro
 
 Sign up for the free trial on the [Snowplow website](https://snowplow.io/get-started/snowplow-free-trial).
 
-After you sign up, your trial environment is provisioned automatically. Provisioning is not instant: trial access becomes available once provisioning completes, which takes around 20 minutes.
+After you sign up, your trial environment is provisioned automatically. You will receive access instructions within around 20 minutes.
 
 The trial runs for 14 days. If you need more time, extensions are available on request.
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -28,6 +28,10 @@ For self-hosted deployments, we have:
 * **Snowplow Community Edition**: not for production use, hosted and managed by you
 * **Snowplow Self-Hosted**: for production use, for existing Snowplow users
 
+:::tip[Try Snowplow for free]
+Not sure which platform is right for you? Start a [free 14-day trial](/docs/get-started/free-trial/index.md) of CDI Cloud.
+:::
+
 ## Customer Data Infrastructure
 
 Snowplow CDI is our full infrastructure offering. Choose whether you'd like the **data plane** to be entirely hosted in your cloud account, or whether you'd prefer Snowplow to host the pipeline infrastructure for you.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -29,7 +29,7 @@ For self-hosted deployments, we have:
 * **Snowplow Self-Hosted**: for production use, for existing Snowplow users
 
 :::tip[Try Snowplow for free]
-Not sure which platform is right for you? Start a [free 14-day trial](/docs/get-started/free-trial/index.md) of CDI Cloud.
+To compare platforms before committing, start a [free 14-day trial](/docs/get-started/free-trial/index.md) of CDI Cloud.
 :::
 
 ## Customer Data Infrastructure

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -163,6 +163,12 @@ const config: Config = {
             position: 'left',
             className: 'mobile-only',
           },
+          {
+            href: 'https://snowplow.io/get-started/snowplow-free-trial',
+            label: 'Start free trial',
+            position: 'right',
+            className: 'snowplow-button cta-button navbar-cta',
+          },
         ],
       },
       footer: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -165,7 +165,7 @@ const config: Config = {
           },
           {
             href: 'https://snowplow.io/get-started/snowplow-free-trial',
-            label: 'Start free trial',
+            label: 'Try for free',
             position: 'right',
             className: 'snowplow-button cta-button navbar-cta',
           },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -386,11 +386,39 @@ button.snowplow-button:focus {
   color: white;
 }
 
-/* Free trial call to action in the navbar */
+/* Free trial call to action in the navbar.
+   Properties are set explicitly here (rather than relying on the base
+   .snowplow-button rules winning the cascade against Infima's
+   .navbar__link) so the button renders identically in the dev server and
+   the minified production build. */
 
-[data-theme] a.navbar-cta.snowplow-button {
+[data-theme] a.navbar-cta {
+  /* display and color use !important to override Infima's theme rules,
+     which the production build inflates with a :not(#\#):not(#\#)
+     specificity hack that a normal selector cannot beat. */
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
   height: 36px;
   margin: auto 0 auto 0.5rem;
+  padding: 0 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: var(--ifm-color-accent);
+  color: white !important;
+  font-weight: 500;
+}
+
+[data-theme] a.navbar-cta:hover,
+[data-theme] a.navbar-cta:focus,
+[data-theme] a.navbar-cta:active {
+  background-color: var(--ifm-color-accent-darker);
+  color: white !important;
+}
+
+/* Hide the auto-injected "opens in new tab" icon on the CTA button */
+[data-theme] a.navbar-cta svg {
+  display: none;
 }
 
 @media (max-width: 996px) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -386,6 +386,19 @@ button.snowplow-button:focus {
   color: white;
 }
 
+/* Free trial call to action in the navbar */
+
+[data-theme] a.navbar-cta.snowplow-button {
+  height: 36px;
+  margin: auto 0 auto 0.5rem;
+}
+
+@media (max-width: 996px) {
+  a.navbar-cta {
+    display: none;
+  }
+}
+
 /* Alert buttons */
 
 .alert a.snowplow-button {


### PR DESCRIPTION
## What changed?

Surfaces the new free 14-day trial in the documentation:

- **New page** `docs/get-started/free-trial/` — overview of the trial (a fully managed CDI Cloud trial), how to start it, and the customer-relevant **product limitations** (collector config, first-party collector/custom domains, advanced infrastructure) and **capacity limits** (1 Micro / 1 warehouse / 1 event forwarding destination, collector rate limiting, non-scaling pipeline/Signals/Identities resources). Positioned just below Feature comparison in the Get started sidebar.
- **Header CTA** — a "Start free trial" button on the right of the navbar, linking to the signup flow. Reuses the existing `snowplow-button cta-button` styling and is hidden below 996px so it doesn't clutter the mobile sidebar.
- **Get started root page** — a "Try Snowplow for free" tip callout before the Customer Data Infrastructure section, linking to the trial page.

## Why?

Snowplow launched a free 14-day trial. The docs need to make it discoverable (header CTA + cross-links) and set clear expectations about what is and isn't available during the trial, reducing support load.

Limitations were drawn from the internal trial-limitations source; only customer-facing constraints are published — internal items (eligibility/business-email checks, deprovisioning, competitor blocking, extension workflow mechanics) were deliberately excluded.

## Reviewer guidance

- The signup button links externally to `https://snowplow.io/get-started/snowplow-free-trial`; in-docs links point to the new trial page.
- Verified with `yarn build` (passes `onBrokenLinks: 'throw'`) and visually in the dev server (navbar CTA, sidebar placement, root-page tip).

## AI reviews

Claude will automatically review this PR against the docs style guide.

If you have questions or want it to look again at something specific, tag `@claude` in a comment.