### PR TITLE
Bump GCS loader to 0.5.7

### DIFF
--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -31,7 +31,7 @@ export const versions = {
   bqLoader: '2.2.0',
   bqLoader1x: '1.7.2',
   esLoader: '3.0.1',
-  gcsLoader: '0.5.6',
+  gcsLoader: '0.5.7',
   postgresLoader: '0.3.3',
   rdbLoader: '6.5.0',
   s3Loader: '3.2.0',


### PR DESCRIPTION
Bumps `gcsLoader` to **0.5.7** in `src/componentVersions.js`.

The 0.5.7 release ([snowplow-google-cloud-storage-loader#99](https://github.com/snowplow-incubator/snowplow-google-cloud-storage-loader/pull/99)) is internal — Java 21 modernization (sbt/Scala/Scio/Beam bumps, distroless `java21-debian13` base) and dependency/CVE upgrades. No user-facing config or option changes, so no other doc updates are needed; the loader page picks up the new version automatically via `${versions.gcsLoader}`.