### PR TITLE
Lake Loader 0.12.0

### DIFF
--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -36,7 +36,7 @@ export const versions = {
   rdbLoader: '6.6.0',
   s3Loader: '3.2.0',
   s3Loader22x: '2.2.9',
-  lakeLoader: '0.11.0',
+  lakeLoader: '0.12.0',
   snowflakeStreamingLoader: '0.6.1',
   databricksStreamingLoader: '0.5.0',
 


### PR DESCRIPTION
## Summary

Documents the [Lake Loader 0.12.0](https://github.com/snowplow-incubator/snowplow-lake-loader-private/releases/tag/0.12.0) release.

This is an internal-only release. All changes between 0.11.0 and 0.12.0 are dependency upgrades (Spark 4, Hadoop 3.5, Delta 4.3, common-streams 0.25.0), CVE fixes, bug fixes, error-message/alert-quality improvements, and internal Spark/Delta tuning defaults. There are no new, deprecated, or dropped user-facing configuration options or features, and the example configs are unchanged.

The only doc change is bumping `lakeLoader` in `src/componentVersions.js` from `0.11.0` to `0.12.0`, which propagates automatically to the versions table, the configuration-reference version note, and the Docker pull commands.