### PR TITLE
Add free trial note to Signals tutorial intros

### DIFF
--- a/tutorials/python-tracking-and-signals/introduction.md
+++ b/tutorials/python-tracking-and-signals/introduction.md
@@ -30,7 +30,7 @@ This tutorial should take around 45 minutes to complete.
 This tutorial assumes that you have:
 
 * a Snowplow pipeline with a [Collector endpoint](/docs/sources/) you can send events to, because Signals computes attributes from your live event stream
-* [Signals enabled](/docs/signals/get-started/) on your Snowplow account, since the personalization features depend on it
+* [Signals enabled](/docs/signals/setup/) on your Snowplow account, since the personalization features depend on it
 * Python 3.9 or later, to run the SDKs
 * basic familiarity with Python and with [Snowplow events, entities, and schemas](/docs/fundamentals/events/)
 

--- a/tutorials/signals-agentic-accelerator/intro.md
+++ b/tutorials/signals-agentic-accelerator/intro.md
@@ -36,7 +36,7 @@ Together, Signals provides real-time behavioral context while AgentCore Memory p
 
 ## Prerequisites
 
-* A Snowplow CDI pipeline with [Signals enabled](/docs/signals/setup/) - the agent fetches behavioral attributes from the Signals Profiles API
+* A Snowplow CDI pipeline with Signals enabled (see [Set up Signals](/docs/signals/setup/)) - the agent fetches behavioral attributes from the Signals Profiles API
 * An AWS account with [Amazon Bedrock](https://aws.amazon.com/bedrock/) access and AgentCore Memory access - the agent runs on Claude via Bedrock, and your IAM user needs permissions for `bedrock:InvokeModel`, `bedrock-agentcore:*`, and `iam:PassRole` (scoped to `bedrock-agentcore.amazonaws.com`) to create AgentCore Memory resources
 * [AWS CLI](https://aws.amazon.com/cli/) installed and configured - used to authenticate with AWS services from the notebook
 * Python 3.11 or later - required by the Strands Agents framework
@@ -45,4 +45,3 @@ Together, Signals provides real-time behavioral context while AgentCore Memory p
 :::note[Snowplow account required]
 The behavioral attributes in this accelerator come from events flowing through a real Snowplow pipeline. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
 :::
-

--- a/tutorials/signals-agentic-accelerator/intro.md
+++ b/tutorials/signals-agentic-accelerator/intro.md
@@ -36,9 +36,13 @@ Together, Signals provides real-time behavioral context while AgentCore Memory p
 
 ## Prerequisites
 
-* A Snowplow CDI pipeline with Signals enabled - the agent fetches behavioral attributes from the Signals Profiles API
+* A Snowplow CDI pipeline with [Signals enabled](/docs/signals/setup/) - the agent fetches behavioral attributes from the Signals Profiles API
 * An AWS account with [Amazon Bedrock](https://aws.amazon.com/bedrock/) access and AgentCore Memory access - the agent runs on Claude via Bedrock, and your IAM user needs permissions for `bedrock:InvokeModel`, `bedrock-agentcore:*`, and `iam:PassRole` (scoped to `bedrock-agentcore.amazonaws.com`) to create AgentCore Memory resources
 * [AWS CLI](https://aws.amazon.com/cli/) installed and configured - used to authenticate with AWS services from the notebook
 * Python 3.11 or later - required by the Strands Agents framework
 * Familiarity with Python and running Jupyter notebooks
+
+:::note[Snowplow account required]
+The behavioral attributes in this accelerator come from events flowing through a real Snowplow pipeline. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+:::
 

--- a/tutorials/signals-ai-agent-context/introduction.md
+++ b/tutorials/signals-ai-agent-context/introduction.md
@@ -47,14 +47,14 @@ The flow works like this:
 
 This tutorial requires:
 
-* A Snowplow account with [Signals enabled](/docs/signals/setup/)
+* A Snowplow account with Signals enabled (see [Set up Signals](/docs/signals/setup/))
 * Node.js 18+ and npm/pnpm
 * A [Vercel AI Gateway API key](https://vercel.com/docs/ai-gateway/getting-started)
   * This tutorial uses `openai/gpt-4o-mini` via AI Gateway, but any supported model works
 * Basic familiarity with Next.js and TypeScript
 
 :::note[Snowplow account required]
-Signals computes the session attributes from real events flowing through your pipeline, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+Signals computes the session attributes from real events flowing through your pipeline. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
 :::
 
 This tutorial should take approximately 30 minutes to complete.

--- a/tutorials/signals-ai-agent-context/introduction.md
+++ b/tutorials/signals-ai-agent-context/introduction.md
@@ -47,10 +47,14 @@ The flow works like this:
 
 This tutorial requires:
 
-* A Snowplow account with [Signals deployed](/docs/signals/connection/)
+* A Snowplow account with [Signals enabled](/docs/signals/setup/)
 * Node.js 18+ and npm/pnpm
 * A [Vercel AI Gateway API key](https://vercel.com/docs/ai-gateway/getting-started)
   * This tutorial uses `openai/gpt-4o-mini` via AI Gateway, but any supported model works
 * Basic familiarity with Next.js and TypeScript
+
+:::note[Snowplow account required]
+Signals computes the session attributes from real events flowing through your pipeline, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+:::
 
 This tutorial should take approximately 30 minutes to complete.

--- a/tutorials/signals-google-adk-agent/introduction.md
+++ b/tutorials/signals-google-adk-agent/introduction.md
@@ -45,10 +45,14 @@ The flow works like this:
 
 ## Prerequisites
 
-- A Snowplow account with [Signals deployed](/docs/signals/connection/)
+- A Snowplow account with [Signals enabled](/docs/signals/setup/)
 - Node.js 18+ and npm/pnpm
 - Python 3.12+
 - A Google AI Studio API key
   - [AI Studio](https://aistudio.google.com/app/apikey)
   - [Vertex AI](https://docs.cloud.google.com/agent-builder/agent-engine/quickstart-adk)
 - Basic familiarity with React, Python, and TypeScript
+
+:::note[Snowplow account required]
+The agent fetches session attributes that Signals computes from your live event stream, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+:::

--- a/tutorials/signals-google-adk-agent/introduction.md
+++ b/tutorials/signals-google-adk-agent/introduction.md
@@ -45,7 +45,7 @@ The flow works like this:
 
 ## Prerequisites
 
-- A Snowplow account with [Signals enabled](/docs/signals/setup/)
+- A Snowplow account with Signals enabled (see [Set up Signals](/docs/signals/setup/))
 - Node.js 18+ and npm/pnpm
 - Python 3.12+
 - A Google AI Studio API key
@@ -54,5 +54,5 @@ The flow works like this:
 - Basic familiarity with React, Python, and TypeScript
 
 :::note[Snowplow account required]
-The agent fetches session attributes that Signals computes from your live event stream, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+The agent fetches session attributes that Signals computes from your live event stream. If you don't have a pipeline, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
 :::

--- a/tutorials/signals-interventions/start.md
+++ b/tutorials/signals-interventions/start.md
@@ -14,6 +14,10 @@ This tutorial provides a hands-on introduction to Signals. You'll use Python to 
 
 To follow this tutorial, you'll need a Snowplow account with Signals enabled.
 
+:::note[Snowplow account required]
+If you don't have a Snowplow account, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+:::
+
 This tutorial should take approximately 20-30 minutes to complete.
 
 ## What you'll learn

--- a/tutorials/signals-interventions/start.md
+++ b/tutorials/signals-interventions/start.md
@@ -15,7 +15,7 @@ This tutorial provides a hands-on introduction to Signals. You'll use Python to 
 To follow this tutorial, you'll need a Snowplow account with Signals enabled.
 
 :::note[Snowplow account required]
-If you don't have a Snowplow account, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+If you don't have a Snowplow account, you can sign up for a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
 :::
 
 This tutorial should take approximately 20-30 minutes to complete.

--- a/tutorials/signals-ml-prospect-scoring/intro.md
+++ b/tutorials/signals-ml-prospect-scoring/intro.md
@@ -36,9 +36,13 @@ We're calculating aggregated attributes based off real-time stream event data, s
 
 ## Prerequisites
 
-1. Follow the [Connect to Signals](/docs/signals/connection/) page to set up the Signals connection in the Snowplow Console
+1. [Enable Signals](/docs/signals/setup/) for your Snowplow account
 2. Open this [Google Colab](https://colab.research.google.com/github/snowplow-incubator/signals-notebooks/blob/main/web/web_prospect_scoring_end_to_end.ipynb) notebook to follow along
 3. [Optional] Integrate Snowplow into your website
+
+:::note[Snowplow account required]
+Signals calculates the prospect attributes from events flowing through your Snowplow pipeline, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+:::
 
 ## Architecture
 

--- a/tutorials/signals-ml-prospect-scoring/intro.md
+++ b/tutorials/signals-ml-prospect-scoring/intro.md
@@ -41,7 +41,7 @@ We're calculating aggregated attributes based off real-time stream event data, s
 3. [Optional] Integrate Snowplow into your website
 
 :::note[Snowplow account required]
-Signals calculates the prospect attributes from events flowing through your Snowplow pipeline, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+Signals calculates the prospect attributes from events flowing through your Snowplow pipeline. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
 :::
 
 ## Architecture

--- a/tutorials/signals-personalize-travel/intro.md
+++ b/tutorials/signals-personalize-travel/intro.md
@@ -21,7 +21,7 @@ You'll build a complete personalization system that captures user interests thro
 
 ## Prerequisites
 
-* [Signals enabled](/docs/signals/setup/) for your CDI pipeline
+* [Enable Signals](/docs/signals/setup/) for your CDI pipeline
 * The [Snowplow Inspector](https://chromewebstore.google.com/detail/snowplow-inspector/maplkdomeamdlngconidoefjpogkmljm) browser extension installed
 * Familiarity with running Jupyter notebooks, either locally or in Google Colab
 * [Docker](https://www.docker.com/) installed and configured
@@ -29,5 +29,5 @@ You'll build a complete personalization system that captures user interests thro
 * Optional: an [OpenAI API key](https://platform.openai.com/api-keys) to customize agent responses
 
 :::note[Snowplow account required]
-Signals processes the behavioral data from events flowing through your Snowplow pipeline, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+Signals processes the behavioral data from events flowing through your Snowplow pipeline. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
 :::

--- a/tutorials/signals-personalize-travel/intro.md
+++ b/tutorials/signals-personalize-travel/intro.md
@@ -21,9 +21,13 @@ You'll build a complete personalization system that captures user interests thro
 
 ## Prerequisites
 
-* Signals enabled for your CDI pipeline
+* [Signals enabled](/docs/signals/setup/) for your CDI pipeline
 * The [Snowplow Inspector](https://chromewebstore.google.com/detail/snowplow-inspector/maplkdomeamdlngconidoefjpogkmljm) browser extension installed
 * Familiarity with running Jupyter notebooks, either locally or in Google Colab
 * [Docker](https://www.docker.com/) installed and configured
 * Access to the Jupyter [notebook](https://colab.research.google.com/github/snowplow/documentation/blob/main/static/notebooks/signals-personalize-travel-demo.ipynb)
 * Optional: an [OpenAI API key](https://platform.openai.com/api-keys) to customize agent responses
+
+:::note[Snowplow account required]
+Signals processes the behavioral data from events flowing through your Snowplow pipeline, so you need a Snowplow account with Signals enabled. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+:::

--- a/tutorials/signals-quickstart/start.md
+++ b/tutorials/signals-quickstart/start.md
@@ -22,10 +22,14 @@ This tutorial assumes that you have:
 
 * Snowplow page view tracking on a web application
 * Snowflake warehouse
-* A Signals connection
+* Signals enabled on your Snowplow account
 
-## Connecting to Signals
+:::note[Snowplow account required]
+Signals calculates attributes from events flowing through your Snowplow pipeline, so you need a Snowplow account to complete this tutorial. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+:::
+
+## Enable Signals
 
 Log in to [Console](https://console.snowplowanalytics.com) and navigate to the **Signals** section.
 
-You'll need to [set up a Signals connection](/docs/signals/connection/) if you don't have one yet.
+You'll need to [enable Signals](/docs/signals/setup/) if you haven't already.

--- a/tutorials/signals-quickstart/start.md
+++ b/tutorials/signals-quickstart/start.md
@@ -25,11 +25,11 @@ This tutorial assumes that you have:
 * Signals enabled on your Snowplow account
 
 :::note[Snowplow account required]
-Signals calculates attributes from events flowing through your Snowplow pipeline, so you need a Snowplow account to complete this tutorial. If you don't have one, you can deploy and use a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
+Signals calculates attributes from events flowing through your Snowplow pipeline. If you don't have an account, you can sign up for a [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial) to follow along.
 :::
 
 ## Enable Signals
 
 Log in to [Console](https://console.snowplowanalytics.com) and navigate to the **Signals** section.
 
-You'll need to [enable Signals](/docs/signals/setup/) if you haven't already.
+If Signals isn't enabled for your organization yet, follow [Set up Signals](/docs/signals/setup/) first.


### PR DESCRIPTION
> This PR was generated automatically by Claude.

## What changed?

Only 1 of the 8 Signals tutorials mentioned the Snowplow free trial, even though the trial includes Signals. This PR adds an access note to the intro page of the other 7 tutorials, modeled on the one in `tutorials/python-tracking-and-signals/introduction.md`. Each note is worded to fit the page and ends with the same sentence pointing to the [Snowplow free trial](https://snowplow.io/get-started/snowplow-free-trial).

While editing the intros, "get access" wording was retargeted from `/docs/signals/connection/` (the credentials page) to `/docs/signals/setup/` (the enable-Signals page):

- `signals-quickstart/start.md`: "set up a Signals connection" is now "enable Signals", the "Connecting to Signals" heading is now "Enable Signals", and the "A Signals connection" prerequisite is now "Signals enabled on your Snowplow account"
- `signals-ai-agent-context/introduction.md` and `signals-google-adk-agent/introduction.md`: "Signals deployed" links now point to the setup page as "Signals enabled"
- `signals-ml-prospect-scoring/intro.md`: the "Connect to Signals" prerequisite step now says "Enable Signals" and links to the setup page
- `signals-agentic-accelerator/intro.md` and `signals-personalize-travel/intro.md`: existing "Signals enabled" prerequisites now link to the setup page

## Why?

The free trial includes Signals, but readers landing on these tutorials without a Snowplow account had no pointer to it. The connection page links sent readers to a credentials page when they actually needed to enable Signals first.

## AI reviews

Claude will automatically review this PR against the docs style guide.

If you have questions or want it to look again at something specific, tag `@claude` in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)