### PR TITLE
Enrich 6.13.0

### DIFF
--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -8,6 +8,7 @@ keywords: ["referrer parser", "traffic source", "attribution", "referer", "utm_s
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import SchemaProperties from "@site/docs/reusable/schema-properties/_index.md"
 
 This enrichment uses the [Snowplow referer-parser](https://github.com/snowplow/referer-parser) library to extract attribution data from referrer URLs.
 
@@ -228,23 +229,17 @@ The hosted database includes `utm_sources` entries for the major chatbot provide
 
 ### Output entity
 
-On a match, the enrichment attaches a [`utm_referrer`](https://github.com/snowplow/iglu-central/tree/master/schemas/com.snowplowanalytics.snowplow/utm_referrer/jsonschema/1-0-0) entity to `derived_contexts`:
+On a match, the enrichment attaches a `utm_referrer` entity to `derived_contexts`.
 
-```json
-{
-  "schema": "iglu:com.snowplowanalytics.snowplow/utm_referrer/jsonschema/1-0-0",
-  "data": {
-    "source": "ChatGPT",
-    "medium": "chatbot"
-  }
-}
-```
+<SchemaProperties
+  overview={{ entity: true }}
+  example={{
+    source: "ChatGPT",
+    medium: "chatbot"
+  }}
+  schema={{ "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#", "description": "Referer identified from an injected utm_source query parameter, classified by the referer parser enrichment against its utm_sources database entries", "self": { "vendor": "com.snowplowanalytics.snowplow", "name": "utm_referrer", "format": "jsonschema", "version": "1-0-0" }, "type": "object", "properties": { "source": { "type": "string", "description": "The name of the referer source (e.g. ChatGPT), equivalent to refr_source", "maxLength": 128 }, "medium": { "type": "string", "description": "The medium of the referer (e.g. chatbot), equivalent to refr_medium", "maxLength": 64 }, "term": { "type": ["string", "null"], "description": "The search term extracted from the referer, equivalent to refr_term", "maxLength": 512 } }, "required": ["source", "medium"], "additionalProperties": false }} />
 
-| Field    | Description                                                                           |
-| -------- | ------------------------------------------------------------------------------------- |
-| `source` | The name of the matched source e.g., `ChatGPT`. Equivalent to `refr_source`.           |
-| `medium` | The medium of the matched source e.g., `chatbot`. Equivalent to `refr_medium`.         |
-| `term`   | The search term. Currently, always absent for `utm_source` matches. Equivalent to `refr_term`.    |
+Currently, the `term` field is always absent for `utm_source` matches, as there's no referrer URL to extract a search term from.
 
 ### How it relates to referrer URL parsing
 

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -223,7 +223,7 @@ The `Referer` header is not set when users share or copy and paste the link, rat
 https://www.example.com/product?utm_source=chatgpt.com
 ```
 
-The enrichment parses both the `Referer` header and the `utm_source` parameter and preserves both pieces of information. The header, if present, populates the `refr_*` fields of the event. If a referrer is detected through the `utm_source` parameter, the enrichment adds a `utm_referrer` entity to the event.
+Note that an event might contain both a `Referer` header value *and* a `utm_source` value. These values might not match. For example, if person A shared the above link with person B via Instagram messages, and person B clicked the link, `Referer` would be `instagram.com`. In these cases, you should rely on the `utm_source` value for first-touch attribution.
 
 The hosted database includes `utm_sources` entries for the major chatbot providers — ChatGPT, Claude.ai, Google Gemini, Microsoft Copilot, META.ai, Mistral.ai, Perplexity.ai, Character.AI and Poe — so this works out of the box, as long as you use the actively-maintained database file (`referers-5.3`). You can recognize additional sources by adding `utm_sources` to your [custom referrer mappings](#custom-referrer-mappings).
 
@@ -246,7 +246,7 @@ Currently, the `term` field is always absent for `utm_source` matches, as there'
 The `utm_source` classification is deliberately kept separate from the `Referer` header parsing described above:
 
 * It **doesn't populate** `refr_medium`, `refr_source`, or `refr_term`. Those fields continue to reflect the referrer URL only, so existing data models and queries are unaffected.
-* It's **additive**. If an event has both a recognized referrer URL and a recognized `utm_source`, you get the `refr_*` fields *and* the `utm_referrer` entity. The two can disagree: if a user shares a ChatGPT link over Instagram messages and the recipient clicks it, `refr_source` is `Instagram` while the `utm_referrer` entity is `ChatGPT`. Rely on the `utm_referrer` entity for first-touch attribution.
+* It's **additive**. If an event has both a recognized referrer URL and a recognized `utm_source`, you get the `refr_*` fields *and* the `utm_referrer` entity.
 * It's **independent of the [campaign attribution enrichment](/docs/pipeline/enrichments/available-enrichments/campaign-attribution-enrichment/index.md)**, which copies `utm_source` into `mkt_source` verbatim. The referrer parser instead resolves the value to a known source and medium. Both can run on the same event.
 
 Matching is an exact, case-sensitive comparison of the full `utm_source` value against the `utm_sources` entries, and only the page URL's query string is inspected. Values from your own `referrers` configuration take precedence over the database.

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -2,8 +2,8 @@
 title: "Referrer parser enrichment"
 sidebar_position: 3
 sidebar_label: Referrer parser
-description: "Extract attribution data from referrer URLs to identify traffic sources, search terms, and marketing channels."
-keywords: ["referrer parser", "traffic source", "attribution", "referer"]
+description: "Extract attribution data from referrer URLs and utm_source parameters to identify traffic sources, search terms, and marketing channels."
+keywords: ["referrer parser", "traffic source", "attribution", "referer", "utm_source", "chatbot"]
 ---
 
 import Tabs from '@theme/Tabs';
@@ -12,6 +12,8 @@ import TabItem from '@theme/TabItem';
 This enrichment uses the [Snowplow referer-parser](https://github.com/snowplow/referer-parser) library to extract attribution data from referrer URLs.
 
 This is particularly useful when looking for traffic from specific search engine providers or social networks.
+
+Since version 6.13.0 of Enrich, it also classifies traffic sources that identify themselves through a [`utm_source` query parameter](#identifying-referrers-from-utm_source) rather than a `Referer` header, which is how most AI chatbots send their traffic.
 
 ## Configuration
 
@@ -48,6 +50,12 @@ Configure the parameters in the Console enrichment editor. Keep the Console defa
       "Social website": {
         "domains": ["social.acme.com"]
       }
+    },
+    "chatbot": {
+      "Acme Assistant": {
+        "domains": ["assistant.acme.com"],
+        "utm_sources": ["assistant.acme.com"]
+      }
     }
   }
 }
@@ -60,7 +68,7 @@ For Self-Hosted, [provide a complete JSON](/docs/pipeline/enrichments/managing-e
 
 ```json
 {
-  "schema": "iglu:com.snowplowanalytics.snowplow/referer_parser/jsonschema/2-0-1",
+  "schema": "iglu:com.snowplowanalytics.snowplow/referer_parser/jsonschema/2-0-2",
   "data": {
     "name": "referer_parser",
     "vendor": "com.snowplowanalytics.snowplow",
@@ -83,12 +91,24 @@ For Self-Hosted, [provide a complete JSON](/docs/pipeline/enrichments/managing-e
           "Social website": {
             "domains": ["social.acme.com"]
           }
+        },
+        "chatbot": {
+          "Acme Assistant": {
+            "domains": ["assistant.acme.com"],
+            "utm_sources": ["assistant.acme.com"]
+          }
         }
       }
     }
   }
 }
 ```
+
+:::note
+
+The `utm_sources` field requires configuration schema version `2-0-2`, available since version 6.13.0 of Enrich. Earlier schema versions (`2-0-0`, `2-0-1`) remain valid, but reject `utm_sources`.
+
+:::
 
   </TabItem>
 </Tabs>
@@ -143,7 +163,8 @@ The `referrers` parameter is a nested object structured like this:
   "<medium>": {
     "<source name>": {
       "domains": ["<domain1>", "<domain2>"],
-      "parameters": ["<param1>"]
+      "parameters": ["<param1>"],
+      "utm_sources": ["<utm_source1>"]
     }
   }
 }
@@ -155,6 +176,7 @@ The `referrers` parameter is a nested object structured like this:
 | `<source name>` | A human-readable name for the source e.g., `"Google"`, `"Internal Search"`. This value populates `refr_source`.   |
 | `domains`       | An array of hostnames to match against the referrer URL. At least one domain is required.                         |
 | `parameters`    | An optional array of URL query parameter names to extract search terms from. Matched values populate `refr_term`. |
+| `utm_sources`   | An optional array of `utm_source` values identifying this source. See [Identifying referrers from `utm_source`](#identifying-referrers-from-utm_source). Available since version 6.13.0 of Enrich. |
 
 For example, to classify a custom search engine and a social network:
 
@@ -188,6 +210,54 @@ You can use custom referrer mappings to immediately test new categorizations in 
 
 :::
 
+## Identifying referrers from `utm_source`
+
+:::note[Availability]
+This feature is available since version 6.13.0 of Enrich.
+:::
+
+Not every traffic source sets a `Referer` header. Many — AI chatbots in particular — instead append a `utm_source` query parameter to the links they send, for example:
+
+```
+https://www.example.com/product?utm_source=chatgpt.com
+```
+
+Because there's no referrer URL, the `refr_*` fields stay empty and this traffic is indistinguishable from direct traffic. To close that gap, the enrichment also matches the `utm_source` parameter of the page URL against the `utm_sources` entries in the referer database, and attaches a `utm_referrer` entity to the event when it recognizes the value.
+
+The hosted database includes `utm_sources` entries for the major chatbot providers — ChatGPT, Claude.ai, Google Gemini, Microsoft Copilot, META.ai, Mistral.ai, Perplexity.ai, Character.AI and Poe — so this works out of the box, as long as you use the actively-maintained database file (`referers-5.3`). You can recognize additional sources by adding `utm_sources` to your [custom referrer mappings](#custom-referrer-mappings).
+
+### Output entity
+
+On a match, the enrichment attaches a [`utm_referrer`](https://github.com/snowplow/iglu-central/tree/master/schemas/com.snowplowanalytics.snowplow/utm_referrer/jsonschema/1-0-0) entity to `derived_contexts`:
+
+```json
+{
+  "schema": "iglu:com.snowplowanalytics.snowplow/utm_referrer/jsonschema/1-0-0",
+  "data": {
+    "source": "ChatGPT",
+    "medium": "chatbot"
+  }
+}
+```
+
+| Field    | Description                                                                           |
+| -------- | ------------------------------------------------------------------------------------- |
+| `source` | The name of the matched source e.g., `ChatGPT`. Equivalent to `refr_source`.           |
+| `medium` | The medium of the matched source e.g., `chatbot`. Equivalent to `refr_medium`.         |
+| `term`   | The search term. Always absent for `utm_source` matches. Equivalent to `refr_term`.    |
+
+### How it relates to referrer URL parsing
+
+The `utm_source` classification is deliberately kept separate from the `Referer` header parsing described above:
+
+* It **doesn't populate** `refr_medium`, `refr_source`, or `refr_term`. Those fields continue to reflect the referrer URL only, so existing data models and queries are unaffected.
+* It's **additive**. If an event has both a recognized referrer URL and a recognized `utm_source`, you get the `refr_*` fields *and* the `utm_referrer` entity. The two can legitimately disagree — for instance, a chatbot link opened from an email client — and keeping them apart lets you decide which signal to trust.
+* It's **independent of the [campaign attribution enrichment](/docs/pipeline/enrichments/available-enrichments/campaign-attribution-enrichment/index.md)**, which copies `utm_source` into `mkt_source` verbatim. The referrer parser instead resolves the value to a known source and medium. Both can run on the same event.
+
+Matching is an exact, case-sensitive comparison of the full `utm_source` value against the `utm_sources` entries, and only the page URL's query string is inspected. Values from your own `referrers` configuration take precedence over the database.
+
 ## Output
 
 This enrichment populates the `refr_medium`, `refr_source`, and `refr_term` [atomic event fields](/docs/fundamentals/canonical-event/index.md#page-fields).
+
+Since version 6.13.0 of Enrich, it can additionally attach a [`utm_referrer` entity](#output-entity) to `derived_contexts`.

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -222,7 +222,7 @@ The `Referer` header is not set when users share or copy and paste the link, rat
 https://www.example.com/product?utm_source=chatgpt.com
 ```
 
-Because there's no referrer URL, the `refr_*` fields stay empty and this traffic is indistinguishable from direct traffic. To close that gap, the enrichment also matches the `utm_source` parameter of the page URL against the `utm_sources` entries in the referer database, and attaches a `utm_referrer` entity to the event when it recognizes the value.
+The enrichment parses both the `Referer` header and the `utm_source` parameter and preserves both pieces of information. The header, if present, populates the `refr_*` fields of the event. If a referrer is detected through the `utm_source` parameter, the enrichment adds a `utm_referrer` entity to the event.
 
 The hosted database includes `utm_sources` entries for the major chatbot providers — ChatGPT, Claude.ai, Google Gemini, Microsoft Copilot, META.ai, Mistral.ai, Perplexity.ai, Character.AI and Poe — so this works out of the box, as long as you use the actively-maintained database file (`referers-5.3`). You can recognize additional sources by adding `utm_sources` to your [custom referrer mappings](#custom-referrer-mappings).
 

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -13,7 +13,7 @@ This enrichment uses the [Snowplow referer-parser](https://github.com/snowplow/r
 
 This is particularly useful when looking for traffic from specific search engine providers or social networks.
 
-Since version 6.13.0 of Enrich, it also classifies traffic sources that identify themselves through a [`utm_source` query parameter](#identifying-referrers-from-utm_source) rather than a `Referer` header, which is how most AI chatbots send their traffic.
+Since version 6.13.0 of Enrich, it also classifies traffic sources that identify themselves through a [`utm_source` query parameter](#identifying-referrers-from-utm_source) rather than (or in addition to) a `Referer` header. An example would be ChatGPT setting `utm_source=chatgpt.com`.
 
 ## Configuration
 

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -244,7 +244,7 @@ On a match, the enrichment attaches a [`utm_referrer`](https://github.com/snowpl
 | -------- | ------------------------------------------------------------------------------------- |
 | `source` | The name of the matched source e.g., `ChatGPT`. Equivalent to `refr_source`.           |
 | `medium` | The medium of the matched source e.g., `chatbot`. Equivalent to `refr_medium`.         |
-| `term`   | The search term. Always absent for `utm_source` matches. Equivalent to `refr_term`.    |
+| `term`   | The search term. Currently, always absent for `utm_source` matches. Equivalent to `refr_term`.    |
 
 ### How it relates to referrer URL parsing
 

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -251,7 +251,7 @@ On a match, the enrichment attaches a [`utm_referrer`](https://github.com/snowpl
 The `utm_source` classification is deliberately kept separate from the `Referer` header parsing described above:
 
 * It **doesn't populate** `refr_medium`, `refr_source`, or `refr_term`. Those fields continue to reflect the referrer URL only, so existing data models and queries are unaffected.
-* It's **additive**. If an event has both a recognized referrer URL and a recognized `utm_source`, you get the `refr_*` fields *and* the `utm_referrer` entity. The two can legitimately disagree — for instance, a chatbot link opened from an email client — and keeping them apart lets you decide which signal to trust.
+* It's **additive**. If an event has both a recognized referrer URL and a recognized `utm_source`, you get the `refr_*` fields *and* the `utm_referrer` entity.
 * It's **independent of the [campaign attribution enrichment](/docs/pipeline/enrichments/available-enrichments/campaign-attribution-enrichment/index.md)**, which copies `utm_source` into `mkt_source` verbatim. The referrer parser instead resolves the value to a known source and medium. Both can run on the same event.
 
 Matching is an exact, case-sensitive comparison of the full `utm_source` value against the `utm_sources` entries, and only the page URL's query string is inspected. Values from your own `referrers` configuration take precedence over the database.

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -216,7 +216,7 @@ You can use custom referrer mappings to immediately test new categorizations in 
 This feature is available since version 6.13.0 of Enrich.
 :::
 
-Not every traffic source sets a `Referer` header. Many — AI chatbots in particular — instead append a `utm_source` query parameter to the links they send, for example:
+The `Referer` header is not set when users share or copy and paste the link, rather than click it directly. To circumvent this limitation and make attribution more reliable, some sites also append a `utm_source` query parameter. For example:
 
 ```
 https://www.example.com/product?utm_source=chatgpt.com

--- a/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
+++ b/docs/pipeline/enrichments/available-enrichments/referrer-parser-enrichment/index.md
@@ -246,7 +246,7 @@ Currently, the `term` field is always absent for `utm_source` matches, as there'
 The `utm_source` classification is deliberately kept separate from the `Referer` header parsing described above:
 
 * It **doesn't populate** `refr_medium`, `refr_source`, or `refr_term`. Those fields continue to reflect the referrer URL only, so existing data models and queries are unaffected.
-* It's **additive**. If an event has both a recognized referrer URL and a recognized `utm_source`, you get the `refr_*` fields *and* the `utm_referrer` entity.
+* It's **additive**. If an event has both a recognized referrer URL and a recognized `utm_source`, you get the `refr_*` fields *and* the `utm_referrer` entity. The two can disagree: if a user shares a ChatGPT link over Instagram messages and the recipient clicks it, `refr_source` is `Instagram` while the `utm_referrer` entity is `ChatGPT`. Rely on the `utm_referrer` entity for first-touch attribution.
 * It's **independent of the [campaign attribution enrichment](/docs/pipeline/enrichments/available-enrichments/campaign-attribution-enrichment/index.md)**, which copies `utm_source` into `mkt_source` verbatim. The referrer parser instead resolves the value to a known source and medium. Both can run on the same event.
 
 Matching is an exact, case-sensitive comparison of the full `utm_source` value against the `utm_sources` entries, and only the page URL's query string is inspected. Values from your own `referrers` configuration take precedence over the database.

--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -22,7 +22,7 @@ export const versions = {
 
   // Core pipeline
   collector: '3.7.0',
-  enrich: '6.12.0',
+  enrich: '6.13.0',
   sqs2kinesis: '1.0.4',
   dataflowRunner: '0.7.8',
   snowbridge: '5.2.0',


### PR DESCRIPTION
Documents [Enrich 6.13.0](https://github.com/snowplow/enrich/blob/master/CHANGELOG), covering the range `6.12.0..6.13.0`.

## Changes

- Bump `enrich` to `6.13.0` in `src/componentVersions.js`.
- **Referrer parser enrichment** — document the new `utm_source` classification ([enrich#260](https://github.com/snowplow/enrich/pull/260)):
  - New "Identifying referrers from `utm_source`" section: why it exists (AI chatbots send traffic with `utm_source` and no `Referer` header), built-in chatbot coverage in the hosted database, the `utm_referrer` derived entity, and how it relates to `refr_*` parsing and the campaign attribution enrichment.
  - New `utm_sources` field documented in the `referrers` custom-mapping table and both config examples.
  - Self-hosted config example bumped to `referer_parser` `2-0-2`, with a note that `2-0-0`/`2-0-1` reject `utm_sources`.
  - Added a pointer in the `database`/`uri` section that the `chatbot` category and `utm_sources` entries require the actively-maintained `referers-5.3` file, not the frozen `referers-latest`.

## Not documented

The rest of the release range is internal and has no user-facing surface:

- Bump common-streams to 0.25.0 — verified no reference config changes between `0.24.0` and `0.25.0` (schema-ddl bumps + zstd compression-context reuse only).
- Add new Metadata dimensions ([#220](https://github.com/snowplow/enrich/pull/220)) — extra dimensions on the internal metadata reporting, no configuration or output change.
- Reuse a single long-lived compressor across batches ([#253](https://github.com/snowplow/enrich/pull/253)) — internal performance.
- CVE remediation workflow/skills, Snyk removal, sbt CI caching, bot detection enrichment refactor — repo internals.

No reference config changes in Enrich itself in this range (`git diff 6.12.0..6.13.0 -- '*.conf' 'config/'` is empty), so no configuration reference updates were needed.

## Prerequisites before merging

This documents behavior whose supporting pieces are not all live yet:

- [ ] **Enrich 6.13.0 is not released** — only `6.13.0-rc1..rc5` tags exist.
- [x] **`iglu-central` schemas are unmerged** — `com.snowplowanalytics.snowplow/utm_referrer/jsonschema/1-0-0` and `referer_parser/jsonschema/2-0-2` exist only on the `utm_referrer` branch. The page links to the `master` path for `utm_referrer` 1-0-0, and tells self-hosted users to declare `2-0-2`; both need that branch merged.
- [ ] **The hosted referer database has no `utm_sources` entries yet** — they exist only on the `utm_sources` branch of `snowplow/referer-parser`. The page states chatbot sources work out of the box with `referers-5.3`, which requires that branch merged and the hosted file regenerated. (Adding `utm_sources` to `referers-5.3` is backwards compatible: the pre-4.0.0 referer-parser decoder ignores unknown keys, so no new versioned database file is needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)