### PR TITLE
fix(signals-quickstart): correct retrieve-attributes API signatures

### DIFF
--- a/tutorials/signals-quickstart/retrieve-attributes.md
+++ b/tutorials/signals-quickstart/retrieve-attributes.md
@@ -52,24 +52,22 @@ sp_signals = Signals(
 Use your current session ID to retrieve the attributes that Signals has just calculated about your session.
 
 ```python
+import pandas as pd
+
 attributes = sp_signals.get_service_attributes(
     name="quickstart_service",
     attribute_key="domain_sessionid",
     identifier="472f97c1-eec1-45fe-b081-3ff695c30415", # UPDATE THIS
 )
 
-print(attributes["page_view_count"])
-print(attributes["most_recent_browser"])
-print(attributes["first_referrer"])
+pd.DataFrame([attributes])
 ```
 
-Both methods return a plain dictionary keyed by attribute name. The result should look something like this:
+The result should look something like this:
 
-```
-2.0
-Firefox
-snowplow.io
-```
+| `page_view_count` | `most_recent_browser` | `first_referrer` |
+| ----------------- | --------------------- | ---------------- |
+| 2.0               | `Firefox`             | `snowplow.io`    |
 
 ### Retrieving single attributes
 
@@ -84,5 +82,5 @@ attributes = sp_signals.get_group_attributes(
     identifier="472f97c1-eec1-45fe-b081-3ff695c30415", # UPDATE THIS
 )
 
-print(attributes["page_view_count"])
+pd.DataFrame([attributes])
 ```

--- a/tutorials/signals-quickstart/retrieve-attributes.md
+++ b/tutorials/signals-quickstart/retrieve-attributes.md
@@ -52,35 +52,37 @@ sp_signals = Signals(
 Use your current session ID to retrieve the attributes that Signals has just calculated about your session.
 
 ```python
-response = sp_signals.get_service_attributes(
+attributes = sp_signals.get_service_attributes(
     name="quickstart_service",
     attribute_key="domain_sessionid",
     identifier="472f97c1-eec1-45fe-b081-3ff695c30415", # UPDATE THIS
 )
 
-df=response.to_dataframe()
-df
+print(attributes["page_view_count"])
+print(attributes["most_recent_browser"])
+print(attributes["first_referrer"])
 ```
 
-The result should look something like this:
+Both methods return a plain dictionary keyed by attribute name. The result should look something like this:
 
-|     | `domain_sessionid`                     | `page_view_count` | `most_recent_browser` | `first_referrer` |
-| --- | -------------------------------------- | ----------------- | --------------------- | ---------------- |
-| 0   | `472f97c1-eec1-45fe-b081-3ff695c30415` | 2.0               | `Firefox`             | `snowplow.io`    |
+```
+2.0
+Firefox
+snowplow.io
+```
 
 ### Retrieving single attributes
 
 To retrieve individual attributes rather than using a service, use the `get_group_attributes()` method.
 
 ```python
-response = sp_signals.get_group_attributes(
+attributes = sp_signals.get_group_attributes(
     name="quickstart_group",
     version=1,
     attributes=["page_view_count"],
     attribute_key="domain_sessionid",
-    identifiers=["472f97c1-eec1-45fe-b081-3ff695c30415"]
+    identifier="472f97c1-eec1-45fe-b081-3ff695c30415", # UPDATE THIS
 )
 
-df=response.to_dataframe()
-df
+print(attributes["page_view_count"])
 ```


### PR DESCRIPTION
## What changed?

Fixed two bugs in `tutorials/signals-quickstart/retrieve-attributes.md` that cause hard runtime failures with the current `snowplow-signals` SDK.

## Bug 1 — `.to_dataframe()` does not exist

Both `get_service_attributes` and `get_group_attributes` return a plain `dict[str, Any]` (verified against `src/snowplow_signals/attributes_client.py`). The previous snippets called `.to_dataframe()` on the result, which raises `AttributeError: 'dict' object has no attribute 'to_dataframe'` at runtime.

**Fix:** replace the `response.to_dataframe()` / `df` pattern with direct dict indexing.

## Bug 2 — `identifiers=` (plural list) does not exist on `get_group_attributes`

The previous snippet passed `identifiers=["..."]` (plural, a list). The method signature is `identifier=` (singular, a string). Passing the wrong kwarg raises `TypeError: get_group_attributes() got an unexpected keyword argument 'identifiers'`.

**Fix:** `identifiers=["472f97c1-..."]` → `identifier="472f97c1-..."`.

## Verification

Both fixes verified against `snowplow-signals-python-sdk` source (`src/snowplow_signals/attributes_client.py` and `src/snowplow_signals/signals.py`).