### PR TITLE
Enrich 6.13.1

### DIFF
--- a/src/componentVersions.js
+++ b/src/componentVersions.js
@@ -22,7 +22,7 @@ export const versions = {
 
   // Core pipeline
   collector: '3.7.0',
-  enrich: '6.13.0',
+  enrich: '6.13.1',
   sqs2kinesis: '1.0.4',
   dataflowRunner: '0.7.10',
   snowbridge: '5.2.0',


### PR DESCRIPTION
Bumps the documented Enrich version to **6.13.1**.

## Release contents

The 6.13.1 release contains a single substantive change:

- **[DPS-2390] Emit non inferred count (#270)** — when the pipeline infers one or more event specifications for an event, Enrich now also emits a "plain" metadata row (`eventSpecInferred = false`) alongside the per-inferred-spec rows. This lets downstream consumers compute the total number of incoming events without the count being multiplied by the number of inferred specifications (filter on `eventSpecInferred = false` to get the total).

This is an internal change to the metadata Enrich emits for event-specification inference. There are no configuration changes, no new reference-config options, and no new/deprecated/dropped user-facing features. Following the release-docs guidance ("no need to document project internals"), no prose docs are added — only the version bump.

[DPS-2390]: https://snplow.atlassian.net/browse/DPS-2390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ