### PR TITLE
docs(signals): add notes column to aggregation types table

### DIFF
--- a/docs/signals/attributes/attributes/index.md
+++ b/docs/signals/attributes/attributes/index.md
@@ -96,22 +96,30 @@ sp_structured = Event(name="event", vendor="com.google.analytics", version="1-0-
 
 Signals supports the following aggregation types:
 
-| Aggregation | Description | Required property type in schema |
-| --- | --- | --- |
-| Counter | Count events | No property used for this aggregation |
-| Sum | Sum of property values | Numeric |
-| Min | Minimum property value | Numeric |
-| Max | Maximum property value | Numeric |
-| Mean | Average of property values | Numeric |
-| First | First property value seen | String, Numeric, Boolean |
-| Last | Last property value seen | String, Numeric, Boolean |
-| Most Frequent | Most frequent property value seen | String, Numeric, Boolean |
-| Least Frequent | Least frequent property value seen | String, Numeric, Boolean |
-| Approx Count Distinct | Approximate distinct count ([HyperLogLog](https://redis.io/docs/latest/develop/data-types/probabilistic/hyperloglogs/)) | String, Numeric, Boolean |
-| Category Count | Dictionary of unique values and their counts | String, Numeric, Boolean |
-| Unique List | List of unique property values | String, Numeric, Boolean |
+| Aggregation | Description | Required property type in schema | Notes |
+| --- | --- | --- | --- |
+| Counter | Count events | No property used for this aggregation | |
+| Sum | Sum of property values | Numeric | |
+| Min | Minimum property value | Numeric | |
+| Max | Maximum property value | Numeric | |
+| Mean | Average of property values | Numeric | |
+| First | First property value seen | String, Numeric, Boolean | Earliest by `derived_tstamp`, not by arrival order |
+| Last | Last property value seen | String, Numeric, Boolean | Latest by `derived_tstamp`, not by arrival order |
+| Most Frequent | Most frequent property value seen | String, Numeric, Boolean | Tracks up to 100 distinct values; ties are broken arbitrarily |
+| Least Frequent | Least frequent property value seen | String, Numeric, Boolean | Tracks up to 100 distinct values; ties are broken arbitrarily |
+| Approx Count Distinct | Approximate distinct count ([HyperLogLog](https://redis.io/docs/latest/develop/data-types/probabilistic/hyperloglogs/)) | String, Numeric, Boolean | Approximate, with a typical error around 1%. Don't use where an exact count matters |
+| Category Count | Dictionary of unique values and their counts | String, Numeric, Boolean | Keeps the 100 highest-count values; lower-count values are dropped |
+| Unique List | List of unique property values | String, Numeric, Boolean | Ordered oldest to newest by `derived_tstamp`, capped at 100 values. See below |
 
 A property isn't used for `counter` aggregation. To only count events with a specific property value, use a criteria filter.
+
+Attributes calculated over high-cardinality properties, such as a product ID or a search term, can exceed the 100-value limits noted above. Consider a criteria filter to narrow the set of events, or a lower-cardinality property.
+
+#### Unique list ordering
+
+A unique list is ordered by when each value was *most recently* seen, oldest first. Seeing a value again doesn't add a second entry: it moves the existing entry to the end of the list. For example, viewing pages `/home`, `/products`, then `/home` again produces `["/products", "/home"]`.
+
+This also determines which values are dropped once the list reaches 100 entries: the least recently seen value is removed first, so a frequently repeated value is retained even if it was first seen long ago.
 
 <Tabs groupId="signals-impl" queryString>
 <TabItem value="console" label="Console" default>


### PR DESCRIPTION
## Summary

The aggregation types table described *what* each aggregation returns but not the behavior that surprises people in production. Adds a **Notes** column covering ordering, limits, and accuracy, plus a short subsection on unique list ordering.

Prompted by a question about whether a repeated value in a `unique_list` keeps its original position or moves to the end — the docs had no answer, and the intuitive guess (first-seen order) is the wrong one.

## Changes

- **Notes column** on the aggregation types table.
- **`first` / `last`** — ordered by `derived_tstamp`, not arrival order. Late-arriving events sort by their own event time.
- **`unique_list`** — ordered oldest to newest by most-recent `derived_tstamp`, capped at 100.
- **`most_frequent` / `least_frequent` / `category_count`** — 100-value limits, previously undocumented.
- **`approx_count_distinct`** — states plainly that the count is approximate (~1% typical error). The row linked to HyperLogLog but never said the number can be wrong.
- **New "Unique list ordering" subsection** — a repeat moves the value to the end rather than adding a duplicate, with a worked example, and the LRU-style eviction that follows from it.
- A sentence on high-cardinality properties, since that's how users hit the 100-value limits.

## Verification

Every claim was checked against the implementation rather than inferred:

| Claim | Source |
|---|---|
| `unique_list` limit 100, `ascending=false` | `shared/attribute/registry.go:29` |
| Repeat overwrites score, re-sorts to end | `shared/attribute/agg_zset_temporal.go:76` (`ZADD`), read path lines 147-182 |
| Worked example `["/products", "/home"]` | `streaming_engine/plugins/updateattributes/processor_unique_list_test.go:79` |
| Score is `derived_tstamp` | `streaming_engine/processors/input/parse_event.blobl:48` → `meta ts`, consumed in `message.go:118` |
| `most_frequent` / `least_frequent` limit 100 | `registry.go:30-31` |
| `category_count` keeps highest-count 100 | `agg_category_count.go` — `ZRemRangeByRank(0, -limit-1)` |
| `approx_count_distinct` is HLL | `agg_count_distinct.go` — `PFAdd` / `PFCount` |

Two points to confirm, since they're the least certain:

1. **Tie-breaking for `most_frequent` / `least_frequent`** — described as "arbitrary". The `Aggregate` map iteration is genuinely non-deterministic in Go, so this is accurate as written, but if the intended contract is stronger the note should say so instead.
2. **The ~1% error figure** — the standard error for Redis HLL, not something measured against Signals data. Happy to drop the number and just say "approximate" if that's safer.

Worth noting the ordering behavior is a real design decision, not a bug — I've documented it as-is. If last-seen ordering and LRU eviction aren't the intended semantics, that's a code conversation and this PR should wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)