### PR TITLE
Add Custom instructions section to Snowplow Assistant docs

### DIFF
--- a/docs/llms-support/console-agent/index.md
+++ b/docs/llms-support/console-agent/index.md
@@ -44,6 +44,12 @@ Only users with the Administrator role can accept the terms and conditions and e
 
 When enabling the feature for the first time, an admin user must accept the terms and conditions related to LLM usage within the Snowplow product.
 
+### Custom instructions
+
+You can give the Snowplow Assistant organization-level information to keep in mind, such as naming conventions, schema patterns, internal terminology, and anything else relevant to how your organization works.
+
+These custom instructions apply to every conversation across all workspaces in your organization.
+
 ### Usage Limits
 
 The Snowplow Assistant has weekly refreshing token limits at the organisation level. The limit is set at a level that under normal usage you will not reach it.

--- a/docs/llms-support/console-agent/index.md
+++ b/docs/llms-support/console-agent/index.md
@@ -50,9 +50,9 @@ You can give the Snowplow Assistant organization-level information to keep in mi
 
 These custom instructions apply to every conversation across all workspaces in your organization.
 
-### Usage Limits
+### Usage limits
 
-The Snowplow Assistant has weekly refreshing token limits at the organisation level. The limit is set at a level that under normal usage you will not reach it.
+The Snowplow Assistant has token limits that refresh weekly at the organization level. Under normal usage, you should not reach the limit.
 
 ## Capabilities
 

--- a/docs/llms-support/console-agent/index.md
+++ b/docs/llms-support/console-agent/index.md
@@ -46,7 +46,8 @@ When enabling the feature for the first time, an admin user must accept the term
 
 ### Custom instructions
 
-You can give the Snowplow Assistant organization-level information to keep in mind, such as naming conventions, schema patterns, internal terminology, and anything else relevant to how your organization works.
+You can give the Snowplow Assistant organization-level information to keep in mind, such as naming conventions, schema patterns, and internal terminology.
+Do not include credentials, secrets, personal data, or other sensitive information.
 
 These custom instructions apply to every conversation across all workspaces in your organization.
 


### PR DESCRIPTION
## Summary

Adds a **Custom instructions** section to the [Snowplow Assistant](https://docs.snowplow.io/docs/llms-support/console-agent/) page, placed after **Enabling and disabling the assistant**.

The new section explains that users can provide organization-level information for the Snowplow Assistant to keep in mind (naming conventions, schema patterns, internal terminology, and similar), and that it applies to every conversation across all workspaces in the organization.

## Notes

- Phrasing follows the repo style guide and `CLAUDE.md` (sentence-case heading, Oxford comma, active voice, no marketing/temporal wording). The word "context" from the original copy was reworded to "information" to comply with the "use entity, never context" terminology rule.
- Draft + `do not merge` as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Simone's note:
- I do not want to add any images or heavy text in order to keep the page simple and focus on the other part, this feature is pretty straightforward we should keep it simple