### PR TITLE
docs(signals): add Inspector verification steps to Signals tutorials

### DIFF
--- a/docs/testing/snowplow-inspector/signals-integration/index.md
+++ b/docs/testing/snowplow-inspector/signals-integration/index.md
@@ -64,8 +64,8 @@ As the extension builds its list of attribute keys based on observed events, it 
 
 If an intervention triggers on a subscription, the interventions counter will increase and you can switch to this tab to view the intervention content of each observed intervention.
 
-Clicking an intervention from the list of received interventions on the will display the contents, including the targeted attribute key and any associated attributes at the time of the intervention.
+Click an intervention in the list of received interventions to display its contents, including the targeted attribute key and any associated attributes at the time of the intervention.
 
 For rule-based interventions, you can also expand the definition of the intervention to see the logic used to trigger it.
 
-![Screenshot of the Snowplow Inspector viewing interventions. The most recent of two triggered interventions is displayed.](../images/signals-attributes.png)
+![Screenshot of the Snowplow Inspector viewing interventions. The most recent of two triggered interventions is displayed.](../images/signals-interventions.png)

--- a/tutorials/signals-ai-agent-context/test.md
+++ b/tutorials/signals-ai-agent-context/test.md
@@ -23,9 +23,20 @@ Open your app in a browser and browse around for a few minutes. Visit different 
 
 Open the chat and ask a general question. If your Signals service is returning attributes for your session, the agent's response will reference what you've been doing.
 
+## Verify tracking and attributes in Snowplow Inspector
+
+The [Snowplow Inspector](/docs/testing/snowplow-inspector/) browser extension lets you check both tracking and attribute calculation without touching any code. Its [Signals integration](/docs/testing/snowplow-inspector/signals-integration/) connects to Signals and displays live attribute values in your browser developer tools.
+
+With your app open, open the Inspector:
+
+* the **Events** tab lists the events the Browser tracker is sending, so you can confirm your interactions are being tracked
+* the **Attributes** tab shows the values Signals has calculated for your session, refreshing automatically as new events arrive
+
+If events appear but the attribute values stay empty, the problem is on the Signals side rather than in your app. If both look correct but the agent's responses don't reflect your behavior, move on to checking the app itself.
+
 ## Verify Signals context
 
-You can verify that the app is receiving the Signals context by adding a log to the API route:
+You can also verify that the app is receiving the Signals context by adding a log to the API route:
 
 ```tsx
 console.log(

--- a/tutorials/signals-google-adk-agent/build-agent.md
+++ b/tutorials/signals-google-adk-agent/build-agent.md
@@ -335,7 +335,14 @@ Open the CopilotKit sidebar and ask a general question. If your Signals service 
 
 ## Verify Signals context
 
-You can verify that the app is receiving the Signals context by checking the agent logs. When you run `npm run dev`, watch the `[agent]` prefix. You should see the session ID present from the first turn:
+The [Snowplow Inspector](/docs/testing/snowplow-inspector/) browser extension is the quickest way to check that tracking and attribute calculation are working, without touching any code. Its [Signals integration](/docs/testing/snowplow-inspector/signals-integration/) connects to Signals and displays live attribute values in your browser developer tools.
+
+With your app open, open the Inspector:
+
+* the **Events** tab lists the events the Browser tracker is sending, so you can confirm your interactions are reaching the Collector
+* the **Attributes** tab shows the values Signals has calculated for your session, such as `page_views_count`, refreshing automatically as new events arrive
+
+Once both look correct, verify that the agent is receiving the Signals context by checking the agent logs. When you run `npm run dev`, watch the `[agent]` prefix. You should see the session ID present from the first turn:
 
 ```
 [agent] before_model_callback: state_keys=['snowplowDomainSessionId', '_ag_ui_thread_id', '_ag_ui_app_name', '_ag_ui_user_id'] snowplow_session_id='472f97c1-eec1-45fe-b081-3ff695c30415'
@@ -343,7 +350,7 @@ You can verify that the app is receiving the Signals context by checking the age
 ```
 
 If the session ID is missing, the Snowplow tracker never initialized. Check:
-* The browser's Network tab for requests to your Collector
+* The Inspector's **Events** tab (or the browser's Network tab) for requests to your Collector
 * That your Collector URL environment variable is set and exposed to the browser (`NEXT_PUBLIC_` prefix in the scaffold)
 * That `SnowplowProvider` wraps `CopilotProvider` in `layout.tsx`
 

--- a/tutorials/signals-ml-prospect-scoring/define-prospect-attributes.md
+++ b/tutorials/signals-ml-prospect-scoring/define-prospect-attributes.md
@@ -141,7 +141,11 @@ Signals will start populating your Profiles Store with attributes calculated fro
 This section expects that you [integrated](/docs/sources/web-trackers/quick-start-guide/) `sp.js` into a website and have events flowing to the collector.
 :::
 
-Go to your website, and use the [Snowplow Inspector](/docs/testing/snowplow-inspector/) browser plugin to find your own `domain_userid` in outbound web events.
+Before wiring the attributes into an ML model, verify that Signals is calculating them as expected. The quickest way is the [Snowplow Inspector](/docs/testing/snowplow-inspector/) browser extension: its [Signals integration](/docs/testing/snowplow-inspector/signals-integration/) connects to Signals and displays live attribute values in your browser developer tools, without writing any code.
+
+Go to your website with the Inspector open, and click around to generate some page view events, including a visit to your pricing page. Switch to the Inspector's **Attributes** tab: you should see the `prospect_scoring_tutorial` attribute group, with values for your own `domain_userid`. The tab refreshes automatically as new events arrive, so `num_page_views` and `num_pricing_views` will increase as you continue to browse.
+
+To retrieve the same values programmatically, first find your own `domain_userid` in outbound web events on the Inspector's **Events** tab.
 
 ![Snowplow Inspector browser extension showing a page_ping event from /docs/, with the User section expanded and the Domain User ID value circled in red](./images/get_domain_userid.png)
 

--- a/tutorials/signals-quickstart/retrieve-attributes.md
+++ b/tutorials/signals-quickstart/retrieve-attributes.md
@@ -1,24 +1,42 @@
 ---
 position: 4
-title: Retrieve calculated attributes using the Signals Python SDK
-sidebar_label: Retrieve attributes using Python
-description: "Access and consume calculated behavioral data attributes from the Snowplow Signals Profiles Store using the Python SDK."
-keywords: ["signals python sdk", "profiles store"]
+title: Verify and retrieve calculated attributes
+sidebar_label: Retrieve attributes
+description: "Verify calculated attributes in the Snowplow Inspector browser extension, then retrieve them from the Snowplow Signals Profiles Store using the Python SDK."
+keywords: ["snowplow inspector", "signals python sdk", "profiles store"]
 ---
+
+Signals is now calculating attributes from your real-time event stream. In this step, you'll verify the calculated values in your browser using the Snowplow Inspector extension, then retrieve them with the Signals Python SDK, the way your application would.
+
+## Verify attributes in Snowplow Inspector
+
+The quickest way to see your calculated attributes is the [Snowplow Inspector](/docs/testing/snowplow-inspector/) browser extension, without writing any code. Its [Signals integration](/docs/testing/snowplow-inspector/signals-integration/) connects to Signals and displays live attribute values for your own session in your browser developer tools.
+
+To set up the integration, log in to Snowplow Console through the extension, and add API credentials for your organization in the extension options.
+
+Once connected:
+
+1. Go to your web application, and open the Inspector in your browser developer tools
+2. Click around to generate some page view events: they'll appear in the **Events** tab
+3. Switch to the **Attributes** tab to see the values Signals has calculated for your session
+
+You should see the `quickstart_group` attribute group, with values for the `page_view_count`, `most_recent_browser`, and `first_referrer` attributes. The **Attributes** tab refreshes automatically as new events arrive: browse a few more pages and watch `page_view_count` increase.
+
+## Use attributes in your application
 
 For a real use case, you'll want to consume calculated attributes in your applications. Read more about this [in the Signals documentation](/docs/signals/attributes/).
 
 For this tutorial, we've provided a [Jupyter notebook](https://colab.research.google.com/github/snowplow-incubator/signals-notebooks/blob/main/quickstart.ipynb) so you can quickly explore attribute retrieval using the Signals Python SDK.
 
-## Finding your current session ID
+### Find your current session ID
 
 In your real application code, you can access the current session ID and use it to retrieve the relevant attribute values. The attributes are being calculated in real time, in session. Read about how to access IDs such as `domain_sessionid` in your web application in [the JavaScript tracker](/docs/sources/web-trackers/cookies-and-local-storage/getting-cookie-values) documentation.
 
-To test this out, use the [Snowplow Inspector](/docs/testing/snowplow-inspector/) browser extension to find out your current session ID on your web application. Click around and generate some page view events. Then find your `Domain Session ID` in the Inspector.
+To test this out, use the Inspector to find your current session ID on your web application. Find your `Domain Session ID` in the **Events** tab.
 
 ![Screenshot showing the session ID in the Snowplow Inspector](./images/inspector-session.png)
 
-## Connecting to Signals
+### Connect to Signals
 
 Install the [Signals Python SDK](https://pypi.org/project/snowplow-signals/) into the notebook, and connect to Signals.
 
@@ -47,7 +65,7 @@ sp_signals = Signals(
 )
 ```
 
-## Retrieving your session attributes
+### Retrieve your session attributes
 
 Use your current session ID to retrieve the attributes that Signals has just calculated about your session.
 
@@ -69,7 +87,9 @@ The result should look something like this:
 | ----------------- | --------------------- | ---------------- |
 | 2.0               | `Firefox`             | `snowplow.io`    |
 
-### Retrieving single attributes
+The values should match what you saw in the Inspector's **Attributes** tab.
+
+### Retrieve single attributes
 
 To retrieve individual attributes rather than using a service, use the `get_group_attributes()` method.
 


### PR DESCRIPTION
## Summary

The Snowplow Inspector's new [Signals integration](https://github.com/snowplow/documentation/blob/main/docs/testing/snowplow-inspector/signals-integration/index.md) provides live Attributes and Interventions tabs in DevTools, but several Signals tutorials still verified attributes only via notebook/SDK pulls or `console.log`. This PR makes the Inspector the first, zero-code verification step across those tutorials, and fixes two bugs on the Signals integration page itself.

- **`tutorials/signals-quickstart/retrieve-attributes.md`**: restructured so the first verification step is the Inspector's **Attributes** tab, with the Python SDK retrieval kept as the "use it in your application" step. The Colab notebook remains the vehicle for the SDK step, so `meta.json` is unchanged.
- **`tutorials/signals-ai-agent-context/test.md`**: added an Inspector verification section (Events tab for tracking, Attributes tab for computed values) before the `console.log` fallback.
- **`tutorials/signals-google-adk-agent/build-agent.md`**: the "Verify Signals context" section now leads with the Inspector before the agent-log check.
- **`tutorials/signals-ml-prospect-scoring/define-prospect-attributes.md`**: added Attributes-tab verification after publishing, before wiring up the ML model.
- **`docs/testing/snowplow-inspector/signals-integration/index.md`**: the Interventions screenshot now embeds the previously unused `signals-interventions.png` (it duplicated the Attributes screenshot), and the dangling sentence "...from the list of received interventions on the will display" is repaired.

## Checks

- All new internal links verified to exist (`/docs/testing/snowplow-inspector/signals-integration/` etc.)
- Attribute names in the quickstart verification step match those defined in `define-attribute-group.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)