### PR TITLE
Fix broken Signals links in python-tracking-and-signals tutorial

### DIFF
--- a/tutorials/python-tracking-and-signals/conclusion.md
+++ b/tutorials/python-tracking-and-signals/conclusion.md
@@ -20,6 +20,6 @@ This is the same pattern that powers production personalization: track behavior,
 
 * Explore more [attribute aggregations and criteria](/docs/signals/attributes/attributes/) to compute richer signals, such as filtered counts or most-frequent values.
 * Set the `user_id` from your authentication layer (mapped to a UUID) consistently across every tracker — web, mobile, and server — so Signals attributes follow the same user everywhere.
-* Read more about [interventions](/docs/signals/interventions/) and the different ways to [subscribe to them](/docs/signals/interventions/subscribe/).
+* Read more about [interventions](/docs/signals/interventions/) and the different ways to [subscribe to them](/docs/signals/applications/subscribe/).
 * Follow the [Signals quickstart](/tutorials/signals-quickstart/start) to define attributes in the Console UI.
 * Review the full [Python tracker](/docs/sources/python-tracker/) and [Signals](/docs/signals/) documentation for the complete API.

--- a/tutorials/python-tracking-and-signals/conclusion.md
+++ b/tutorials/python-tracking-and-signals/conclusion.md
@@ -18,8 +18,8 @@ This is the same pattern that powers production personalization: track behavior,
 
 ## Next steps
 
-* Explore more [attribute aggregations and criteria](/docs/signals/attributes/attributes/index.md) to compute richer signals, such as filtered counts or most-frequent values.
+* Explore more [attribute aggregations and criteria](/docs/signals/attributes/attributes/) to compute richer signals, such as filtered counts or most-frequent values.
 * Set the `user_id` from your authentication layer (mapped to a UUID) consistently across every tracker — web, mobile, and server — so Signals attributes follow the same user everywhere.
-* Read more about [interventions](/docs/signals/interventions/index.md) and the different ways to [subscribe to them](/docs/signals/applications/subscribe/index.md).
+* Read more about [interventions](/docs/signals/interventions/) and the different ways to [subscribe to them](/docs/signals/applications/subscribe/).
 * Follow the [Signals quickstart](/tutorials/signals-quickstart/start) to define attributes in the Console UI.
-* Review the full [Python tracker](/docs/sources/python-tracker/index.md) and [Signals](/docs/signals/index.md) documentation for the complete API.
+* Review the full [Python tracker](/docs/sources/python-tracker/) and [Signals](/docs/signals/) documentation for the complete API.

--- a/tutorials/python-tracking-and-signals/conclusion.md
+++ b/tutorials/python-tracking-and-signals/conclusion.md
@@ -18,8 +18,8 @@ This is the same pattern that powers production personalization: track behavior,
 
 ## Next steps
 
-* Explore more [attribute aggregations and criteria](/docs/signals/attributes/attributes/) to compute richer signals, such as filtered counts or most-frequent values.
+* Explore more [attribute aggregations and criteria](/docs/signals/attributes/attributes/index.md) to compute richer signals, such as filtered counts or most-frequent values.
 * Set the `user_id` from your authentication layer (mapped to a UUID) consistently across every tracker — web, mobile, and server — so Signals attributes follow the same user everywhere.
-* Read more about [interventions](/docs/signals/interventions/) and the different ways to [subscribe to them](/docs/signals/applications/subscribe/).
+* Read more about [interventions](/docs/signals/interventions/index.md) and the different ways to [subscribe to them](/docs/signals/applications/subscribe/index.md).
 * Follow the [Signals quickstart](/tutorials/signals-quickstart/start) to define attributes in the Console UI.
-* Review the full [Python tracker](/docs/sources/python-tracker/) and [Signals](/docs/signals/) documentation for the complete API.
+* Review the full [Python tracker](/docs/sources/python-tracker/index.md) and [Signals](/docs/signals/index.md) documentation for the complete API.

--- a/tutorials/python-tracking-and-signals/define-attributes.md
+++ b/tutorials/python-tracking-and-signals/define-attributes.md
@@ -9,11 +9,11 @@ date: "2026-06-19"
 
 Now that events are flowing, you'll tell Signals what to compute from them. In this section you'll connect to Signals and define three things with the Python SDK:
 
-* an [attribute group](/docs/signals/attributes/attribute-groups/index.md) that counts completed tasks per user
-* a [service](/docs/signals/applications/services/index.md) that bundles the group for easy retrieval
-* an [intervention](/docs/signals/interventions/index.md) that fires when a user crosses an engagement threshold
+* an [attribute group](/docs/signals/attributes/attribute-groups/) that counts completed tasks per user
+* a [service](/docs/signals/applications/services/) that bundles the group for easy retrieval
+* an [intervention](/docs/signals/interventions/) that fires when a user crosses an engagement threshold
 
-You can also define all of these in the Console UI. This tutorial uses the [Python SDK](/docs/signals/connection/index.md) so the whole loop lives in code.
+You can also define all of these in the Console UI. This tutorial uses the [Python SDK](/docs/signals/connection/) so the whole loop lives in code.
 
 ## Connect to Signals
 

--- a/tutorials/python-tracking-and-signals/define-attributes.md
+++ b/tutorials/python-tracking-and-signals/define-attributes.md
@@ -10,10 +10,10 @@ date: "2026-06-19"
 Now that events are flowing, you'll tell Signals what to compute from them. In this section you'll connect to Signals and define three things with the Python SDK:
 
 * an [attribute group](/docs/signals/attributes/attribute-groups/) that counts completed tasks per user
-* a [service](/docs/signals/attributes/services/) that bundles the group for easy retrieval
+* a [service](/docs/signals/applications/services/) that bundles the group for easy retrieval
 * an [intervention](/docs/signals/interventions/) that fires when a user crosses an engagement threshold
 
-You can also define all of these in the Console UI. This tutorial uses the [Python SDK](/docs/signals/attributes/using-python-sdk/) so the whole loop lives in code.
+You can also define all of these in the Console UI. This tutorial uses the [Python SDK](/docs/signals/connection/) so the whole loop lives in code.
 
 ## Connect to Signals
 

--- a/tutorials/python-tracking-and-signals/define-attributes.md
+++ b/tutorials/python-tracking-and-signals/define-attributes.md
@@ -9,11 +9,11 @@ date: "2026-06-19"
 
 Now that events are flowing, you'll tell Signals what to compute from them. In this section you'll connect to Signals and define three things with the Python SDK:
 
-* an [attribute group](/docs/signals/attributes/attribute-groups/) that counts completed tasks per user
-* a [service](/docs/signals/applications/services/) that bundles the group for easy retrieval
-* an [intervention](/docs/signals/interventions/) that fires when a user crosses an engagement threshold
+* an [attribute group](/docs/signals/attributes/attribute-groups/index.md) that counts completed tasks per user
+* a [service](/docs/signals/applications/services/index.md) that bundles the group for easy retrieval
+* an [intervention](/docs/signals/interventions/index.md) that fires when a user crosses an engagement threshold
 
-You can also define all of these in the Console UI. This tutorial uses the [Python SDK](/docs/signals/connection/) so the whole loop lives in code.
+You can also define all of these in the Console UI. This tutorial uses the [Python SDK](/docs/signals/connection/index.md) so the whole loop lives in code.
 
 ## Connect to Signals
 


### PR DESCRIPTION
## Summary

- The `signals-new-batch-engine` merge (#1809) moved pages but missed updating links in `tutorials/python-tracking-and-signals/`
- Three broken links caused `onBrokenLinks: throw` to fail the Cloudflare build

## Changes

| File | Old link | New link |
|------|----------|----------|
| `conclusion.md` | `/docs/signals/interventions/subscribe/` | `/docs/signals/applications/subscribe/` |
| `define-attributes.md` | `/docs/signals/attributes/services/` | `/docs/signals/applications/services/` |
| `define-attributes.md` | `/docs/signals/attributes/using-python-sdk/` | `/docs/signals/connection/` |

## Test plan

- [x] `yarn build` passes locally with these fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)